### PR TITLE
feat: add a naive slab allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ version = "0.1.0"
 dependencies = [
  "bitmap-allocator",
  "buddy_system_allocator",
+ "slab_allocator",
 ]
 
 [[package]]
@@ -966,6 +967,13 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab_allocator"
+version = "0.3.1"
+dependencies = [
+ "buddy_system_allocator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/page_table_entry",
     "crates/ratio",
     "crates/scheduler",
+    "crates/slab_allocator",
     "crates/spinlock",
     "crates/tuple_for_each",
 

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -9,3 +9,4 @@ authors = ["Yuekai Jia <equation618@gmail.com>"]
 [dependencies]
 buddy_system_allocator = { version = "0.9", default-features = false }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator.git", rev = "88e871a" }
+slab_allocator = { path = "../slab_allocator" }

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -3,9 +3,11 @@
 
 mod bitmap;
 mod buddy;
+mod slab;
 
 pub use bitmap::BitmapPageAllocator;
 pub use buddy::BuddyByteAllocator;
+pub use slab::SlabByteAllocator;
 
 /// The error type used for allocation.
 #[derive(Debug)]

--- a/crates/allocator/src/slab.rs
+++ b/crates/allocator/src/slab.rs
@@ -1,0 +1,65 @@
+//! Slab memory allocation.
+//!
+//! TODO: comments
+
+use super::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use core::alloc::Layout;
+use slab_allocator::Heap;
+
+pub struct SlabByteAllocator {
+    inner: Option<Heap>,
+}
+
+impl SlabByteAllocator {
+    pub const fn new() -> Self {
+        Self { inner: None }
+    }
+
+    fn inner_mut(&mut self) -> &mut Heap {
+        self.inner.as_mut().unwrap()
+    }
+
+    fn inner(&self) -> &Heap {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl BaseAllocator for SlabByteAllocator {
+    fn init(&mut self, start: usize, size: usize) {
+        self.inner = unsafe { Some(Heap::new(start, size)) };
+    }
+
+    fn add_memory(&mut self, start: usize, size: usize) -> AllocResult {
+        unsafe {
+            self.inner_mut().add_memory(start, size);
+        }
+        Ok(())
+    }
+}
+
+impl ByteAllocator for SlabByteAllocator {
+    fn alloc(&mut self, size: usize, align_pow2: usize) -> AllocResult<usize> {
+        self.inner_mut()
+            .allocate(Layout::from_size_align(size, align_pow2).unwrap())
+            .map_err(|_| AllocError::NoMemory)
+    }
+
+    fn dealloc(&mut self, pos: usize, size: usize, align_pow2: usize) {
+        unsafe {
+            self.inner_mut()
+                .deallocate(pos, Layout::from_size_align(size, align_pow2).unwrap())
+        }
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.inner().total_bytes()
+    }
+
+    fn used_bytes(&self) -> usize {
+        self.inner().used_bytes()
+    }
+
+    fn available_bytes(&self) -> usize {
+        self.inner().available_bytes()
+    }
+}

--- a/crates/slab_allocator/Cargo.toml
+++ b/crates/slab_allocator/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "slab_allocator"
+version = "0.3.1"
+authors = ["Robert Węcławski <r.weclawski@gmail.com>"]
+license = "MIT"
+
+description = "Slab allocator for no_std systems. Uses multiple slabs with blocks of different sizes and a linked list for blocks larger than 4096 bytes"
+keywords = ["slab", "allocator", "no_std", "heap", "kernel"]
+
+[dependencies]
+buddy_system_allocator = { version = "0.9", default-features = false }

--- a/crates/slab_allocator/src/lib.rs
+++ b/crates/slab_allocator/src/lib.rs
@@ -1,0 +1,249 @@
+#![feature(allocator_api)]
+#![no_std]
+
+extern crate alloc;
+extern crate buddy_system_allocator;
+
+use alloc::alloc::{AllocError, Layout};
+use core::ptr::NonNull;
+
+#[cfg(test)]
+mod tests;
+
+mod slab;
+use slab::Slab;
+
+pub const NUM_OF_SLABS: usize = 8;
+pub const MIN_SLAB_SIZE: usize = 4096;
+pub const MIN_HEAP_SIZE: usize = NUM_OF_SLABS * MIN_SLAB_SIZE;
+
+pub enum HeapAllocator {
+    Slab64Bytes,
+    Slab128Bytes,
+    Slab256Bytes,
+    Slab512Bytes,
+    Slab1024Bytes,
+    Slab2048Bytes,
+    Slab4096Bytes,
+    BuddyAllocator,
+}
+
+/// A fixed size heap backed by multiple slabs with blocks of different sizes.
+/// Allocations over 4096 bytes are served by linked list allocator.
+pub struct Heap {
+    slab_64_bytes: Slab,
+    slab_128_bytes: Slab,
+    slab_256_bytes: Slab,
+    slab_512_bytes: Slab,
+    slab_1024_bytes: Slab,
+    slab_2048_bytes: Slab,
+    slab_4096_bytes: Slab,
+    buddy_allocator: buddy_system_allocator::Heap<32>,
+}
+
+impl Heap {
+    /// Creates a new heap with the given `heap_start_addr` and `heap_size`. The start address must be valid
+    /// and the memory in the `[heap_start_addr, heap_start_addr + heap_size)` range must not be used for
+    /// anything else.
+    ///
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn new(heap_start_addr: usize, heap_size: usize) -> Heap {
+        assert!(
+            heap_start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size >= MIN_HEAP_SIZE,
+            "Heap size should be greater or equal to minimum heap size"
+        );
+        assert!(
+            heap_size % MIN_HEAP_SIZE == 0,
+            "Heap size should be a multiple of minimum heap size"
+        );
+        let slab_size = heap_size / NUM_OF_SLABS;
+        Heap {
+            slab_64_bytes: Slab::new(heap_start_addr, slab_size, 64),
+            slab_128_bytes: Slab::new(heap_start_addr + slab_size, slab_size, 128),
+            slab_256_bytes: Slab::new(heap_start_addr + 2 * slab_size, slab_size, 256),
+            slab_512_bytes: Slab::new(heap_start_addr + 3 * slab_size, slab_size, 512),
+            slab_1024_bytes: Slab::new(heap_start_addr + 4 * slab_size, slab_size, 1024),
+            slab_2048_bytes: Slab::new(heap_start_addr + 5 * slab_size, slab_size, 2048),
+            slab_4096_bytes: Slab::new(heap_start_addr + 6 * slab_size, slab_size, 4096),
+            buddy_allocator: {
+                let mut buddy = buddy_system_allocator::Heap::<32>::new();
+                buddy.init(heap_start_addr + 7 * slab_size, slab_size);
+                buddy
+            },
+        }
+    }
+
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn add_memory(&mut self, heap_start_addr: usize, heap_size: usize) {
+        assert!(
+            heap_start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size >= MIN_HEAP_SIZE,
+            "Add Heap size should be greater or equal to minimum heap size"
+        );
+        assert!(
+            heap_size % MIN_HEAP_SIZE == 0,
+            "Add Heap size should be a multiple of minimum heap size"
+        );
+        let slab_size = heap_size / NUM_OF_SLABS;
+        self.slab_64_bytes.grow(heap_start_addr, slab_size);
+        self.slab_128_bytes
+            .grow(heap_start_addr + slab_size, slab_size);
+        self.slab_256_bytes
+            .grow(heap_start_addr + 2 * slab_size, slab_size);
+        self.slab_512_bytes
+            .grow(heap_start_addr + 3 * slab_size, slab_size);
+        self.slab_1024_bytes
+            .grow(heap_start_addr + 4 * slab_size, slab_size);
+        self.slab_2048_bytes
+            .grow(heap_start_addr + 5 * slab_size, slab_size);
+        self.slab_4096_bytes
+            .grow(heap_start_addr + 6 * slab_size, slab_size);
+        self.buddy_allocator.add_to_heap(
+            heap_start_addr + 7 * slab_size,
+            heap_start_addr + 8 * slab_size,
+        );
+    }
+
+    /// Adds memory to the heap. The start address must be valid
+    /// and the memory in the `[mem_start_addr, mem_start_addr + heap_size)` range must not be used for
+    /// anything else.
+    /// In case of linked list allocator the memory can only be extended.
+    ///
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn grow(&mut self, mem_start_addr: usize, mem_size: usize, slab: HeapAllocator) {
+        match slab {
+            HeapAllocator::Slab64Bytes => self.slab_64_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab128Bytes => self.slab_128_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab256Bytes => self.slab_256_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab512Bytes => self.slab_512_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab1024Bytes => self.slab_1024_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab2048Bytes => self.slab_2048_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::Slab4096Bytes => self.slab_4096_bytes.grow(mem_start_addr, mem_size),
+            HeapAllocator::BuddyAllocator => self
+                .buddy_allocator
+                .add_to_heap(mem_start_addr, mem_start_addr + mem_size),
+        }
+    }
+
+    /// Allocates a chunk of the given size with the given alignment. Returns a pointer to the
+    /// beginning of that chunk if it was successful. Else it returns `Err`.
+    /// This function finds the slab of lowest size which can still accomodate the given chunk.
+    /// The runtime is in `O(1)` for chunks of size <= 4096, and `O(n)` when chunk size is > 4096,
+    pub fn allocate(&mut self, layout: Layout) -> Result<usize, AllocError> {
+        match Heap::layout_to_allocator(&layout) {
+            HeapAllocator::Slab64Bytes => self.slab_64_bytes.allocate(layout),
+            HeapAllocator::Slab128Bytes => self.slab_128_bytes.allocate(layout),
+            HeapAllocator::Slab256Bytes => self.slab_256_bytes.allocate(layout),
+            HeapAllocator::Slab512Bytes => self.slab_512_bytes.allocate(layout),
+            HeapAllocator::Slab1024Bytes => self.slab_1024_bytes.allocate(layout),
+            HeapAllocator::Slab2048Bytes => self.slab_2048_bytes.allocate(layout),
+            HeapAllocator::Slab4096Bytes => self.slab_4096_bytes.allocate(layout),
+            HeapAllocator::BuddyAllocator => self
+                .buddy_allocator
+                .alloc(layout)
+                .map(|ptr| ptr.as_ptr() as usize)
+                .map_err(|_| AllocError),
+        }
+    }
+
+    /// Frees the given allocation. `ptr` must be a pointer returned
+    /// by a call to the `allocate` function with identical size and alignment. Undefined
+    /// behavior may occur for invalid arguments, thus this function is unsafe.
+    ///
+    /// This function finds the slab which contains address of `ptr` and adds the blocks beginning
+    /// with `ptr` address to the list of free blocks.
+    /// This operation is in `O(1)` for blocks <= 4096 bytes and `O(n)` for blocks > 4096 bytes.
+    ///
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn deallocate(&mut self, ptr: usize, layout: Layout) {
+        match Heap::layout_to_allocator(&layout) {
+            HeapAllocator::Slab64Bytes => self.slab_64_bytes.deallocate(ptr),
+            HeapAllocator::Slab128Bytes => self.slab_128_bytes.deallocate(ptr),
+            HeapAllocator::Slab256Bytes => self.slab_256_bytes.deallocate(ptr),
+            HeapAllocator::Slab512Bytes => self.slab_512_bytes.deallocate(ptr),
+            HeapAllocator::Slab1024Bytes => self.slab_1024_bytes.deallocate(ptr),
+            HeapAllocator::Slab2048Bytes => self.slab_2048_bytes.deallocate(ptr),
+            HeapAllocator::Slab4096Bytes => self.slab_4096_bytes.deallocate(ptr),
+            HeapAllocator::BuddyAllocator => self
+                .buddy_allocator
+                .dealloc(NonNull::new(ptr as *mut u8).unwrap(), layout),
+        }
+    }
+
+    /// Returns bounds on the guaranteed usable size of a successful
+    /// allocation created with the specified `layout`.
+    pub fn usable_size(&self, layout: Layout) -> (usize, usize) {
+        match Heap::layout_to_allocator(&layout) {
+            HeapAllocator::Slab64Bytes => (layout.size(), 64),
+            HeapAllocator::Slab128Bytes => (layout.size(), 128),
+            HeapAllocator::Slab256Bytes => (layout.size(), 256),
+            HeapAllocator::Slab512Bytes => (layout.size(), 512),
+            HeapAllocator::Slab1024Bytes => (layout.size(), 1024),
+            HeapAllocator::Slab2048Bytes => (layout.size(), 2048),
+            HeapAllocator::Slab4096Bytes => (layout.size(), 4096),
+            HeapAllocator::BuddyAllocator => (layout.size(), layout.size()),
+        }
+    }
+
+    ///Finds allocator to use based on layout size and alignment
+    pub fn layout_to_allocator(layout: &Layout) -> HeapAllocator {
+        if layout.size() > 4096 {
+            HeapAllocator::BuddyAllocator
+        } else if layout.size() <= 64 && layout.align() <= 64 {
+            HeapAllocator::Slab64Bytes
+        } else if layout.size() <= 128 && layout.align() <= 128 {
+            HeapAllocator::Slab128Bytes
+        } else if layout.size() <= 256 && layout.align() <= 256 {
+            HeapAllocator::Slab256Bytes
+        } else if layout.size() <= 512 && layout.align() <= 512 {
+            HeapAllocator::Slab512Bytes
+        } else if layout.size() <= 1024 && layout.align() <= 1024 {
+            HeapAllocator::Slab1024Bytes
+        } else if layout.size() <= 2048 && layout.align() <= 2048 {
+            HeapAllocator::Slab2048Bytes
+        } else {
+            HeapAllocator::Slab4096Bytes
+        }
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        self.slab_64_bytes.total_blocks() * 64
+            + self.slab_128_bytes.total_blocks() * 128
+            + self.slab_256_bytes.total_blocks() * 256
+            + self.slab_512_bytes.total_blocks() * 512
+            + self.slab_1024_bytes.total_blocks() * 1024
+            + self.slab_2048_bytes.total_blocks() * 2048
+            + self.slab_4096_bytes.total_blocks() * 4096
+            + self.buddy_allocator.stats_total_bytes()
+    }
+
+    pub fn used_bytes(&self) -> usize {
+        self.slab_64_bytes.used_blocks() * 64
+            + self.slab_128_bytes.used_blocks() * 128
+            + self.slab_256_bytes.used_blocks() * 256
+            + self.slab_512_bytes.used_blocks() * 512
+            + self.slab_1024_bytes.used_blocks() * 1024
+            + self.slab_2048_bytes.used_blocks() * 2048
+            + self.slab_4096_bytes.used_blocks() * 4096
+            + self.buddy_allocator.stats_alloc_actual()
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        self.total_bytes() - self.used_bytes()
+    }
+}

--- a/crates/slab_allocator/src/slab.rs
+++ b/crates/slab_allocator/src/slab.rs
@@ -1,0 +1,109 @@
+use alloc::alloc::{AllocError, Layout};
+
+pub struct Slab {
+    block_size: usize,
+    free_block_list: FreeBlockList,
+
+    total_blocks: usize,
+}
+
+impl Slab {
+    pub unsafe fn new(start_addr: usize, slab_size: usize, block_size: usize) -> Slab {
+        let num_of_blocks = slab_size / block_size;
+        Slab {
+            block_size,
+            free_block_list: FreeBlockList::new(start_addr, block_size, num_of_blocks),
+            total_blocks: num_of_blocks,
+        }
+    }
+
+    pub fn total_blocks(&self) -> usize {
+        self.total_blocks
+    }
+
+    pub fn used_blocks(&self) -> usize {
+        self.free_block_list.len()
+    }
+
+    pub unsafe fn grow(&mut self, start_addr: usize, slab_size: usize) {
+        let num_of_blocks = slab_size / self.block_size;
+        self.total_blocks += num_of_blocks;
+        let mut block_list = FreeBlockList::new(start_addr, self.block_size, num_of_blocks);
+        while let Some(block) = block_list.pop() {
+            self.free_block_list.push(block);
+        }
+    }
+
+    pub fn allocate(&mut self, _layout: Layout) -> Result<usize, AllocError> {
+        match self.free_block_list.pop() {
+            Some(block) => Ok(block.addr()),
+            None => Err(AllocError),
+        }
+    }
+
+    pub fn deallocate(&mut self, ptr: usize) {
+        let ptr = ptr as *mut FreeBlock;
+        unsafe {
+            self.free_block_list.push(&mut *ptr);
+        }
+    }
+}
+
+struct FreeBlockList {
+    len: usize,
+    head: Option<&'static mut FreeBlock>,
+}
+
+impl FreeBlockList {
+    unsafe fn new(start_addr: usize, block_size: usize, num_of_blocks: usize) -> FreeBlockList {
+        let mut new_list = FreeBlockList::new_empty();
+        for i in (0..num_of_blocks).rev() {
+            let new_block = (start_addr + i * block_size) as *mut FreeBlock;
+            new_list.push(&mut *new_block);
+        }
+        new_list
+    }
+
+    fn new_empty() -> FreeBlockList {
+        FreeBlockList { len: 0, head: None }
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn pop(&mut self) -> Option<&'static mut FreeBlock> {
+        self.head.take().map(|node| {
+            self.head = node.next.take();
+            self.len -= 1;
+            node
+        })
+    }
+
+    fn push(&mut self, free_block: &'static mut FreeBlock) {
+        free_block.next = self.head.take();
+        self.len += 1;
+        self.head = Some(free_block);
+    }
+
+    #[allow(dead_code)]
+    fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+}
+
+impl Drop for FreeBlockList {
+    fn drop(&mut self) {
+        while self.pop().is_some() {}
+    }
+}
+
+struct FreeBlock {
+    next: Option<&'static mut FreeBlock>,
+}
+
+impl FreeBlock {
+    fn addr(&self) -> usize {
+        self as *const _ as usize
+    }
+}

--- a/crates/slab_allocator/src/tests.rs
+++ b/crates/slab_allocator/src/tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+use alloc::alloc::Layout;
+use core::mem::{align_of, size_of};
+
+const HEAP_SIZE: usize = 8 * 4096;
+const BIG_HEAP_SIZE: usize = HEAP_SIZE * 10;
+
+#[repr(align(4096))]
+struct TestHeap {
+    heap_space: [u8; HEAP_SIZE],
+}
+
+#[repr(align(4096))]
+struct TestBigHeap {
+    heap_space: [u8; BIG_HEAP_SIZE],
+}
+
+fn new_heap() -> Heap {
+    let test_heap = TestHeap {
+        heap_space: [0u8; HEAP_SIZE],
+    };
+    let heap = unsafe { Heap::new(&test_heap.heap_space[0] as *const u8 as usize, HEAP_SIZE) };
+    heap
+}
+
+fn new_big_heap() -> Heap {
+    let test_heap = TestBigHeap {
+        heap_space: [0u8; BIG_HEAP_SIZE],
+    };
+    let heap = unsafe {
+        Heap::new(
+            &test_heap.heap_space[0] as *const u8 as usize,
+            BIG_HEAP_SIZE,
+        )
+    };
+    heap
+}
+
+#[test]
+fn oom() {
+    let mut heap = new_heap();
+    let layout = Layout::from_size_align(HEAP_SIZE + 1, align_of::<usize>());
+    let addr = heap.allocate(layout.unwrap());
+    assert!(addr.is_err());
+}
+
+#[test]
+fn allocate_double_usize() {
+    let mut heap = new_heap();
+    let size = size_of::<usize>() * 2;
+    let layout = Layout::from_size_align(size, align_of::<usize>());
+    let addr = heap.allocate(layout.unwrap());
+    assert!(addr.is_ok());
+}
+
+#[test]
+fn allocate_and_free_double_usize() {
+    let mut heap = new_heap();
+    let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
+    let addr = heap.allocate(layout.clone());
+    assert!(addr.is_ok());
+    let addr = addr.unwrap();
+    unsafe {
+        *(addr as *mut (usize, usize)) = (0xdeafdeadbeafbabe, 0xdeafdeadbeafbabe);
+
+        heap.deallocate(addr, layout.clone());
+    }
+}
+
+#[test]
+fn reallocate_double_usize() {
+    let mut heap = new_heap();
+
+    let layout = Layout::from_size_align(size_of::<usize>() * 2, align_of::<usize>()).unwrap();
+
+    let x = heap.allocate(layout.clone()).unwrap();
+    unsafe {
+        heap.deallocate(x, layout.clone());
+    }
+
+    let y = heap.allocate(layout.clone()).unwrap();
+    unsafe {
+        heap.deallocate(y, layout.clone());
+    }
+
+    assert_eq!(x as usize, y as usize);
+}
+
+#[test]
+fn allocate_multiple_sizes() {
+    let mut heap = new_heap();
+    let base_size = size_of::<usize>();
+    let base_align = align_of::<usize>();
+
+    let layout_1 = Layout::from_size_align(base_size * 2, base_align).unwrap();
+    let layout_2 = Layout::from_size_align(base_size * 3, base_align).unwrap();
+    let layout_3 = Layout::from_size_align(base_size * 3, base_align * 8).unwrap();
+    let layout_4 = Layout::from_size_align(base_size * 10, base_align).unwrap();
+
+    let x = heap.allocate(layout_1.clone()).unwrap();
+    let y = heap.allocate(layout_2.clone()).unwrap();
+    assert_eq!(x as usize + 64, y as usize);
+    let z = heap.allocate(layout_3.clone()).unwrap();
+    assert_eq!(z as usize % (base_size * 8), 0);
+
+    unsafe {
+        heap.deallocate(x, layout_1.clone());
+    }
+
+    let a = heap.allocate(layout_4.clone()).unwrap();
+    let b = heap.allocate(layout_1.clone()).unwrap();
+    assert_eq!(a as usize, x as usize + 4096);
+    assert_eq!(x as usize, b as usize);
+
+    unsafe {
+        heap.deallocate(y, layout_2);
+        heap.deallocate(z, layout_3);
+        heap.deallocate(a, layout_4);
+        heap.deallocate(b, layout_1);
+    }
+}
+
+#[test]
+fn allocate_one_4096_block() {
+    let mut heap = new_big_heap();
+    let base_size = size_of::<usize>();
+    let base_align = align_of::<usize>();
+
+    let layout = Layout::from_size_align(base_size * 512, base_align).unwrap();
+
+    let x = heap.allocate(layout.clone()).unwrap();
+
+    unsafe {
+        heap.deallocate(x, layout.clone());
+    }
+}
+
+#[test]
+fn allocate_multiple_4096_blocks() {
+    let mut heap = new_big_heap();
+    let base_size = size_of::<usize>();
+    let base_align = align_of::<usize>();
+
+    let layout = Layout::from_size_align(base_size * 512, base_align).unwrap();
+    let layout_2 = Layout::from_size_align(base_size * 1024, base_align).unwrap();
+
+    let _x = heap.allocate(layout.clone()).unwrap();
+    let y = heap.allocate(layout.clone()).unwrap();
+    let z = heap.allocate(layout.clone()).unwrap();
+
+    unsafe {
+        heap.deallocate(y, layout.clone());
+    }
+
+    let a = heap.allocate(layout.clone()).unwrap();
+    let _b = heap.allocate(layout.clone()).unwrap();
+
+    unsafe {
+        heap.deallocate(a, layout.clone());
+        heap.deallocate(z, layout.clone());
+    }
+    let c = heap.allocate(layout_2.clone()).unwrap();
+    let _d = heap.allocate(layout.clone()).unwrap();
+    unsafe {
+        *(c as *mut (usize, usize)) = (0xdeafdeadbeafbabe, 0xdeafdeadbeafbabe);
+    }
+}

--- a/modules/axalloc/src/lib.rs
+++ b/modules/axalloc/src/lib.rs
@@ -8,24 +8,24 @@ extern crate alloc;
 mod page;
 
 use allocator::{AllocResult, BaseAllocator, ByteAllocator, PageAllocator};
-use allocator::{BitmapPageAllocator, BuddyByteAllocator};
+use allocator::{BitmapPageAllocator, SlabByteAllocator};
 use core::alloc::{GlobalAlloc, Layout};
 use spinlock::SpinNoIrq;
 
 const PAGE_SIZE: usize = 0x1000;
-const MIN_HEAP_SIZE: usize = 0x4000; // 16 K
+const MIN_HEAP_SIZE: usize = 0x8000; // 32 K
 
 pub use page::GlobalPage;
 
 pub struct GlobalAllocator {
-    balloc: SpinNoIrq<BuddyByteAllocator>, // TODO: use IRQ-disabled lock
+    balloc: SpinNoIrq<SlabByteAllocator>,
     palloc: SpinNoIrq<BitmapPageAllocator<PAGE_SIZE>>,
 }
 
 impl GlobalAllocator {
     pub const fn new() -> Self {
         Self {
-            balloc: SpinNoIrq::new(BuddyByteAllocator::new()),
+            balloc: SpinNoIrq::new(SlabByteAllocator::new()),
             palloc: SpinNoIrq::new(BitmapPageAllocator::new()),
         }
     }


### PR DESCRIPTION
A naive slab memory allocator copied from [redox-os](https://gitlab.redox-os.org/redox-os/slab_allocator).
* Speed-up: time cost of `memtest` is reduced from 1.81s to 0.38s in qemu-system-riscv64.