### PR TITLE
add axfs_os module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "axfs_os"
+version = "0.1.0"
+dependencies = [
+ "axerrno",
+ "axfs",
+ "axhal",
+ "axio",
+ "axsync",
+ "axtask",
+ "bitflags 2.1.0",
+]
+
+[[package]]
 name = "axfs_ramfs"
 version = "0.1.0"
 dependencies = [
@@ -669,10 +682,6 @@ checksum = "e15e994575e38332cf4a2dc9dc745ff6a65695d37a41e00efadd57fcd42c1ba4"
 dependencies = [
  "thiserror",
 ]
-
-[[package]]
-name = "deptool"
-version = "0.1.0"
 
 [[package]]
 name = "driver_block"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "modules/axruntime",
     "modules/axsync",
     "modules/axtask",
+    "modules/axfs_os",
 
     "ulib/libax",
 ]

--- a/modules/axfs_os/Cargo.toml
+++ b/modules/axfs_os/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "axfs_os"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axerrno = { path = "../../crates/axerrno" }
+axfs = { path = "../axfs" }
+axtask = { path = "../axtask" }
+axio = { path = "../../crates/axio" }
+axsync = { path = "../axsync" }
+axhal = { path = "../axhal" }
+bitflags = "= 2.1.0"

--- a/modules/axfs_os/src/file.rs
+++ b/modules/axfs_os/src/file.rs
@@ -1,0 +1,57 @@
+use super::file_io::FileIO;
+use crate::flags::OpenFlags;
+use alloc::sync::Arc;
+use axerrno::AxResult;
+use axfs::api::File;
+use axio::{Read, Seek, SeekFrom, Write};
+use axsync::Mutex;
+
+pub struct FileDesc {
+    file: Arc<Mutex<File>>,
+    flags: OpenFlags,
+}
+
+impl FileIO for FileDesc {
+    fn readable(&self) -> bool {
+        self.flags.readable()
+    }
+
+    fn writable(&self) -> bool {
+        self.flags.writable()
+    }
+
+    fn read(&self, buf: &mut [u8]) -> AxResult<usize> {
+        self.file.lock().read(buf)
+    }
+
+    fn write(&self, buf: &[u8]) -> AxResult<usize> {
+        self.file.lock().write(buf)
+    }
+
+    fn seek(&self, offset: usize) -> AxResult<u64> {
+        self.file.lock().seek(SeekFrom::Start(offset as u64))
+    }
+}
+
+impl FileDesc {
+    pub fn new(file: Arc<Mutex<File>>, flags: u8) -> Self {
+        Self {
+            file,
+            flags: OpenFlags::from_bits(flags as u32).unwrap(),
+        }
+    }
+}
+
+pub fn new_fd(path: &str, flags: u8) -> AxResult<FileDesc> {
+    let file = File::options()
+        .read(flags & 0b0000_0001 != 0)
+        .write(flags & 0b0000_0010 != 0)
+        .append(flags & 0b0000_0100 != 0)
+        .truncate(flags & 0b0000_1000 != 0)
+        .create(flags & 0b0001_0000 != 0)
+        .create_new(flags & 0b0010_0000 != 0)
+        .open(path)?;
+
+    let fd = FileDesc::new(Arc::new(Mutex::new(file)), flags);
+    Ok(fd)
+}

--- a/modules/axfs_os/src/file_io.rs
+++ b/modules/axfs_os/src/file_io.rs
@@ -1,0 +1,22 @@
+use axerrno::{AxError, AxResult};
+
+/// File I/O interface
+pub trait FileIO: Send + Sync {
+    /// Returns true if file is readable.
+    fn readable(&self) -> bool;
+    /// Returns true if file is writeable.
+    fn writable(&self) -> bool;
+    /// Reads data to the buffer.
+    /// Returns the number of bytes read.
+    fn read(&self, buf: &mut [u8]) -> AxResult<usize>;
+    /// Writes data into the buffer.
+    /// Returns the number of bytes written.
+    fn write(&self, data: &[u8]) -> AxResult<usize>;
+    /// Moves the cursor.
+    /// Returns the new position.
+    fn seek(&self, pos: usize) -> AxResult<u64>;
+    /// Flushes buffer data.
+    fn flush(&self) -> AxResult<()> {
+        Err(AxError::Unsupported)
+    }
+}

--- a/modules/axfs_os/src/flags.rs
+++ b/modules/axfs_os/src/flags.rs
@@ -1,0 +1,55 @@
+use bitflags::*;
+
+bitflags! {
+    /// OpenFlags
+    /// TODO(weny): Adds comments
+    pub struct OpenFlags: u32 {
+        const RDONLY = 0;
+
+        const WRONLY = 1 << 0;
+
+        const RDWR = 1 << 1;
+
+        const CREATE = 1 << 6;
+
+        const EXCLUSIVE = 1 << 7;
+
+        const NOCTTY = 1 << 8;
+
+        const EXCL = 1 << 9;
+
+        const NON_BLOCK = 1 << 11;
+
+        const TEXT = 1 << 14;
+
+        const BINARY = 1 << 15;
+
+        const DSYNC = 1 << 16;
+
+        const NOFOLLOW = 1 << 17;
+
+        const CLOEXEC = 1 << 19;
+
+        const DIR = 1 << 21;
+    }
+}
+
+impl OpenFlags {
+    pub fn read_write(&self) -> (bool, bool) {
+        if self.is_empty() {
+            (true, false)
+        } else if self.contains(Self::WRONLY) {
+            (false, true)
+        } else {
+            (true, true)
+        }
+    }
+
+    pub fn readable(&self) -> bool {
+        !self.contains(Self::WRONLY)
+    }
+
+    pub fn writable(&self) -> bool {
+        self.contains(Self::WRONLY) || self.contains(Self::RDWR)
+    }
+}

--- a/modules/axfs_os/src/lib.rs
+++ b/modules/axfs_os/src/lib.rs
@@ -1,0 +1,69 @@
+#![cfg_attr(not(test), no_std)]
+
+pub mod file;
+pub mod file_io;
+pub mod stdio;
+extern crate alloc;
+use alloc::format;
+use alloc::vec::Vec;
+pub mod flags;
+use axerrno::{ax_err_type, AxResult};
+use axfs::api::OpenOptions;
+use axio::{Read, Seek, SeekFrom};
+pub use file::new_fd;
+pub use stdio::{Stderr, Stdin, Stdout};
+
+/// Reads the content of file, Doesn't create a new file descriptor.
+pub fn read_file(path: &str) -> AxResult<Vec<u8>> {
+    let mut file = OpenOptions::new().read(true).open(path).map_err(|err| {
+        ax_err_type!(
+            Io,
+            format!("failed to open file: {}, source: {}", path, err.as_str())
+        )
+    })?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).map_err(|err| {
+        ax_err_type!(
+            Io,
+            format!(
+                "failed to read the file: {}, source: {}",
+                path,
+                err.as_str()
+            )
+        )
+    })?;
+    Ok(buf)
+}
+
+/// Reads a file from offest.
+pub fn read_file_with_offset(path: &str, offset: isize) -> AxResult<Vec<u8>> {
+    let mut file = OpenOptions::new().read(true).open(path).map_err(|err| {
+        ax_err_type!(
+            Io,
+            format!("failed to open file: {}, source: {}", path, err.as_str())
+        )
+    })?;
+    file.seek(SeekFrom::Start(offset as u64)).map_err(|err| {
+        ax_err_type!(
+            Io,
+            format!(
+                "failed to seek file: {} at {}, source: {}",
+                path,
+                offset,
+                err.as_str()
+            )
+        )
+    })?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).map_err(|err| {
+        ax_err_type!(
+            Io,
+            format!(
+                "failed to read the file: {}, source: {}",
+                path,
+                err.as_str()
+            )
+        )
+    })?;
+    Ok(buf)
+}

--- a/modules/axfs_os/src/stdio.rs
+++ b/modules/axfs_os/src/stdio.rs
@@ -1,0 +1,97 @@
+use super::file_io::FileIO;
+use axerrno::{AxError, AxResult};
+use axhal::console::{getchar, write_bytes};
+use axtask::yield_now;
+
+/// stdin file for getting chars from console
+pub struct Stdin;
+
+/// stdout file for putting chars to console
+pub struct Stdout;
+
+/// stderr file for putting chars to console
+pub struct Stderr;
+
+impl FileIO for Stdin {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn writable(&self) -> bool {
+        false
+    }
+
+    fn read(&self, buf: &mut [u8]) -> AxResult<usize> {
+        let ch: u8;
+        loop {
+            match getchar() {
+                Some(c) => {
+                    ch = c;
+                    break;
+                }
+                None => {
+                    yield_now();
+                    continue;
+                }
+            }
+        }
+        unsafe {
+            buf.as_mut_ptr().write_volatile(ch);
+        }
+        Ok(1)
+    }
+
+    fn write(&self, _buf: &[u8]) -> AxResult<usize> {
+        panic!("Cannot write to stdin!");
+    }
+
+    fn seek(&self, _pos: usize) -> AxResult<u64> {
+        Err(AxError::Unsupported)
+    }
+}
+
+impl FileIO for Stdout {
+    fn readable(&self) -> bool {
+        false
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn read(&self, _buf: &mut [u8]) -> AxResult<usize> {
+        panic!("Cannot read from stdout!");
+    }
+
+    fn write(&self, buf: &[u8]) -> AxResult<usize> {
+        write_bytes(buf);
+        Ok(buf.len())
+    }
+
+    fn seek(&self, _pos: usize) -> AxResult<u64> {
+        Err(AxError::Unsupported)
+    }
+}
+
+impl FileIO for Stderr {
+    fn readable(&self) -> bool {
+        false
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn read(&self, _buf: &mut [u8]) -> AxResult<usize> {
+        panic!("Cannot read from stdout!");
+    }
+
+    fn write(&self, buf: &[u8]) -> AxResult<usize> {
+        write_bytes(buf);
+        Ok(buf.len())
+    }
+
+    fn seek(&self, _pos: usize) -> AxResult<u64> {
+        Err(AxError::Unsupported)
+    }
+}


### PR DESCRIPTION
## Summary

- Refactors axfs_os based on [eb18704](https://github.com/WenyXu/arceos/pull/2/commits/eb187044027077962fde50619742b24af0ad5aab)

I'm still figuring out whether we can remove some redundant code in this crate. I might update this PR later.

## Related issue
- #45