### PR TITLE
Fix hypercraft missing docs & add traits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2023-02-01
+        toolchain: nightly
         components: rust-src, clippy, rustfmt
     - name: Clone github submodule
       run: git submodule update --init --recursive
@@ -39,7 +39,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2023-02-01
+        toolchain: nightly
         components: rust-src, llvm-tools-preview
     - uses: actions-rs/install@v0.1
       with:
@@ -70,6 +70,8 @@ jobs:
       run: make ARCH=${{ matrix.arch }} A=apps/net/httpclient NET=y
     - name: Build net/httpserver
       run: make ARCH=${{ matrix.arch }} A=apps/net/httpserver NET=y
+    - name: Build hv
+      run: make ARCH=${{ matrix.arch }} A=apps/hv HV=y
 
     - name: Download musl toolchain
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2023-02-01
+        toolchain: nightly
     - name: Clone github submodule
       run: git submodule update --init --recursive
     - name: Build docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2023-02-01
+        toolchain: nightly
         components: rust-src, llvm-tools-preview
     - name: Clone github submodule
       run: git submodule update --init --recursive

--- a/crates/timer_list/src/lib.rs
+++ b/crates/timer_list/src/lib.rs
@@ -28,7 +28,6 @@
 //! ```
 
 #![cfg_attr(not(test), no_std)]
-#![feature(binary_heap_retain)]
 
 extern crate alloc;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2023-02-01"
+channel = "nightly"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
 targets = ["x86_64-unknown-none", "riscv64gc-unknown-none-elf", "aarch64-unknown-none-softfloat"]

--- a/scripts/make/cargo.mk
+++ b/scripts/make/cargo.mk
@@ -53,7 +53,7 @@ ifeq ($(default_features),n)
   build_args += --no-default-features
 endif
 
-rustc_flags := -Clink-args="-T$(LD_SCRIPT) -no-pie"
+rustc_flags := -Clink-args="-T$(LD_SCRIPT) -no-pie" -Ctarget-feature=+h
 
 define cargo_build
   cargo rustc $(build_args) $(1) -- $(rustc_flags)

--- a/scripts/make/cargo.mk
+++ b/scripts/make/cargo.mk
@@ -53,7 +53,11 @@ ifeq ($(default_features),n)
   build_args += --no-default-features
 endif
 
-rustc_flags := -Clink-args="-T$(LD_SCRIPT) -no-pie" -Ctarget-feature=+h
+rustc_flags := -Clink-args="-T$(LD_SCRIPT) -no-pie"
+
+ifeq ($(HV), y)
+  rustc_flags += -Ctarget-feature=+h
+endif 
 
 define cargo_build
   cargo rustc $(build_args) $(1) -- $(rustc_flags)


### PR DESCRIPTION
This PR do the following:
- Add `![deny(missing_docs)]` && fix missing docs.
- Add basic traits defining [here](https://github.com/KuangjuX/hypercraft/blob/dev/src/traits.rs) for supporting basic hypervisor functions of all platforms.
- Update rust toolchain to the newest nigjtly version.