### PR TITLE
feat: create basic_allocator, tlsf_allocator (C and rust) and user test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,17 @@ dependencies = [
 name = "allocator"
 version = "0.1.0"
 dependencies = [
+ "axlog",
+ "basic_allocator",
  "bitmap-allocator",
  "buddy_system_allocator",
+ "libax",
+ "libc",
+ "log",
  "slab_allocator",
+ "spin 0.9.8",
+ "tlsf_allocator",
+ "tlsf_c_allocator",
 ]
 
 [[package]]
@@ -384,6 +392,13 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "basic_allocator"
+version = "0.1.0"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "bindgen"
@@ -1620,6 +1635,21 @@ dependencies = [
 [[package]]
 name = "timer_list"
 version = "0.1.0"
+
+[[package]]
+name = "tlsf_allocator"
+version = "0.1.0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "tlsf_c_allocator"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "tock-registers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ members = [
     "crates/spinlock",
     "crates/timer_list",
     "crates/tuple_for_each",
+    "crates/basic_allocator",
+    "crates/tlsf_allocator",
+    "crates/tlsf_c_allocator",
 
     "modules/axalloc",
     "modules/axconfig",

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ export LOG
 
 # Binutils
 ifeq ($(APP_LANG), c)
+  # CROSS_COMPILE ?= $(ARCH)-linux-gnu-
   CROSS_COMPILE ?= $(ARCH)-linux-musl-
   CC := $(CROSS_COMPILE)gcc
   AR := $(CROSS_COMPILE)ar

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -3,6 +3,10 @@ name = "allocator"
 version = "0.1.0"
 edition = "2021"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
+# To run user mode test, add below
+# build = "tests/build.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 description = "Various allocator algorithms in a unified interface"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"
@@ -13,3 +17,12 @@ documentation = "https://rcore-os.github.io/arceos/allocator/index.html"
 buddy_system_allocator = { version = "0.9", default-features = false }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator.git", rev = "88e871a" }
 slab_allocator = { path = "../slab_allocator" }
+basic_allocator = { path = "../basic_allocator" }
+tlsf_allocator = { path = "../tlsf_allocator" }
+tlsf_c_allocator = { path = "../tlsf_c_allocator" }
+log = "0.4"
+[dev-dependencies]
+spin = "0.9"
+axlog = {path = "../../modules/axlog", features = ["std"]}
+libax = {path = "../../ulib/libax"}
+libc = "0.2.0"

--- a/crates/allocator/src/basic.rs
+++ b/crates/allocator/src/basic.rs
@@ -1,0 +1,66 @@
+//! Basic memory allocation.
+//!
+//!
+
+use super::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use basic_allocator::Heap;
+use core::alloc::Layout;
+
+pub struct BasicAllocator {
+    inner: Option<Heap>,
+}
+
+impl BasicAllocator {
+    pub const fn new() -> Self {
+        Self { inner: None }
+    }
+
+    fn inner_mut(&mut self) -> &mut Heap {
+        self.inner.as_mut().unwrap()
+    }
+
+    fn inner(&self) -> &Heap {
+        self.inner.as_ref().unwrap()
+    }
+
+    pub fn set_strategy(&mut self, strategy: &str) {
+        self.inner_mut().set_strategy(strategy);
+    }
+}
+
+impl BaseAllocator for BasicAllocator {
+    fn init(&mut self, start: usize, size: usize) {
+        self.inner = Some(Heap::new());
+        self.inner_mut().init(start, size);
+    }
+
+    fn add_memory(&mut self, start: usize, size: usize) -> AllocResult {
+        self.inner_mut().add_memory(start, size);
+        Ok(())
+    }
+}
+
+impl ByteAllocator for BasicAllocator {
+    fn alloc(&mut self, size: usize, align_pow2: usize) -> AllocResult<usize> {
+        self.inner_mut()
+            .allocate(Layout::from_size_align(size, align_pow2).unwrap())
+            .map_err(|_| AllocError::NoMemory)
+    }
+
+    fn dealloc(&mut self, pos: usize, size: usize, align_pow2: usize) {
+        self.inner_mut()
+            .deallocate(pos, Layout::from_size_align(size, align_pow2).unwrap())
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.inner().total_bytes()
+    }
+
+    fn used_bytes(&self) -> usize {
+        self.inner().used_bytes()
+    }
+
+    fn available_bytes(&self) -> usize {
+        self.inner().available_bytes()
+    }
+}

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -3,7 +3,7 @@
 //! There are three types of allocators:
 //!
 //! - [`ByteAllocator`]: Byte-granularity memory allocator. (e.g.,
-//!   [`BuddyByteAllocator`], [`SlabByteAllocator`])
+//!   [`BuddyByteAllocator`], [`SlabByteAllocator`], [`BasicAllocator`], [`TLSFAllocator`], [`TLSFCAllocator`])
 //! - [`PageAllocator`]: Page-granularity memory allocator. (e.g.,
 //!   [`BitmapPageAllocator`])
 //! - [`IdAllocator`]: Used to allocate unique IDs.
@@ -11,13 +11,19 @@
 #![no_std]
 #![feature(result_option_inspect)]
 
+mod basic;
 mod bitmap;
 mod buddy;
 mod slab;
+mod tlsf;
+mod tlsf_c;
 
+pub use basic::BasicAllocator;
 pub use bitmap::BitmapPageAllocator;
 pub use buddy::BuddyByteAllocator;
 pub use slab::SlabByteAllocator;
+pub use tlsf::TLSFAllocator;
+pub use tlsf_c::TLSFCAllocator;
 
 /// The error type used for allocation.
 #[derive(Debug)]

--- a/crates/allocator/src/tlsf.rs
+++ b/crates/allocator/src/tlsf.rs
@@ -1,0 +1,62 @@
+//! TLSF memory allocation.
+//!
+//!
+
+use super::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use core::alloc::Layout;
+use tlsf_allocator::Heap;
+
+pub struct TLSFAllocator {
+    inner: Option<Heap>,
+}
+
+impl TLSFAllocator {
+    pub const fn new() -> Self {
+        Self { inner: None }
+    }
+
+    fn inner_mut(&mut self) -> &mut Heap {
+        self.inner.as_mut().unwrap()
+    }
+
+    fn inner(&self) -> &Heap {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl BaseAllocator for TLSFAllocator {
+    fn init(&mut self, start: usize, size: usize) {
+        self.inner = Some(Heap::new());
+        self.inner_mut().init(start, size);
+    }
+
+    fn add_memory(&mut self, start: usize, size: usize) -> AllocResult {
+        self.inner_mut().add_memory(start, size);
+        Ok(())
+    }
+}
+
+impl ByteAllocator for TLSFAllocator {
+    fn alloc(&mut self, size: usize, align_pow2: usize) -> AllocResult<usize> {
+        self.inner_mut()
+            .allocate(Layout::from_size_align(size, align_pow2).unwrap())
+            .map_err(|_| AllocError::NoMemory)
+    }
+
+    fn dealloc(&mut self, pos: usize, size: usize, align_pow2: usize) {
+        self.inner_mut()
+            .deallocate(pos, Layout::from_size_align(size, align_pow2).unwrap())
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.inner().total_bytes()
+    }
+
+    fn used_bytes(&self) -> usize {
+        self.inner().used_bytes()
+    }
+
+    fn available_bytes(&self) -> usize {
+        self.inner().available_bytes()
+    }
+}

--- a/crates/allocator/src/tlsf_c.rs
+++ b/crates/allocator/src/tlsf_c.rs
@@ -1,0 +1,60 @@
+//! TLSF memory allocation.
+//!
+//!
+
+use super::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use tlsf_c_allocator::Heap;
+
+pub struct TLSFCAllocator {
+    inner: Option<Heap>,
+}
+
+impl TLSFCAllocator {
+    pub const fn new() -> Self {
+        Self { inner: None }
+    }
+
+    fn inner_mut(&mut self) -> &mut Heap {
+        self.inner.as_mut().unwrap()
+    }
+
+    fn inner(&self) -> &Heap {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl BaseAllocator for TLSFCAllocator {
+    fn init(&mut self, start: usize, size: usize) {
+        self.inner = Some(Heap::new());
+        self.inner_mut().init(start, size);
+    }
+
+    fn add_memory(&mut self, start: usize, size: usize) -> AllocResult {
+        self.inner_mut().add_memory(start, size);
+        Ok(())
+    }
+}
+
+impl ByteAllocator for TLSFCAllocator {
+    fn alloc(&mut self, size: usize, align_pow2: usize) -> AllocResult<usize> {
+        self.inner_mut()
+            .allocate(size, align_pow2)
+            .map_err(|_| AllocError::NoMemory)
+    }
+
+    fn dealloc(&mut self, pos: usize, size: usize, align_pow2: usize) {
+        self.inner_mut().deallocate(pos, size, align_pow2)
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.inner().total_bytes()
+    }
+
+    fn used_bytes(&self) -> usize {
+        self.inner().used_bytes()
+    }
+
+    fn available_bytes(&self) -> usize {
+        self.inner().available_bytes()
+    }
+}

--- a/crates/allocator/tests/basic_test.rs
+++ b/crates/allocator/tests/basic_test.rs
@@ -1,0 +1,112 @@
+use libax::rand::rand_u32;
+use std::collections::BTreeMap;
+use std::vec::Vec;
+
+pub fn test_vec(n: usize) {
+    println!("test_vec() begin...");
+    let mut v = Vec::new();
+    for _ in 0..n {
+        v.push(rand_u32());
+    }
+    println!("test_vec() OK!");
+}
+
+pub fn test_btree_map(n: usize) {
+    println!("test_btree_map() begin...");
+    let mut m = BTreeMap::new();
+    for _ in 0..n {
+        if rand_u32() % 5 == 0 && !m.is_empty() {
+            m.pop_first();
+        } else {
+            let value = rand_u32() as usize;
+            let key = format!("key_{value}");
+            m.insert(key, value);
+        }
+    }
+    for (k, v) in m.iter() {
+        if let Some(k) = k.strip_prefix("key_") {
+            assert_eq!(k.parse::<usize>().unwrap(), *v);
+        }
+    }
+    println!("test_btree_map() OK!");
+}
+
+pub fn test_vec_2(n: usize, m: usize) {
+    println!("test_vec2() begin...");
+    let mut v: Vec<Vec<usize>> = Vec::new();
+    for _ in 0..n {
+        let mut tmp: Vec<usize> = Vec::with_capacity(m);
+        for _ in 0..m {
+            tmp.push(rand_u32() as usize);
+        }
+        tmp.sort();
+        for j in 0..m - 1 {
+            assert!(tmp[j] <= tmp[j + 1]);
+        }
+        v.push(tmp);
+    }
+
+    let mut p: Vec<usize> = Vec::with_capacity(n);
+    for i in 0..n {
+        p.push(i);
+    }
+
+    for i in 1..n {
+        let o: usize = rand_u32() as usize % (i + 1);
+        let tmp = p[i];
+        p[i] = p[o];
+        p[o] = tmp;
+    }
+    for i in 0..n {
+        let o = p[i];
+        let tmp: Vec<usize> = Vec::new();
+        v[o] = tmp;
+    }
+    println!("test_vec2() OK!");
+}
+
+pub fn test_vec_3(n: usize, k1: usize, k2: usize) {
+    println!("test_vec3() begin...");
+    let mut v: Vec<Vec<usize>> = Vec::new();
+    for i in 0..n * 4 {
+        let nw = match i >= n * 2 {
+            true => k1,
+            false => match i % 2 {
+                0 => k1,
+                _ => k2,
+            },
+        };
+        v.push(Vec::with_capacity(nw));
+        for _ in 0..nw {
+            v[i].push(rand_u32() as usize);
+        }
+    }
+    for i in 0..n * 4 {
+        if i % 2 == 1 {
+            let tmp: Vec<usize> = Vec::new();
+            v[i] = tmp;
+        }
+    }
+    for i in 0..n {
+        let nw = k2;
+        v.push(Vec::with_capacity(nw));
+        for _ in 0..nw {
+            v[4 * n + i].push(rand_u32() as usize);
+        }
+    }
+    println!("test_vec3() OK!");
+}
+
+/// basic test
+pub fn basic_test() {
+    println!("Basic alloc test begin...");
+    let t0 = std::time::Instant::now();
+    test_vec(3000000);
+    test_vec_2(30000, 64);
+    test_vec_2(7500, 520);
+    test_btree_map(50000);
+    test_vec_3(10000, 32, 64);
+    let t1 = std::time::Instant::now();
+    println!("time: {:#?}", t1 - t0);
+    println!("Basic alloc test OK!");
+}

--- a/crates/allocator/tests/build.rs
+++ b/crates/allocator/tests/build.rs
@@ -1,0 +1,76 @@
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    // test.c
+    Command::new("cc")
+        .args(&["tests/test.c", "-O3", "-c", "-fPIC", "-o"])
+        .arg(&format!("{}/test.o", out_dir))
+        .status()
+        .unwrap();
+
+    Command::new("ar")
+        .args(&["crus", "libtest.a", "test.o"])
+        .current_dir(&Path::new(&out_dir))
+        .status()
+        .unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=test");
+
+    //mitest/mitest.c
+    Command::new("cc")
+        .args(&["tests/mitest/mitest.c", "-O3", "-c", "-fPIC", "-o"])
+        .arg(&format!("{}/mitest.o", out_dir))
+        .status()
+        .unwrap();
+    Command::new("ar")
+        .args(&["crus", "libmitest.a", "mitest.o"])
+        .current_dir(&Path::new(&out_dir))
+        .status()
+        .unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=mitest");
+
+    //malloc_large/malloc_large.c
+    Command::new("cc")
+        .args(&[
+            "tests/malloc_large/malloc_large.c",
+            "-O3",
+            "-c",
+            "-fPIC",
+            "-o",
+        ])
+        .arg(&format!("{}/malloc_large.o", out_dir))
+        .status()
+        .unwrap();
+    Command::new("ar")
+        .args(&["crus", "libmalloc_large.a", "malloc_large.o"])
+        .current_dir(&Path::new(&out_dir))
+        .status()
+        .unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=malloc_large");
+
+    //glibc_bench/glibc_bench.c
+    Command::new("cc")
+        .args(&[
+            "tests/glibc_bench/glibc_bench.c",
+            "-O3",
+            "-c",
+            "-fPIC",
+            "-o",
+        ])
+        .arg(&format!("{}/glibc_bench.o", out_dir))
+        .status()
+        .unwrap();
+    Command::new("ar")
+        .args(&["crus", "libglibc_bench.a", "glibc_bench.o"])
+        .current_dir(&Path::new(&out_dir))
+        .status()
+        .unwrap();
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=glibc_bench");
+}

--- a/crates/allocator/tests/glibc_bench/glibc_bench.c
+++ b/crates/allocator/tests/glibc_bench/glibc_bench.c
@@ -1,0 +1,146 @@
+/* Benchmark malloc and free functions.
+   Copyright (C) 2019-2021 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+// modified by Daan Leijen to fit the bench suite and add lifo/fifo free order.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "glibc_bench.h"
+// #include "bench-timing.h"
+// #include "json-lib.h"
+
+/* Benchmark the malloc/free performance of a varying number of blocks of a
+   given size.  This enables performance tracking of the t-cache and fastbins.
+   It tests 3 different scenarios: single-threaded using main arena,
+   multi-threaded using thread-arena, and main arena with SINGLE_THREAD_P
+   false.  */
+
+#define NUM_ITERS 2000000
+#define NUM_ALLOCS 4
+#define MAX_ALLOCS 1600
+
+// Daan: disable timing
+typedef long timing_t;
+#define TIMING_NOW(s) 
+#define TIMING_DIFF(e,start,stop)
+
+
+typedef struct
+{
+  size_t iters;
+  size_t size;
+  int n;
+  timing_t elapsed;
+} malloc_args;
+
+static void
+do_benchmark (malloc_args *args, char**arr)
+{
+  printf("do benchmark: %d %d %d %d\n",args->iters,args->size,args->n,args->elapsed);
+  timing_t start, stop;
+  size_t iters = args->iters;
+  size_t size = args->size;
+  int n = args->n;
+
+  TIMING_NOW (start);
+
+  int *_size = glibc_bench_malloc(n * sizeof(int));
+
+  for (int j = 0; j < iters; j++)
+    {
+      for (int i = 0; i < n; i++) {
+        arr[i] = glibc_bench_malloc (size);
+        _size[i] = size;
+        for(int g = 0; g < size; g++) { arr[i][g] =(char)g; }
+      }
+
+      // free half in fifo order
+      for (int i = 0; i < n/2; i++) {
+	      glibc_bench_free (arr[i],_size[i]);  
+      }
+    
+      // and the other half in lifo order
+      for(int i = n-1; i >= n/2; i--) {
+        glibc_bench_free(arr[i],_size[i]);
+      }
+  }
+
+  glibc_bench_free(_size, n * sizeof(int));
+
+
+  TIMING_NOW (stop);
+
+  TIMING_DIFF (args->elapsed, start, stop);
+}
+
+static malloc_args tests[3][NUM_ALLOCS];
+static int allocs[NUM_ALLOCS] = { 25, 100, 400, MAX_ALLOCS };
+
+static void *
+thread_test (void *p)
+{
+  char **arr = (char**)p;
+
+  /* Run benchmark multi-threaded.  */
+  for (int i = 0; i < NUM_ALLOCS; i++)
+    do_benchmark (&tests[2][i], arr);
+
+  return p;
+}
+
+void
+bench (unsigned long size)
+{
+  printf("bench: size = %d\n",size);
+  size_t iters = NUM_ITERS;
+  char**arr = (char**)glibc_bench_malloc (MAX_ALLOCS * sizeof (void*));
+
+  for (int t = 0; t < 3; t++)
+    for (int i = 0; i < NUM_ALLOCS; i++)
+      {
+	tests[t][i].n = allocs[i];
+	tests[t][i].size = size;
+	tests[t][i].iters = iters / allocs[i];
+
+	/* Do a quick warmup run.  */
+	if (t == 0)
+	  do_benchmark (&tests[0][i], arr);
+      }
+
+  /* Run benchmark single threaded in main_arena.  */
+  for (int i = 0; i < NUM_ALLOCS; i++)
+    do_benchmark (&tests[0][i], arr);
+
+  /* Repeat benchmark in main_arena with SINGLE_THREAD_P == false.  */
+  for (int i = 0; i < NUM_ALLOCS; i++)
+    do_benchmark (&tests[1][i], arr);
+
+  glibc_bench_free (arr, MAX_ALLOCS * sizeof (void*));
+
+}
+
+void glibc_bench_test_start(CallBackMalloc _cb1,CallBackMallocAligned _cb2,CallBackFree _cb3) {
+  cb1 = _cb1;
+  cb2 = _cb2;
+  cb3 = _cb3;
+  long size = 16;
+
+  bench (size);
+  bench (2*size);
+  bench (4*size);
+}

--- a/crates/allocator/tests/glibc_bench/glibc_bench.h
+++ b/crates/allocator/tests/glibc_bench/glibc_bench.h
@@ -1,0 +1,18 @@
+#include <stdio.h>
+typedef void* (*CallBackMalloc)(size_t size);
+typedef void* (*CallBackMallocAligned)(size_t size,size_t align);
+typedef void (*CallBackFree)(void* ptr,size_t size);
+CallBackMalloc cb1;
+CallBackMallocAligned cb2;
+CallBackFree cb3;
+
+void* glibc_bench_malloc(size_t size){
+    return cb1(size);
+}
+void* glibc_bench_malloc_aligned(size_t size,size_t align){
+    return cb2(size,align);
+}
+void glibc_bench_free(void* ptr,size_t size){
+    cb3(ptr,size);
+}
+

--- a/crates/allocator/tests/malloc_large/malloc_large.c
+++ b/crates/allocator/tests/malloc_large/malloc_large.c
@@ -1,0 +1,35 @@
+// Test allocation large blocks between 2 and 5 MiB with up to 10 live at any time.
+// Provided by Leonid Stolyarov in issue #447 and modified by Daan Leijen.
+#include <stdio.h>
+#include <stdlib.h>
+#include "malloc_large.h"
+int get_random(int xmin,int xmax){
+  return rand() % (xmax - xmin + 1) + xmin;
+}
+void malloc_large_test_start(CallBackMalloc _cb1,CallBackMallocAligned _cb2,CallBackFree _cb3) {
+  cb1 = _cb1;
+  cb2 = _cb2;
+  cb3 = _cb3;
+  static const int kNumBuffers = 10;
+  static const size_t kMinBufferSize = 2 * 1024 * 1024;//2MB
+  static const size_t kMaxBufferSize = 5 * 1024 * 1024;//5MB
+  char* buffers[kNumBuffers];
+  int size[kNumBuffers];
+
+  srand(42);
+  static const int kNumIterations = 100000;
+  for (int i = 0; i < kNumBuffers; ++i){
+    buffers[i] = large_malloc(kMinBufferSize);
+    size[i] = kMinBufferSize;
+  }
+  for (int i = 0; i < kNumIterations; ++i) {
+    int buffer_idx = get_random(0, kNumBuffers - 1);
+    size_t new_size = get_random(kMinBufferSize, kMaxBufferSize);
+    large_free(buffers[buffer_idx],size[buffer_idx]);
+    buffers[buffer_idx] = large_malloc(new_size);
+    size[buffer_idx] = new_size;
+  }
+  for(int i = 0;i < kNumBuffers;++i){
+    large_free(buffers[i],size[i]);
+  }
+}

--- a/crates/allocator/tests/malloc_large/malloc_large.h
+++ b/crates/allocator/tests/malloc_large/malloc_large.h
@@ -1,0 +1,18 @@
+#include <stdio.h>
+typedef void* (*CallBackMalloc)(size_t size);
+typedef void* (*CallBackMallocAligned)(size_t size,size_t align);
+typedef void (*CallBackFree)(void* ptr,size_t size);
+CallBackMalloc cb1;
+CallBackMallocAligned cb2;
+CallBackFree cb3;
+
+void* large_malloc(size_t size){
+    return cb1(size);
+}
+void* large_malloc_aligned(size_t size,size_t align){
+    return cb2(size,align);
+}
+void large_free(void* ptr,size_t size){
+    cb3(ptr,size);
+}
+

--- a/crates/allocator/tests/mitest/mitest.c
+++ b/crates/allocator/tests/mitest/mitest.c
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <assert.h>
+#include "mitest.h"
+
+void test_large() {
+  const size_t N = 1000;
+
+  for (size_t i = 0; i < N; ++i) {
+    size_t sz = 1ull << 21;
+    char *a = mi_malloc(sz);
+    for (size_t k = 0; k < sz; k++) { a[k] = 'x'; }
+    mi_free(a,sz);
+  }
+}
+
+void mi_test_start(CallBackMalloc _cb1,CallBackMallocAligned _cb2,CallBackFree _cb3) {
+  cb1 = _cb1;
+  cb2 = _cb2;
+  cb3 = _cb3;
+  void* p1 = mi_malloc(16);
+  void* p2 = mi_malloc(1000000);
+  mi_free(p1,16);
+  mi_free(p2,1000000);
+  p1 = mi_malloc(16);
+  p2 = mi_malloc(16);
+  mi_free(p1,16);
+  mi_free(p2,16);
+
+  p1 = mi_malloc_aligned(64, 8);
+  p2 = mi_malloc_aligned(160,8);
+  mi_free(p2,160);
+  mi_free(p1,64);
+  test_large();
+}

--- a/crates/allocator/tests/mitest/mitest.h
+++ b/crates/allocator/tests/mitest/mitest.h
@@ -1,0 +1,18 @@
+#include <stdio.h>
+typedef void* (*CallBackMalloc)(size_t size);
+typedef void* (*CallBackMallocAligned)(size_t size,size_t align);
+typedef void (*CallBackFree)(void* ptr,size_t size);
+CallBackMalloc cb1;
+CallBackMallocAligned cb2;
+CallBackFree cb3;
+
+void* mi_malloc(size_t size){
+    return cb1(size);
+}
+void* mi_malloc_aligned(size_t size,size_t align){
+    return cb2(size,align);
+}
+void mi_free(void* ptr,size_t size){
+    cb3(ptr,size);
+}
+

--- a/crates/allocator/tests/test.c
+++ b/crates/allocator/tests/test.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+typedef int (*CallBack)(int x);
+
+int hello(int x, CallBack cb){
+    printf("hello c! %d\n",x);
+    return cb(x + 1);
+}

--- a/crates/allocator/tests/test_main.rs
+++ b/crates/allocator/tests/test_main.rs
@@ -1,0 +1,568 @@
+#![feature(ptr_alignment_type)]
+mod basic_test;
+use allocator::{AllocResult, BaseAllocator, ByteAllocator};
+use allocator::{
+    BasicAllocator, BuddyByteAllocator, SlabByteAllocator, TLSFAllocator, TLSFCAllocator,
+};
+use basic_test::basic_test;
+use libax::rand::{rand_u32, srand};
+use std::mem::size_of;
+use std::vec::Vec;
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    ffi::c_ulonglong,
+};
+
+use core::panic;
+use spin::Mutex;
+pub enum AllocType {
+    SystemAlloc,
+    BasicAlloc,
+    BuddyAlloc,
+    SlabAlloc,
+    TLSFCAlloc,
+    TLSFRustAlloc,
+}
+
+pub struct GlobalAllocator {
+    basic_alloc: Mutex<BasicAllocator>,
+    buddy_alloc: Mutex<BuddyByteAllocator>,
+    slab_alloc: Mutex<SlabByteAllocator>,
+    tlsf_c_alloc: Mutex<TLSFCAllocator>,
+    tlsf_rust_alloc: Mutex<TLSFAllocator>,
+    alloc_type: AllocType,
+    heap_arddress: usize,
+    heap_size: usize,
+}
+
+const PAGE_SIZE: usize = 1 << 12; // need 4KB aligned
+const HEAP_SIZE: usize = 1 << 26; // 512MB
+static mut HEAP: [usize; HEAP_SIZE + PAGE_SIZE] = [0; HEAP_SIZE + PAGE_SIZE];
+
+static mut FLAG: bool = false;
+
+impl GlobalAllocator {
+    pub const fn new() -> Self {
+        Self {
+            basic_alloc: Mutex::new(BasicAllocator::new()),
+            buddy_alloc: Mutex::new(BuddyByteAllocator::new()),
+            slab_alloc: Mutex::new(SlabByteAllocator::new()),
+            tlsf_c_alloc: Mutex::new(TLSFCAllocator::new()),
+            tlsf_rust_alloc: Mutex::new(TLSFAllocator::new()),
+            alloc_type: AllocType::SystemAlloc,
+            heap_arddress: 0,
+            heap_size: 0,
+        }
+    }
+
+    pub unsafe fn init_heap(&mut self) {
+        self.heap_arddress = (HEAP.as_ptr() as usize + PAGE_SIZE - 1) / PAGE_SIZE * PAGE_SIZE;
+        self.heap_size = HEAP_SIZE * size_of::<usize>();
+    }
+
+    pub unsafe fn init_system(&mut self) {
+        self.alloc_type = AllocType::SystemAlloc;
+    }
+
+    pub unsafe fn init_basic(&mut self, strategy: &str) {
+        self.basic_alloc
+            .lock()
+            .init(self.heap_arddress, self.heap_size);
+        self.basic_alloc.lock().set_strategy(strategy);
+        self.alloc_type = AllocType::BasicAlloc;
+    }
+
+    pub unsafe fn init_buddy(&mut self) {
+        self.buddy_alloc
+            .lock()
+            .init(self.heap_arddress, self.heap_size);
+        self.alloc_type = AllocType::BuddyAlloc;
+    }
+
+    pub unsafe fn init_slab(&mut self) {
+        self.slab_alloc
+            .lock()
+            .init(self.heap_arddress, self.heap_size);
+        self.alloc_type = AllocType::SlabAlloc;
+    }
+
+    pub unsafe fn init_tlsf_c(&mut self) {
+        self.tlsf_c_alloc
+            .lock()
+            .init(self.heap_arddress, self.heap_size);
+        self.alloc_type = AllocType::TLSFCAlloc;
+    }
+
+    pub unsafe fn init_tlsf_rust(&mut self) {
+        self.tlsf_rust_alloc
+            .lock()
+            .init(self.heap_arddress, self.heap_size);
+        self.alloc_type = AllocType::TLSFRustAlloc;
+    }
+
+    pub unsafe fn alloc(&self, layout: Layout) -> AllocResult<usize> {
+        let size: usize = layout.size();
+        let align_pow2: usize = layout.align();
+        if FLAG {
+            let ptr = System.alloc(layout);
+            return Ok(ptr as usize);
+        }
+
+        match self.alloc_type {
+            AllocType::SystemAlloc => {
+                let ptr = System.alloc(layout);
+                return Ok(ptr as usize);
+            }
+            AllocType::BasicAlloc => {
+                FLAG = true;
+                if let Ok(ptr) = self.basic_alloc.lock().alloc(size, align_pow2) {
+                    FLAG = false;
+                    return Ok(ptr);
+                } else {
+                    panic!("alloc err: no memery.");
+                }
+            }
+            AllocType::BuddyAlloc => {
+                FLAG = true;
+                if let Ok(ptr) = self.buddy_alloc.lock().alloc(size, align_pow2) {
+                    FLAG = false;
+                    return Ok(ptr);
+                } else {
+                    panic!("alloc err: no memery.");
+                }
+            }
+            AllocType::SlabAlloc => {
+                FLAG = true;
+                if let Ok(ptr) = self.slab_alloc.lock().alloc(size, align_pow2) {
+                    FLAG = false;
+                    return Ok(ptr);
+                } else {
+                    panic!("alloc err: no memery.");
+                }
+            }
+            AllocType::TLSFCAlloc => {
+                FLAG = true;
+                if let Ok(ptr) = self.tlsf_c_alloc.lock().alloc(size, align_pow2) {
+                    FLAG = false;
+                    return Ok(ptr);
+                } else {
+                    panic!("alloc err: no memery.");
+                }
+            }
+            AllocType::TLSFRustAlloc => {
+                FLAG = true;
+                if let Ok(ptr) = self.tlsf_rust_alloc.lock().alloc(size, align_pow2) {
+                    FLAG = false;
+                    return Ok(ptr);
+                } else {
+                    panic!("alloc err: no memery.");
+                }
+            }
+        }
+    }
+
+    pub unsafe fn dealloc(&self, pos: usize, layout: Layout) {
+        let size: usize = layout.size();
+        let align_pow2: usize = layout.align();
+        if FLAG {
+            System.dealloc(pos as *mut u8, layout);
+            return;
+        }
+
+        match self.alloc_type {
+            AllocType::SystemAlloc => {
+                System.dealloc(pos as *mut u8, layout);
+            }
+            AllocType::BasicAlloc => {
+                FLAG = true;
+                self.basic_alloc.lock().dealloc(pos, size, align_pow2);
+                FLAG = false;
+            }
+            AllocType::BuddyAlloc => {
+                FLAG = true;
+                self.buddy_alloc.lock().dealloc(pos, size, align_pow2);
+                FLAG = false;
+            }
+            AllocType::SlabAlloc => {
+                FLAG = true;
+                self.slab_alloc.lock().dealloc(pos, size, align_pow2);
+                FLAG = false;
+            }
+            AllocType::TLSFCAlloc => {
+                FLAG = true;
+                self.tlsf_c_alloc.lock().dealloc(pos, size, align_pow2);
+                FLAG = false;
+            }
+            AllocType::TLSFRustAlloc => {
+                FLAG = true;
+                self.tlsf_rust_alloc.lock().dealloc(pos, size, align_pow2);
+                FLAG = false;
+            }
+        }
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        match self.alloc_type {
+            AllocType::SystemAlloc => 0,
+            AllocType::BasicAlloc => self.basic_alloc.lock().total_bytes(),
+            AllocType::BuddyAlloc => self.buddy_alloc.lock().total_bytes(),
+            AllocType::SlabAlloc => self.slab_alloc.lock().total_bytes(),
+            AllocType::TLSFCAlloc => self.tlsf_c_alloc.lock().total_bytes(),
+            AllocType::TLSFRustAlloc => self.tlsf_rust_alloc.lock().total_bytes(),
+        }
+    }
+
+    pub fn used_bytes(&self) -> usize {
+        match self.alloc_type {
+            AllocType::SystemAlloc => 0,
+            AllocType::BasicAlloc => self.basic_alloc.lock().used_bytes(),
+            AllocType::BuddyAlloc => self.buddy_alloc.lock().used_bytes(),
+            AllocType::SlabAlloc => self.slab_alloc.lock().used_bytes(),
+            AllocType::TLSFCAlloc => self.tlsf_c_alloc.lock().used_bytes(),
+            AllocType::TLSFRustAlloc => self.tlsf_rust_alloc.lock().used_bytes(),
+        }
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        match self.alloc_type {
+            AllocType::SystemAlloc => 0,
+            AllocType::BasicAlloc => self.basic_alloc.lock().available_bytes(),
+            AllocType::BuddyAlloc => self.buddy_alloc.lock().available_bytes(),
+            AllocType::SlabAlloc => self.slab_alloc.lock().available_bytes(),
+            AllocType::TLSFCAlloc => self.tlsf_c_alloc.lock().available_bytes(),
+            AllocType::TLSFRustAlloc => self.tlsf_rust_alloc.lock().available_bytes(),
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for GlobalAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if let Ok(ptr) = GlobalAllocator::alloc(self, layout) {
+            ptr as _
+        } else {
+            panic!("alloc err.");
+        }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        GlobalAllocator::dealloc(self, ptr as _, layout)
+    }
+}
+
+#[global_allocator]
+pub static mut GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator::new();
+
+use std::ffi::c_int;
+pub type CallBack = unsafe extern "C" fn(c_int) -> c_int;
+#[link(name = "test")]
+extern "C" {
+    pub fn hello(a: c_int, cb: CallBack) -> c_int;
+}
+pub unsafe extern "C" fn cb_func(x: c_int) -> c_int {
+    println!("hello rust! {:#?}", x);
+    return x * x + 1;
+}
+pub fn call_back_test(x: c_int) {
+    unsafe {
+        let y = hello(x, cb_func);
+        println!("rust call_back test passed! {:#?}", y);
+    }
+}
+
+pub type CallBackMalloc = unsafe extern "C" fn(size: c_ulonglong) -> c_ulonglong;
+pub type CallBackMallocAligned =
+    unsafe extern "C" fn(size: c_ulonglong, align: c_ulonglong) -> c_ulonglong;
+pub type CallBackFree = unsafe extern "C" fn(ptr: c_ulonglong, size: c_ulonglong);
+
+pub unsafe extern "C" fn cb_malloc_func(size: c_ulonglong) -> c_ulonglong {
+    if let Ok(ptr) = GLOBAL_ALLOCATOR.alloc(Layout::from_size_align_unchecked(size as usize, 8)) {
+        return ptr as c_ulonglong;
+    }
+    panic!("alloc err.");
+}
+pub unsafe extern "C" fn cb_malloc_aligned_func(
+    size: c_ulonglong,
+    align: c_ulonglong,
+) -> c_ulonglong {
+    if let Ok(ptr) = GLOBAL_ALLOCATOR.alloc(Layout::from_size_align_unchecked(
+        size as usize,
+        align as usize,
+    )) {
+        return ptr as c_ulonglong;
+    }
+    panic!("alloc err.");
+}
+pub unsafe extern "C" fn cb_free_func(ptr: c_ulonglong, size: c_ulonglong) {
+    GLOBAL_ALLOCATOR.dealloc(
+        ptr as usize,
+        Layout::from_size_align_unchecked(size as usize, 8),
+    );
+}
+
+#[link(name = "mitest")]
+extern "C" {
+    pub fn mi_test_start(cb1: CallBackMalloc, cb2: CallBackMallocAligned, cb3: CallBackFree);
+}
+pub fn mi_test() {
+    //return;
+    println!("Mi alloc test begin...");
+    let t0 = std::time::Instant::now();
+    unsafe {
+        mi_test_start(cb_malloc_func, cb_malloc_aligned_func, cb_free_func);
+    }
+    let t1 = std::time::Instant::now();
+    println!("time: {:#?}", t1 - t0);
+    println!("Mi alloc test OK!");
+}
+
+#[link(name = "malloc_large")]
+extern "C" {
+    pub fn malloc_large_test_start(
+        cb1: CallBackMalloc,
+        cb2: CallBackMallocAligned,
+        cb3: CallBackFree,
+    );
+}
+pub fn malloc_large_test() {
+    //return;
+    println!("Malloc large test begin...");
+    let t0 = std::time::Instant::now();
+    unsafe {
+        malloc_large_test_start(cb_malloc_func, cb_malloc_aligned_func, cb_free_func);
+    }
+    let t1 = std::time::Instant::now();
+    println!("time: {:#?}", t1 - t0);
+    println!("Malloc large test OK!");
+}
+
+#[link(name = "glibc_bench")]
+extern "C" {
+    pub fn glibc_bench_test_start(
+        cb1: CallBackMalloc,
+        cb2: CallBackMallocAligned,
+        cb3: CallBackFree,
+    );
+}
+pub fn glibc_bench_test() {
+    //return;
+    println!("Glibc bench test begin...");
+    let t0 = std::time::Instant::now();
+    unsafe {
+        glibc_bench_test_start(cb_malloc_func, cb_malloc_aligned_func, cb_free_func);
+    }
+    let t1 = std::time::Instant::now();
+    println!("time: {:#?}", t1 - t0);
+    println!("Glibc bench test OK!");
+}
+
+///memory chk
+pub fn memory_chk() {
+    unsafe {
+        let tot = GLOBAL_ALLOCATOR.total_bytes() as f64;
+        let used = GLOBAL_ALLOCATOR.used_bytes() as f64;
+        let avail = GLOBAL_ALLOCATOR.available_bytes() as f64;
+        println!("total memory: {:#?} MB", tot / 1048576.0);
+        println!("used memory: {:#?} MB", used / 1048576.0);
+        println!("available memory: {:#?} MB", avail / 1048576.0);
+        println!("occupied memory: {:#?} MB", (tot - avail) / 1048576.0);
+        println!(
+            "extra memory rate: {:#?}%",
+            (tot - avail - used) / (tot - avail) * 100.0
+        );
+    }
+}
+
+/// new aligned memory
+pub fn new_mem(size: usize, align: usize) -> usize {
+    unsafe {
+        if let Ok(ptr) = GLOBAL_ALLOCATOR.alloc(Layout::from_size_align_unchecked(size, align)) {
+            return ptr;
+        }
+        panic!("alloc err.");
+    }
+}
+
+/// align test
+pub fn align_test() {
+    println!("Align alloc test begin...");
+    let t0 = std::time::Instant::now();
+    let mut v = Vec::new();
+    let mut v2 = Vec::new();
+    let mut v3 = Vec::new();
+    let mut p = Vec::new();
+    let n = 50000;
+    let mut cnt = 0;
+    let mut nw = 0;
+    for _ in 0..n {
+        if (rand_u32() % 3 != 0) | (nw == 0) {
+            //插入一个块
+            let size = (((1 << (rand_u32() & 15)) as f64)
+                * (1.0 + (rand_u32() as f64) / (0xffffffff as u32 as f64)))
+                as usize;
+            let align = (1 << (rand_u32() & 7)) as usize;
+            let addr = new_mem(size, align);
+            v.push(addr);
+            assert!((addr & (align - 1)) == 0, "align not correct.");
+            v2.push(size);
+            v3.push(align);
+            p.push(cnt);
+            cnt += 1;
+            nw += 1;
+        } else {
+            //删除一个块
+            let idx = rand_u32() as usize % nw;
+            let addr = v[p[idx]];
+            let size = v2[p[idx]];
+            let align = v3[p[idx]];
+            unsafe {
+                GLOBAL_ALLOCATOR.dealloc(
+                    addr,
+                    Layout::from_size_align_unchecked(size as usize, align),
+                );
+            }
+            nw -= 1;
+            p[idx] = p[nw];
+            p.pop();
+        }
+    }
+    memory_chk();
+    for idx in 0..nw {
+        let addr = v[p[idx]];
+        let size = v2[p[idx]];
+        let align = v3[p[idx]];
+        unsafe {
+            GLOBAL_ALLOCATOR.dealloc(
+                addr,
+                Layout::from_size_align_unchecked(size as usize, align),
+            );
+        }
+    }
+    let t1 = std::time::Instant::now();
+    println!("time: {:#?}", t1 - t0);
+    println!("Align alloc test OK!");
+}
+
+#[test]
+fn test_start() {
+    srand(2333);
+    axlog::init();
+    axlog::set_max_level("debug");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_heap();
+    }
+    call_back_test(233);
+    println!("Running memory tests...");
+
+    println!("system alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+    align_test();
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("system test passed!");
+    println!("*****************************");
+
+    println!("tlsf_rust alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_tlsf_rust();
+    }
+    align_test();
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("tlsf_rust alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("first fit alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_basic("first_fit");
+    }
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("first fit alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("best fit alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_basic("best_fit");
+    }
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("best fit alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("worst fit alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_basic("worst_fit");
+    }
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("worst fit alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("buddy alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_buddy();
+    }
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("buddy alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("slab alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_slab();
+    }
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("slab alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("tlsf_c alloc test:");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_tlsf_c();
+    }
+    align_test();
+    basic_test();
+    mi_test();
+    malloc_large_test();
+    glibc_bench_test();
+    println!("tlsf_c alloc test passed!");
+    println!("*****************************");
+    unsafe {
+        GLOBAL_ALLOCATOR.init_system();
+    }
+
+    println!("Memory tests run OK!");
+}

--- a/crates/basic_allocator/Cargo.toml
+++ b/crates/basic_allocator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "basic_allocator"
+version = "0.1.0"
+edition = "2021"
+authors = ["Yibin Zhang <zhangyb20@mails.tsinghua.edu.cn>"]
+
+[dependencies]
+log = "0.4"

--- a/crates/basic_allocator/src/lib.rs
+++ b/crates/basic_allocator/src/lib.rs
@@ -1,0 +1,295 @@
+#![feature(allocator_api)]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::alloc::{AllocError, Layout};
+use alloc::vec::Vec;
+use core::mem::size_of;
+pub mod linked_list;
+use core::cmp::max;
+pub use linked_list::{LinkedList, MemBlockFoot, MemBlockHead};
+
+pub enum BasicAllocatorStrategy {
+    FirstFitStrategy,
+    BestFitStrategy,
+    WorstFitStrategy,
+}
+
+pub struct Heap {
+    free_list: LinkedList,
+    user: usize,                      //分配给用户的内存大小
+    allocated: usize,                 //实际分配出去的内存大小
+    total: usize,                     //总内存大小
+    strategy: BasicAllocatorStrategy, //使用的内存分配策略
+    begin_addr: usize,                //堆区起始地址
+    end_addr: usize,                  //堆区结束地址
+
+    kernel_begin: Vec<usize>,
+    kernel_end: Vec<usize>,
+}
+
+/// 获取一个地址加上一个usize(分配出去的块的头)大小后对齐到align的结果
+fn get_aligned(addr: usize, align: usize) -> usize {
+    (addr + size_of::<usize>() + align - 1) / align * align
+}
+
+/// 获取一个size对齐到align的结果
+fn alignto(size: usize, align: usize) -> usize {
+    (size + align - 1) / align * align
+}
+
+impl Heap {
+    /// Create an empty heap
+    /// Currently, [`BestFitStrategy`] is used as the default allocator strategy,
+    pub const fn new() -> Self {
+        Heap {
+            free_list: LinkedList::new(),
+            user: 0,
+            allocated: 0,
+            total: 0,
+
+            strategy: BasicAllocatorStrategy::BestFitStrategy,
+            begin_addr: 0,
+            end_addr: 0,
+
+            kernel_begin: Vec::new(),
+            kernel_end: Vec::new(),
+        }
+    }
+
+    ///init
+    pub fn init(&mut self, heap_start_addr: usize, heap_size: usize) {
+        assert!(
+            heap_start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size % 4096 == 0 && heap_size > 0,
+            "Add Heap size should be a multiple of page size"
+        );
+        self.free_list = LinkedList::new();
+        self.kernel_begin = Vec::new();
+        self.kernel_end = Vec::new();
+        self.begin_addr = heap_start_addr;
+        self.end_addr = heap_start_addr + heap_size;
+        self.push_mem_block(heap_start_addr, heap_size);
+        self.total = heap_size;
+    }
+
+    ///set strategy
+    pub fn set_strategy(&mut self, strategy: &str) {
+        match strategy {
+            "first_fit" => {
+                self.strategy = BasicAllocatorStrategy::FirstFitStrategy;
+            }
+            "best_fit" => {
+                self.strategy = BasicAllocatorStrategy::BestFitStrategy;
+            }
+            "worst_fit" => {
+                self.strategy = BasicAllocatorStrategy::WorstFitStrategy;
+            }
+            _ => {
+                panic!("unknown basic alloc strategy!");
+            }
+        }
+    }
+
+    /// Adds memory to the heap. The start address must be valid
+    /// and the memory in the `[mem_start_addr, mem_start_addr + heap_size)` range must not be used for
+    /// anything else.
+    /// In case of linked list allocator the memory can only be extended.
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub fn add_memory(&mut self, start_addr: usize, heap_size: usize) {
+        if start_addr != self.end_addr {
+            self.kernel_begin.push(self.end_addr);
+            self.kernel_end.push(start_addr);
+        }
+        assert!(
+            start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size % 4096 == 0 && heap_size > 0,
+            "Add Heap size should be a multiple of page size"
+        );
+        self.end_addr = start_addr + heap_size;
+        self.push_mem_block(start_addr, heap_size);
+        self.total += heap_size;
+    }
+
+    /// fitst fit strategy
+    pub fn first_fit(&mut self, size: usize, align: usize) -> Option<*mut MemBlockHead> {
+        let mut block = self.free_list.head;
+        while !block.is_null() {
+            unsafe {
+                let addr = block as usize;
+                let bsize = (*block).size();
+                if addr + bsize >= get_aligned(addr, align) + size + size_of::<usize>() {
+                    return Some(block);
+                }
+                block = (*block).nxt;
+            }
+        }
+        None
+    }
+
+    /// best fit strategy
+    pub fn best_fit(&mut self, size: usize, align: usize) -> Option<*mut MemBlockHead> {
+        let mut res: Option<*mut MemBlockHead> = None;
+        let mut now_size: usize = 0;
+        let mut block = self.free_list.head;
+        while !block.is_null() {
+            unsafe {
+                let addr = block as usize;
+                let bsize = (*block).size();
+                let addr_left = addr + bsize - get_aligned(addr, align) - size - size_of::<usize>();
+                if addr + bsize >= get_aligned(addr, align) + size + size_of::<usize>()
+                    && (res.is_none() || addr_left < now_size)
+                {
+                    now_size = addr_left;
+                    res = Some(block);
+                }
+                block = (*block).nxt;
+            }
+        }
+        res
+    }
+
+    /// worst fit strategy
+    pub fn worst_fit(&mut self, size: usize, align: usize) -> Option<*mut MemBlockHead> {
+        let mut res: Option<*mut MemBlockHead> = None;
+        let mut now_size: usize = 0;
+        let mut block = self.free_list.head;
+        while !block.is_null() {
+            unsafe {
+                let addr = block as usize;
+                let bsize = (*block).size();
+                let addr_left = addr + bsize - get_aligned(addr, align) - size - size_of::<usize>();
+                if addr + bsize >= get_aligned(addr, align) + size + size_of::<usize>()
+                    && (res.is_none() || addr_left > now_size)
+                {
+                    now_size = addr_left;
+                    res = Some(block);
+                }
+                block = (*block).nxt;
+            }
+        }
+        res
+    }
+
+    /// Allocates a chunk of the given size with the given alignment. Returns a pointer to the
+    /// beginning of that chunk if it was successful. Else it returns `Err`.
+    pub fn allocate(&mut self, layout: Layout) -> Result<usize, AllocError> {
+        // The minimum allocate memory is 16 Bytes
+        let size = alignto(
+            max(layout.size(), max(layout.align(), 2 * size_of::<usize>())),
+            size_of::<usize>(),
+        );
+
+        unsafe {
+            let block = match self.strategy {
+                BasicAllocatorStrategy::FirstFitStrategy => self.first_fit(size, layout.align()),
+                BasicAllocatorStrategy::BestFitStrategy => self.best_fit(size, layout.align()),
+                BasicAllocatorStrategy::WorstFitStrategy => self.worst_fit(size, layout.align()),
+            };
+            match block {
+                Some(inner) => {
+                    let res = inner as usize;
+                    let block_size = (*inner).size();
+                    let addr = get_aligned(res, layout.align());
+                    let addr_left = res + block_size - addr - size - size_of::<usize>();
+                    if addr_left > 4 * size_of::<usize>() {
+                        (*inner).set_size(block_size - addr_left);
+                        (*inner).set_used(true);
+                        self.free_list.del(inner);
+                        self.user += layout.size();
+                        self.allocated += block_size - addr_left;
+                        self.free_list.push(
+                            (addr + size + size_of::<usize>()) as *mut MemBlockHead,
+                            addr_left,
+                        );
+                    } else {
+                        (*inner).set_used(true);
+                        self.user += layout.size();
+                        self.allocated += block_size;
+                        self.free_list.del(inner);
+                    }
+
+                    Ok(addr)
+                }
+                None => Err(AllocError),
+            }
+        }
+    }
+
+    /// push a memblock to linked list
+    /// before push,need to check merge
+    pub fn push_mem_block(&mut self, addr: usize, size: usize) {
+        let mut now_addr = addr;
+        let mut now_size = size;
+
+        if now_addr + now_size != self.end_addr
+            && !self.kernel_begin.contains(&(now_addr + now_size))
+        {
+            let nxt_block = (now_addr + now_size) as *mut MemBlockHead;
+            unsafe {
+                if !(*nxt_block).used() {
+                    now_size += (*nxt_block).size();
+                    self.free_list.del(nxt_block);
+                }
+            }
+        }
+
+        if now_addr != self.begin_addr && !self.kernel_end.contains(&(now_addr)) {
+            unsafe {
+                let pre_block =
+                    (*((now_addr - size_of::<usize>()) as *mut MemBlockFoot)).get_head();
+                if !(*pre_block).used() {
+                    now_addr = pre_block as usize;
+                    now_size += (*pre_block).size();
+                    self.free_list.del(pre_block);
+                }
+            }
+        }
+        unsafe {
+            self.free_list.push(now_addr as *mut MemBlockHead, now_size);
+        }
+    }
+
+    /// Frees the given allocation. `ptr` must be a pointer returned
+    /// by a call to the `allocate` function with identical size and alignment. Undefined
+    /// behavior may occur for invalid arguments, thus this function is unsafe.
+    ///
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub fn deallocate(&mut self, ptr: usize, layout: Layout) {
+        let size = alignto(
+            max(layout.size(), max(layout.align(), 2 * size_of::<usize>())),
+            size_of::<usize>(),
+        );
+        let block = (ptr - size_of::<usize>()) as *mut MemBlockHead;
+        unsafe {
+            let block_size = (*block).size();
+            assert!(block_size >= size, "Dealloc error");
+            self.user -= layout.size();
+            self.allocated -= block_size;
+            self.push_mem_block(block as usize, block_size);
+        }
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        self.total
+    }
+
+    pub fn used_bytes(&self) -> usize {
+        self.user
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        self.total - self.allocated
+    }
+}

--- a/crates/basic_allocator/src/linked_list.rs
+++ b/crates/basic_allocator/src/linked_list.rs
@@ -1,0 +1,168 @@
+//! Provide the intrusive LinkedList for basic allocator
+#![allow(dead_code)]
+
+use core::mem::size_of;
+use core::ptr;
+
+/// An intrusive linked list
+///
+/// A clean room implementation of the one used in CS140e 2018 Winter
+///
+/// Thanks Sergio Benitez for his excellent work,
+/// See [CS140e](https://cs140e.sergio.bz/) for more information
+
+pub struct MemBlockHead {
+    pub size: usize, //最低位标记是否使用过
+    pub pre: *mut MemBlockHead,
+    pub nxt: *mut MemBlockHead,
+}
+
+impl MemBlockHead {
+    ///获取这一块的地址
+    pub fn addr(&mut self) -> usize {
+        self as *mut MemBlockHead as usize
+    }
+    //获取这一块的大小
+    pub fn size(&self) -> usize {
+        self.size >> 1
+    }
+    ///获取这一块的使用位
+    pub fn used(&self) -> bool {
+        (self.size & 1) == 1
+    }
+
+    ///重设这一块的大小，别忘了同时修改foot的信息
+    ///在同时需要修改size和used的时候，一定注意要先改size再改used
+    pub fn set_size(&mut self, size: usize) {
+        self.size = (size << 1) | (self.size & 1);
+        unsafe { (*(self.get_foot())).set_size(size) };
+    }
+    ///重设这一块的使用位，别忘了同时修改foot的信息
+    pub fn set_used(&mut self, used: bool) {
+        if used {
+            self.size |= 1_usize;
+        } else {
+            self.size &= !1_usize;
+        }
+        unsafe {
+            (*(self.get_foot())).set_used(used);
+        }
+    }
+
+    ///获取这一块的foot
+    pub fn get_foot(&mut self) -> *mut MemBlockFoot {
+        (self.addr() + self.size() - size_of::<usize>()) as *mut MemBlockFoot
+    }
+    ///获取下一块的head
+    pub fn get_nxt_block(&mut self) -> *mut MemBlockHead {
+        (self.addr() + self.size()) as *mut MemBlockHead
+    }
+    ///获取上一块的head
+    pub fn get_pre_block(&mut self) -> *mut MemBlockHead {
+        unsafe { (*((self.addr() - size_of::<usize>()) as *mut MemBlockFoot)).get_head() }
+    }
+}
+
+pub struct MemBlockFoot {
+    pub size: usize, //最低位标记是否使用过
+}
+
+impl MemBlockFoot {
+    ///获取这一块的地址
+    pub fn addr(&mut self) -> usize {
+        (self as *mut MemBlockFoot as usize) - self.size() + size_of::<usize>()
+    }
+    //获取这一块的大小
+    pub fn size(&self) -> usize {
+        self.size >> 1
+    }
+    ///获取这一块的使用位
+    pub fn used(&self) -> bool {
+        (self.size & 1) == 1
+    }
+    ///重设这一块的大小
+    pub fn set_size(&mut self, size: usize) {
+        self.size = (size << 1) | (self.size & 1);
+    }
+    ///重设这一块的使用位
+    pub fn set_used(&mut self, used: bool) {
+        if used {
+            self.size |= 1_usize;
+        } else {
+            self.size &= !1_usize;
+        }
+    }
+    ///获取这一块的head
+    pub fn get_head(&mut self) -> *mut MemBlockHead {
+        self.addr() as *mut MemBlockHead
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct LinkedList {
+    pub head: *mut MemBlockHead,
+}
+
+unsafe impl Send for LinkedList {}
+
+impl LinkedList {
+    /// Create a new LinkedList
+    pub const fn new() -> LinkedList {
+        LinkedList {
+            head: ptr::null_mut(),
+        }
+    }
+
+    /// Return `true` if the list is empty
+    pub fn is_empty(&self) -> bool {
+        self.head.is_null()
+    }
+
+    /// Push `item` to the front of the list
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn push(&mut self, item: *mut MemBlockHead, size: usize) {
+        (*item).nxt = self.head;
+        (*item).pre = ptr::null_mut();
+        (*item).set_size(size);
+        (*item).set_used(false);
+        if !self.is_empty() {
+            (*self.head).pre = item;
+        }
+        self.head = item;
+    }
+
+    /// Try to remove the first item in the list
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn pop(&mut self) -> Option<*mut MemBlockHead> {
+        match self.is_empty() {
+            true => None,
+            false => {
+                // Advance head pointer
+                let item = self.head;
+                self.head = (*item).nxt;
+                (*self.head).pre = ptr::null_mut();
+                Some(item)
+            }
+        }
+    }
+
+    /// Try to remove an item in the list
+    /// ensure this item is in the list now
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub unsafe fn del(&mut self, item: *mut MemBlockHead) {
+        if self.head == item {
+            self.head = (*item).nxt;
+        } else {
+            (*(*item).pre).nxt = (*item).nxt;
+        }
+        if !(*item).nxt.is_null() {
+            (*(*item).nxt).pre = (*item).pre;
+        }
+    }
+}

--- a/crates/tlsf_allocator/Cargo.toml
+++ b/crates/tlsf_allocator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tlsf_allocator"
+version = "0.1.0"
+edition = "2021"
+authors = ["Yibin Zhang <zhangyb20@mails.tsinghua.edu.cn>"]
+
+[dependencies]
+log = "0.4"

--- a/crates/tlsf_allocator/src/data.rs
+++ b/crates/tlsf_allocator/src/data.rs
@@ -1,0 +1,430 @@
+use core::mem::size_of;
+
+/// the address pointer
+#[derive(Clone, Copy)]
+pub struct AddrPointer {
+    pub addr: usize,
+}
+
+impl AddrPointer {
+    pub fn get_block_header(&self) -> &BlockHeader {
+        unsafe { &(*(self.addr as *const BlockHeader)) }
+    }
+    pub fn get_mut_block_header(&mut self) -> &mut BlockHeader {
+        unsafe { &mut (*(self.addr as *mut BlockHeader)) }
+    }
+    pub fn get_controller(&self) -> &Controller {
+        unsafe { &(*(self.addr as *const Controller)) }
+    }
+    pub fn get_mut_controller(&mut self) -> &mut Controller {
+        unsafe { &mut (*(self.addr as *mut Controller)) }
+    }
+
+    /// BlockHeader的功能
+    pub fn get_prev_phy_pointer(&self) -> AddrPointer {
+        return self.get_block_header().prev_phy;
+    }
+    pub fn set_prev_phy_pointer(&mut self, prev_phy: AddrPointer) {
+        self.get_mut_block_header().prev_phy = prev_phy;
+    }
+    pub fn get_prev_free_pointer(&self) -> AddrPointer {
+        return self.get_block_header().prev_free;
+    }
+    pub fn set_prev_free_pointer(&mut self, prev_free: AddrPointer) {
+        self.get_mut_block_header().prev_free = prev_free;
+    }
+    pub fn get_next_free_pointer(&self) -> AddrPointer {
+        return self.get_block_header().next_free;
+    }
+    pub fn set_next_free_pointer(&mut self, next_free: AddrPointer) {
+        self.get_mut_block_header().next_free = next_free;
+    }
+
+    pub fn get_now_free(&self) -> bool {
+        return self.get_block_header().get_now_free();
+    }
+    pub fn get_prev_free(&self) -> bool {
+        return self.get_block_header().get_prev_free();
+    }
+    pub fn set_now_free(&mut self) {
+        self.get_mut_block_header().set_now_free();
+    }
+    pub fn set_now_used(&mut self) {
+        self.get_mut_block_header().set_now_used();
+    }
+    pub fn set_prev_free(&mut self) {
+        self.get_mut_block_header().set_prev_free();
+    }
+    pub fn set_prev_used(&mut self) {
+        self.get_mut_block_header().set_prev_used();
+    }
+
+    ///设置以及判断一个块是否为null
+    pub fn set_null(&mut self) {
+        self.get_mut_block_header().set_null();
+    }
+    pub fn is_null(&self) -> bool {
+        return self.get_block_header().is_null();
+    }
+
+    pub fn get_size(&self) -> usize {
+        return self.get_block_header().get_size();
+    }
+    pub fn set_size(&mut self, size: usize) {
+        self.get_mut_block_header().set_size(size);
+    }
+
+    ///设置这个块为used，除了要设置自己还要设置物理上的下一个块
+    pub fn set_used(&mut self) {
+        self.get_mut_block_header().set_used();
+    }
+    ///设置这个块为free，除了要设置自己还要设置物理上的下一个块
+    pub fn set_free(&mut self) {
+        self.get_mut_block_header().set_free();
+    }
+
+    ///Controller的功能
+    pub fn init_controller(&mut self, addr: usize, size: usize) {
+        self.get_mut_controller().init(addr, size);
+    }
+    pub fn add_memory(&mut self, addr: usize, size: usize) {
+        self.get_mut_controller().add_memory(addr, size);
+    }
+    pub fn add_into_list(&mut self, block: AddrPointer) {
+        self.get_mut_controller().add_into_list(block);
+    }
+    pub fn del_into_list(&mut self, block: AddrPointer) {
+        self.get_mut_controller().del_into_list(block);
+    }
+    pub fn get_first_block(&mut self, fl: usize, sl: usize) -> AddrPointer {
+        self.get_mut_controller().get_first_block(fl, sl)
+    }
+    pub fn find_block(&mut self, size: usize) -> AddrPointer {
+        self.get_mut_controller().find_block(size)
+    }
+}
+
+pub fn get_addr_pointer(addr: usize) -> AddrPointer {
+    AddrPointer { addr }
+}
+
+/// tlsf块头结构
+pub struct BlockHeader {
+    pub prev_phy: AddrPointer, //物理上的上一个块
+    pub size: usize, //“净”块大小，一定是8对齐的，所以末两位可以标记物理上的这个块/上一个块是否free
+    //以上16个字节是分配出去的块要占的头部大小
+    pub prev_free: AddrPointer, //free链表的上一个块
+    pub next_free: AddrPointer, //free链表的下一个块
+}
+
+impl BlockHeader {
+    pub fn get_now_free(&self) -> bool {
+        (self.size & 1) == 1
+    }
+    pub fn get_prev_free(&self) -> bool {
+        (self.size & 2) == 2
+    }
+    pub fn set_now_free(&mut self) {
+        self.size |= 1;
+    }
+    pub fn set_now_used(&mut self) {
+        self.size &= !1_usize;
+    }
+    pub fn set_prev_free(&mut self) {
+        self.size |= 2;
+    }
+    pub fn set_prev_used(&mut self) {
+        self.size &= !2_usize;
+    }
+
+    pub fn get_my_pointer(&self) -> AddrPointer {
+        AddrPointer {
+            addr: self as *const BlockHeader as usize,
+        }
+    }
+
+    ///设置以及判断一个块是否为null
+    pub fn set_null(&mut self) {
+        self.size = 0;
+        let my_pointer = self.get_my_pointer();
+        self.prev_free = my_pointer;
+        self.next_free = my_pointer;
+        self.prev_phy = my_pointer;
+    }
+    pub fn is_null(&self) -> bool {
+        self.size < 4
+    }
+
+    pub fn get_size(&self) -> usize {
+        self.size & (!3_usize)
+    }
+    pub fn set_size(&mut self, size: usize) {
+        self.size = size | (self.size & 3);
+    }
+
+    ///设置这个块为used，除了要设置自己还要设置物理上的下一个块
+    pub fn set_used(&mut self) {
+        let mut next = get_block_phy_next(self.get_my_pointer());
+        self.set_now_used();
+        if !(next.is_null()) {
+            next.set_prev_used();
+        }
+    }
+    ///设置这个块为free，除了要设置自己还要设置物理上的下一个块
+    pub fn set_free(&mut self) {
+        let mut next = get_block_phy_next(self.get_my_pointer());
+        self.set_now_free();
+        if !(next.is_null()) {
+            next.set_prev_free();
+        }
+    }
+}
+
+///获取一个块物理上的下一个块
+pub fn get_block_phy_next(block: AddrPointer) -> AddrPointer {
+    AddrPointer {
+        addr: (block.addr + block.get_size() + 2 * size_of::<usize>()),
+    }
+}
+///获取一个块物理上的上一个块
+pub fn get_block_phy_prev(block: AddrPointer) -> AddrPointer {
+    block.get_prev_phy_pointer()
+}
+
+const FL_INDEX_COUNT: usize = 28;
+const SL_INDEX_COUNT: usize = 32;
+const FL_INDEX_SHIFT: usize = 8;
+const SMALL_BLOCK_SIZE: usize = 256;
+//地址的后3位一定是0
+//对于不足256的块，直接8对齐
+//对于超过256的块，最高位表示一级链表，接下来5位表示二级链表
+
+/// tlsf 控制头结构
+pub struct Controller {
+    pub block_null: BlockHeader, //空块
+
+    /* Bitmaps for free lists. */
+    pub fl_bitmap: usize, //一级链表的bitmap，标记每个一级链表是否非空
+    pub sl_bitmap: [usize; FL_INDEX_COUNT], //二级链表的bitmap，标记每个二级链表是否非空
+
+    /* Head of free lists. */
+    pub blocks: [[AddrPointer; SL_INDEX_COUNT]; FL_INDEX_COUNT], //二级链表结构
+                                                                 //SL_INDEX_COUNT=32表示二级链表将一级链表的一个区间拆分成了32段，也就是要根据最高位后的5个二进制位来判断
+}
+
+/// lowbit
+pub fn my_lowbit(x: usize) -> usize {
+    x & ((!x) + 1)
+}
+
+/// log2
+pub fn my_log2(x: usize) -> usize {
+    let mut ans = 0;
+    let mut y = x;
+    if (y >> 32) > 0 {
+        y >>= 32;
+        ans += 32;
+    }
+    if (y >> 16) > 0 {
+        y >>= 16;
+        ans += 16;
+    }
+    if (y >> 8) > 0 {
+        y >>= 8;
+        ans += 8;
+    }
+    if (y >> 4) > 0 {
+        y >>= 4;
+        ans += 4;
+    }
+    if (y >> 2) > 0 {
+        y >>= 2;
+        ans += 2;
+    }
+    if (y >> 1) > 0 {
+        ans += 1;
+    }
+    ans
+}
+
+/// log lowbit
+pub fn my_log_lowbit(x: usize) -> usize {
+    my_log2(my_lowbit(x))
+}
+
+/// 获取一个size对齐到align的结果
+pub fn alignto(size: usize, align: usize) -> usize {
+    (size + align - 1) / align * align
+}
+
+pub struct ListIndex {
+    pub fl: usize,
+    pub sl: usize,
+    pub size: usize,
+}
+/// 获取一个块对应的一级和二级链表
+pub fn get_fl_and_sl(size: usize) -> ListIndex {
+    if size < SMALL_BLOCK_SIZE {
+        //小块
+        ListIndex {
+            fl: 0,
+            sl: size >> 3,
+            size,
+        }
+    } else {
+        let tmp = (my_log2(size)) - FL_INDEX_SHIFT + 1;
+        ListIndex {
+            fl: tmp,
+            sl: (size >> (tmp + 2)) & (SL_INDEX_COUNT - 1),
+            size,
+        }
+    }
+}
+
+/// 给定二级链表，求其最小块大小
+pub fn get_block_begin_size(fl: usize, sl: usize) -> usize {
+    if fl == 0 {
+        sl << 3
+    } else {
+        (1_usize << (fl + FL_INDEX_SHIFT - 1)) + (sl << (fl + 2))
+    }
+}
+
+/// 获取一个块向上对齐到一级链表的最小块大小
+pub fn get_up_size(size: usize) -> usize {
+    let mut nsize = size;
+    if size < SMALL_BLOCK_SIZE {
+        //小块
+        alignto(size, 8)
+    } else {
+        let linkidx = get_fl_and_sl(size);
+        let fl = linkidx.fl;
+        let sl = linkidx.sl;
+        if get_block_begin_size(fl, sl) != size {
+            nsize += 1_usize << (fl + 2);
+        }
+        nsize
+    }
+}
+
+/// 获取一个块向上对齐到一级链表的最小块大小，以及相应的fl和sl
+fn get_up_fl_and_sl(size: usize) -> ListIndex {
+    let nsize = get_up_size(size);
+    get_fl_and_sl(nsize)
+}
+
+impl Controller {
+    ///init
+    pub fn init(&mut self, addr: usize, size: usize) {
+        self.block_null.set_null();
+        self.fl_bitmap = 0;
+        for i in 0..FL_INDEX_COUNT {
+            self.sl_bitmap[i] = 0;
+        }
+        for i in 0..FL_INDEX_COUNT {
+            for j in 0..SL_INDEX_COUNT {
+                self.blocks[i][j] = self.block_null.get_my_pointer();
+            }
+        }
+        // 把剩余的空间用于添加内存
+        let offset = alignto(size_of::<Controller>(), 8);
+        self.add_memory(addr + offset, size - offset);
+    }
+
+    /// add memory
+    /// addr和size都应该是8对齐的
+    pub fn add_memory(&mut self, addr: usize, size: usize) {
+        //第一个块
+        let mut first = get_addr_pointer(addr);
+        let null_pointer = self.block_null.get_my_pointer();
+        first.set_prev_phy_pointer(null_pointer);
+        first.set_next_free_pointer(null_pointer);
+        first.set_prev_free_pointer(null_pointer);
+        //set_size传入是这个块的“净大小”，要扣去头部的16个字节和尾部多一个null块的32字节
+        first.set_now_free();
+        first.set_prev_used();
+        first.set_size(size - 6 * size_of::<usize>());
+        //把第一个块插入到链表中
+        self.add_into_list(first);
+        //尾部再加一个null块，占32字节
+        let mut tail = get_addr_pointer(addr + size - 4 * size_of::<usize>());
+        tail.set_null();
+    }
+
+    /// 把一个块插入free list中，需要确保这个块是空闲的
+    pub fn add_into_list(&mut self, mut block: AddrPointer) {
+        let size = block.get_size();
+        let listidx = get_fl_and_sl(size);
+        let fl = listidx.fl;
+        let sl = listidx.sl;
+        //获取了这个块的二级链表之后，插入
+        let mut head = self.blocks[fl][sl];
+        block.set_next_free_pointer(head);
+        block.set_prev_free_pointer(self.block_null.get_my_pointer());
+        if !(head.is_null()) {
+            head.set_prev_free_pointer(block);
+        }
+        // 别忘了修改链表头以及修改bitmap
+        self.blocks[fl][sl] = block;
+        self.sl_bitmap[fl] |= 1_usize << sl;
+        self.fl_bitmap |= 1_usize << fl;
+    }
+
+    ///把一个块从list中删除，需要确保它之前确实在free list里
+    pub fn del_into_list(&mut self, block: AddrPointer) {
+        let size = block.get_size();
+        let listidx = get_fl_and_sl(size);
+        let fl = listidx.fl;
+        let sl = listidx.sl;
+        let mut prev = block.get_prev_free_pointer();
+        let mut next = block.get_next_free_pointer();
+        if !(prev.is_null()) {
+            prev.set_next_free_pointer(next);
+        } else {
+            //要更新链表头
+            self.blocks[fl][sl] = next;
+            if next.is_null() {
+                //要更新bitmap
+                self.sl_bitmap[fl] &= !(1_usize << sl);
+                if self.sl_bitmap[fl] == 0 {
+                    self.fl_bitmap &= !(1_usize << fl);
+                }
+            }
+        }
+        if !(next.is_null()) {
+            next.set_prev_free_pointer(prev);
+        }
+    }
+
+    /// 获取某一个链表的第一个块，并从链表中删除
+    pub fn get_first_block(&mut self, fl: usize, sl: usize) -> AddrPointer {
+        if self.blocks[fl][sl].is_null() {
+            return self.block_null.get_my_pointer();
+        }
+        let block = self.blocks[fl][sl];
+        self.del_into_list(block);
+        block
+    }
+
+    /// 给定大小，获取一个能用的块，并从链表中删除
+    pub fn find_block(&mut self, size: usize) -> AddrPointer {
+        let listidx = get_up_fl_and_sl(size);
+        let mut fl = listidx.fl;
+        let mut sl = listidx.sl;
+        let psl = !((1_usize << sl) - 1); //第二级链表的掩码
+        if (psl & self.sl_bitmap[fl]) != 0 {
+            //可以在当前一级链表里找到块
+            sl = my_log_lowbit(psl & self.sl_bitmap[fl]);
+        } else {
+            let pfl = !((1_usize << (fl + 1)) - 1); //第一级链表的掩码
+            if (pfl & self.fl_bitmap) != 0 {
+                //可以在更高的一级链表里找到块
+                fl = my_log_lowbit(pfl & self.fl_bitmap);
+                sl = my_log_lowbit(self.sl_bitmap[fl]);
+            } else {
+                return self.block_null.get_my_pointer();
+            }
+        }
+        self.get_first_block(fl, sl)
+    }
+}

--- a/crates/tlsf_allocator/src/lib.rs
+++ b/crates/tlsf_allocator/src/lib.rs
@@ -1,0 +1,241 @@
+#![feature(allocator_api)]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::alloc::{AllocError, Layout};
+use core::cmp::max;
+use core::mem::size_of;
+
+mod data;
+use data::*;
+
+pub struct Heap {
+    head: AddrPointer,
+    total_mem: usize, // 总共占用内存
+    used_mem: usize,  // 已经分配出去的内存
+    avail_mem: usize, // 实际可用的内存
+}
+
+unsafe impl Send for Heap {}
+
+impl Heap {
+    /// Create an empty heap
+    pub const fn new() -> Self {
+        Heap {
+            head: AddrPointer { addr: 0 },
+            total_mem: 0,
+            used_mem: 0,
+            avail_mem: 0,
+        }
+    }
+
+    ///init
+    pub fn init(&mut self, heap_start_addr: usize, heap_size: usize) {
+        assert!(
+            heap_start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size % 4096 == 0 && heap_size > 0,
+            "Add Heap size should be a multiple of page size"
+        );
+        self.head = get_addr_pointer(heap_start_addr);
+        self.head.init_controller(heap_start_addr, heap_size);
+        self.total_mem = heap_size;
+        self.used_mem = 0;
+        self.avail_mem = heap_size - alignto(size_of::<Controller>(), 8) - 6 * size_of::<usize>();
+    }
+
+    /// Adds memory to the heap. The start address must be valid
+    /// and the memory in the `[mem_start_addr, mem_start_addr + heap_size)` range must not be used for
+    /// anything else.
+    /// In case of linked list allocator the memory can only be extended.
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub fn add_memory(&mut self, start_addr: usize, heap_size: usize) {
+        assert!(
+            start_addr % 4096 == 0,
+            "Start address should be page aligned"
+        );
+        assert!(
+            heap_size % 4096 == 0 && heap_size > 0,
+            "Add Heap size should be a multiple of page size"
+        );
+        self.head.add_memory(start_addr, heap_size);
+        self.total_mem += heap_size;
+        self.avail_mem += heap_size - 6 * size_of::<usize>();
+    }
+
+    /// Allocates a chunk of the given size with the given alignment. Returns a pointer to the
+    /// beginning of that chunk if it was successful. Else it returns `Err`.
+    pub fn allocate(&mut self, layout: Layout) -> Result<usize, AllocError> {
+        //单次分配最小16字节
+        assert!(
+            my_lowbit(layout.align()) == layout.align(),
+            "align should be power of 2."
+        );
+        let mut size = alignto(
+            max(layout.size(), max(layout.align(), 2 * size_of::<usize>())),
+            max(layout.align(), size_of::<usize>()),
+        );
+
+        //处理align更大的分配请求
+        if layout.align() > size_of::<usize>() {
+            size = alignto(
+                size + layout.align() + 4 * size_of::<usize>(),
+                layout.align(),
+            );
+            //给size加上足够的大小，使得切出来的块的头部可以分裂成一个新的块
+        }
+
+        let mut block = self.head.find_block(size);
+        if !(block.is_null()) {
+            let mut nsize = block.get_size();
+            assert!(nsize >= size, "Alloc error.");
+            let mut addr = block.addr + 2 * size_of::<usize>();
+
+            //处理align更大的分配请求
+            if layout.align() > size_of::<usize>() {
+                let mut new_addr = alignto(addr, layout.align());
+                if new_addr != addr {
+                    //要切出头部单独组成一块
+                    while new_addr - block.addr < 6 * size_of::<usize>() {
+                        //切出的头部不足以构成一个新块，于是把头部再扩大一个align
+                        //因为new_addr是实际分配出去的起始地址，因此到原来块的开头至少要48个字节才能让中间再拆出一个块
+                        new_addr += layout.align();
+                    }
+                    //创造一个新的块pre_block
+                    let mut pre_block = block;
+                    let mut nxt_block = get_block_phy_next(block);
+                    block = get_addr_pointer(new_addr - 2 * size_of::<usize>());
+                    //设置物理上的前一块
+                    block.set_prev_phy_pointer(pre_block);
+                    if !(nxt_block.is_null()) {
+                        nxt_block.set_prev_phy_pointer(block);
+                    }
+                    //设置块大小
+                    let pre_size = block.addr - addr;
+                    nsize -= pre_size + 2 * size_of::<usize>();
+                    pre_block.set_size(pre_size);
+                    block.set_size(nsize);
+                    //设置使用状态
+                    pre_block.set_free();
+                    //插回到链表中去
+                    self.head.add_into_list(pre_block);
+                    self.avail_mem -= 2 * size_of::<usize>();
+                    addr = new_addr;
+                }
+
+                //把size改回来，这里的size就是实际分配出去的大小了
+                size = alignto(
+                    max(layout.size(), max(layout.align(), 2 * size_of::<usize>())),
+                    layout.align(),
+                );
+                assert!(nsize >= size, "Alloc error.");
+            }
+            block.set_used();
+
+            //把块的尾部拆分之后扔回去
+            if nsize >= size + 4 * size_of::<usize>() {
+                //最小32字节才能切出一个新块
+                //新块
+                let mut new_block = get_addr_pointer(addr + size);
+                new_block.set_prev_phy_pointer(block);
+                //原块的下一个块
+                let mut nxt_block = get_block_phy_next(block);
+                if !(nxt_block.is_null()) {
+                    nxt_block.set_prev_phy_pointer(new_block);
+                }
+
+                //设置块大小
+                block.set_size(size);
+                new_block.set_size(nsize - size - 2 * size_of::<usize>()); //别忘了减去新块的头部大小
+
+                //设置使用状态
+                block.set_used();
+                new_block.set_free();
+
+                //插回到链表中去
+                self.head.add_into_list(new_block);
+                self.avail_mem -= 2 * size_of::<usize>();
+            }
+            self.used_mem += layout.size();
+            self.avail_mem -= block.get_size();
+            Ok(addr)
+        } else {
+            Err(AllocError)
+        }
+    }
+
+    /// 把这个块和物理上后一个块合并，要求两个块都是空闲的，且已经从链表中摘下来了
+    pub fn merge_block(&self, mut block: AddrPointer) {
+        let nxt = get_block_phy_next(block);
+        //改block的size
+        let size = block.get_size();
+        let nsize = nxt.get_size();
+        block.set_size(size + nsize + 2 * size_of::<usize>());
+        //改block.nxt.nxt的pre指针为block自己
+        let mut nnxt = get_block_phy_next(nxt);
+        if !(nnxt.is_null()) {
+            nnxt.set_prev_phy_pointer(block);
+        }
+    }
+
+    /// Frees the given allocation. `ptr` must be a pointer returned
+    /// by a call to the `allocate` function with identical size and alignment. Undefined
+    /// behavior may occur for invalid arguments, thus this function is unsafe.
+    ///
+    /// # Safety
+    /// This function is unsafe because it can cause undefined behavior if the
+    /// given address is invalid.
+    pub fn deallocate(&mut self, ptr: usize, layout: Layout) {
+        assert!(
+            my_lowbit(layout.align()) == layout.align(),
+            "align should be power of 2."
+        );
+        let size = alignto(
+            max(layout.size(), max(layout.align(), 2 * size_of::<usize>())),
+            max(layout.align(), size_of::<usize>()),
+        );
+        let mut block = get_addr_pointer(ptr - 2 * size_of::<usize>());
+        let block_size = block.get_size();
+        assert!(block_size >= size && !block.get_now_free(), "Dealloc error");
+        block.set_free();
+        self.used_mem -= layout.size();
+        self.avail_mem += block_size;
+
+        //把这个块与前后的块合并
+        let mut nblock = block;
+        let pre = get_block_phy_prev(block);
+        let nxt = get_block_phy_next(block);
+        if !(nxt.is_null()) && nxt.get_now_free() {
+            //如果物理上的下一个块不是null且是空闲的，就合并
+            self.head.del_into_list(nxt);
+            self.merge_block(nblock);
+            self.avail_mem += 2 * size_of::<usize>();
+        }
+        if !pre.is_null() && pre.get_now_free() {
+            //如果物理上的上一个块不是null且是空闲的，就合并
+            self.head.del_into_list(pre);
+            self.merge_block(pre);
+            nblock = pre;
+            self.avail_mem += 2 * size_of::<usize>();
+        }
+        self.head.add_into_list(nblock);
+    }
+
+    /// 查询内存使用情况
+    pub fn total_bytes(&self) -> usize {
+        self.total_mem
+    }
+
+    pub fn used_bytes(&self) -> usize {
+        self.used_mem
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        self.avail_mem
+    }
+}

--- a/crates/tlsf_c_allocator/Cargo.toml
+++ b/crates/tlsf_c_allocator/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tlsf_c_allocator"
+version = "0.1.0"
+edition = "2021"
+authors = ["Yibin Zhang <zhangyb20@mails.tsinghua.edu.cn>"]
+build = "./build.rs"
+
+[dependencies]
+log = "0.4"
+[dev-dependencies]
+libc = "0.2.0"

--- a/crates/tlsf_c_allocator/build.rs
+++ b/crates/tlsf_c_allocator/build.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+
+    //to run user mode test, change the mode to "cc"
+    //Command::new("cc")
+    //Command::new("riscv64-linux-gnu-gcc")
+    Command::new("riscv64-linux-musl-gcc")
+        .args(["src/tlsf.c", "-O3", "-c", "-fPIC", "-o"])
+        .arg(&format!("{}/tlsf.o", out_dir))
+        .status()
+        .unwrap();
+
+    //to run user mode test, change the mode to "ar"
+    //Command::new("ar")
+    //Command::new("riscv64-linux-gnu-ar")
+    Command::new("riscv64-linux-musl-ar")
+        .args(["crus", "libtlsf.a", "tlsf.o"])
+        .current_dir(Path::new(&out_dir))
+        .status()
+        .unwrap();
+
+    println!("cargo:rustc-link-search=native={}", out_dir);
+    println!("cargo:rustc-link-lib=static=tlsf");
+}

--- a/crates/tlsf_c_allocator/src/lib.rs
+++ b/crates/tlsf_c_allocator/src/lib.rs
@@ -1,0 +1,97 @@
+//! TLSF_C memory allocation.
+//!
+#![feature(allocator_api)]
+#![no_std]
+
+extern crate alloc;
+use alloc::alloc::AllocError;
+
+use core::ffi::c_ulonglong;
+
+#[link(name = "tlsf")]
+extern "C" {
+    pub fn tlsf_create_with_pool(mem: c_ulonglong, bytes: c_ulonglong) -> c_ulonglong;
+    pub fn tlsf_add_pool(tlsf: c_ulonglong, mem: c_ulonglong, bytes: c_ulonglong) -> c_ulonglong;
+
+    pub fn tlsf_malloc(tlsf: c_ulonglong, bytes: c_ulonglong) -> c_ulonglong; //申请一段内存
+    pub fn tlsf_memalign(tlsf: c_ulonglong, align: c_ulonglong, bytes: c_ulonglong) -> c_ulonglong; //申请一段内存，要求对齐到align
+    pub fn tlsf_free(tlsf: c_ulonglong, ptr: c_ulonglong); //回收
+}
+
+/// the structure in rust code
+pub struct Heap {
+    inner: Option<c_ulonglong>,
+}
+
+impl Heap {
+    pub const fn new() -> Self {
+        Self { inner: None }
+    }
+    pub fn inner_mut(&mut self) -> &mut c_ulonglong {
+        self.inner.as_mut().unwrap()
+    }
+
+    pub fn inner(&self) -> &c_ulonglong {
+        self.inner.as_ref().unwrap()
+    }
+
+    pub fn init(&mut self, start: usize, size: usize) {
+        unsafe {
+            self.inner = Some(
+                tlsf_create_with_pool(start as c_ulonglong, size as c_ulonglong) as c_ulonglong,
+            );
+        }
+    }
+
+    pub fn add_memory(&mut self, start: usize, size: usize) {
+        unsafe {
+            tlsf_add_pool(
+                *self.inner() as c_ulonglong,
+                start as c_ulonglong,
+                size as c_ulonglong,
+            );
+        }
+    }
+
+    pub fn allocate(&mut self, size: usize, align_pow2: usize) -> Result<usize, AllocError> {
+        if align_pow2 <= 8 {
+            unsafe {
+                let ptr = tlsf_malloc(*self.inner() as c_ulonglong, size as c_ulonglong) as usize;
+                if ptr == 0 {
+                    return Err(AllocError);
+                }
+                Ok(ptr)
+            }
+        } else {
+            unsafe {
+                let ptr = tlsf_memalign(
+                    *self.inner() as c_ulonglong,
+                    align_pow2 as c_ulonglong,
+                    size as c_ulonglong,
+                ) as usize;
+                if ptr == 0 {
+                    return Err(AllocError);
+                }
+                Ok(ptr)
+            }
+        }
+    }
+
+    pub fn deallocate(&mut self, pos: usize, _size: usize, _align_pow2: usize) {
+        unsafe {
+            tlsf_free(*self.inner() as c_ulonglong, pos as c_ulonglong);
+        }
+    }
+
+    pub fn total_bytes(&self) -> usize {
+        0
+    }
+
+    pub fn used_bytes(&self) -> usize {
+        0
+    }
+
+    pub fn available_bytes(&self) -> usize {
+        0
+    }
+}

--- a/crates/tlsf_c_allocator/src/tlsf.c
+++ b/crates/tlsf_c_allocator/src/tlsf.c
@@ -1,0 +1,1207 @@
+#include <limits.h>
+#include <stddef.h>
+
+#include "tlsf.h"
+
+#if defined(__cplusplus)
+#define tlsf_decl inline
+#else
+#define tlsf_decl static
+#endif
+
+/*
+** Architecture-specific bit manipulation routines.
+**
+** TLSF achieves O(1) cost for malloc and free operations by limiting
+** the search for a free block to a free list of guaranteed size
+** adequate to fulfill the request, combined with efficient free list
+** queries using bitmasks and architecture-specific bit-manipulation
+** routines.
+**
+** Most modern processors provide instructions to count leading zeroes
+** in a word, find the lowest and highest set bit, etc. These
+** specific implementations will be used when available, falling back
+** to a reasonably efficient generic implementation.
+**
+** NOTE: TLSF spec relies on ffs/fls returning value 0..31.
+** ffs/fls return 1-32 by default, returning 0 for error.
+*/
+
+/*
+** Detect whether or not we are building for a 32- or 64-bit (LP/LLP)
+** architecture. There is no reliable portable method at compile-time.
+*/
+#if defined (__alpha__) || defined (__ia64__) || defined (__x86_64__) \
+	|| defined (_WIN64) || defined (__LP64__) || defined (__LLP64__)
+#define TLSF_64BIT
+#endif
+
+/*
+** gcc 3.4 and above have builtin support, specialized for architecture.
+** Some compilers masquerade as gcc; patchlevel test filters them out.
+*/
+#if defined (__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)) \
+	&& defined (__GNUC_PATCHLEVEL__)
+
+#if defined (__SNC__)
+/* SNC for Playstation 3. */
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	const unsigned int reverse = word & (~word + 1);
+	const int bit = 32 - __builtin_clz(reverse);
+	return bit - 1;
+}
+
+#else
+
+// get the lowerest bit of 1
+tlsf_decl int tlsf_ffs(unsigned int word){
+	if(!word) return 0;
+	unsigned int x = word & ((~word) + 1);
+	int ans = 0;
+	if(x >= (1 << 16)){x >>= 16;ans += 16;}
+	if(x >= (1 << 8)){x >>= 8;ans += 8;}
+	if(x >= (1 << 4)){x >>= 4;ans += 4;}
+	if(x >= (1 << 2)){x >>= 2;ans += 2;}
+	if(x >= (1 << 1)){x >>= 1;ans += 1;}
+	return ans;
+}
+
+#endif
+
+// get the hightest bit of 1
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	if(!word) return -1;
+	unsigned int x = word;
+	int ans = 0;
+	if(x >= (1 << 16)){x >>= 16;ans += 16;}
+	if(x >= (1 << 8)){x >>= 8;ans += 8;}
+	if(x >= (1 << 4)){x >>= 4;ans += 4;}
+	if(x >= (1 << 2)){x >>= 2;ans += 2;}
+	if(x >= (1 << 1)){x >>= 1;ans += 1;}
+	return ans;
+}
+
+#elif defined (_MSC_VER) && (_MSC_VER >= 1400) && (defined (_M_IX86) || defined (_M_X64))
+/* Microsoft Visual C++ support on x86/X64 architectures. */
+
+#include <intrin.h>
+
+#pragma intrinsic(_BitScanReverse)
+#pragma intrinsic(_BitScanForward)
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	unsigned long index;
+	return _BitScanReverse(&index, word) ? index : -1;
+}
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	unsigned long index;
+	return _BitScanForward(&index, word) ? index : -1;
+}
+
+#elif defined (_MSC_VER) && defined (_M_PPC)
+/* Microsoft Visual C++ support on PowerPC architectures. */
+
+#include <ppcintrinsics.h>
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	const int bit = 32 - _CountLeadingZeros(word);
+	return bit - 1;
+}
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	const unsigned int reverse = word & (~word + 1);
+	const int bit = 32 - _CountLeadingZeros(reverse);
+	return bit - 1;
+}
+
+#elif defined (__ARMCC_VERSION)
+/* RealView Compilation Tools for ARM */
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	const unsigned int reverse = word & (~word + 1);
+	const int bit = 32 - __clz(reverse);
+	return bit - 1;
+}
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	const int bit = word ? 32 - __clz(word) : 0;
+	return bit - 1;
+}
+
+#elif defined (__ghs__)
+/* Green Hills support for PowerPC */
+
+#include <ppc_ghs.h>
+
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	const unsigned int reverse = word & (~word + 1);
+	const int bit = 32 - __CLZ32(reverse);
+	return bit - 1;
+}
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	const int bit = word ? 32 - __CLZ32(word) : 0;
+	return bit - 1;
+}
+
+#else
+/* Fall back to generic implementation. */
+
+tlsf_decl int tlsf_fls_generic(unsigned int word)
+{
+	int bit = 32;
+
+	if (!word) bit -= 1;
+	if (!(word & 0xffff0000)) { word <<= 16; bit -= 16; }
+	if (!(word & 0xff000000)) { word <<= 8; bit -= 8; }
+	if (!(word & 0xf0000000)) { word <<= 4; bit -= 4; }
+	if (!(word & 0xc0000000)) { word <<= 2; bit -= 2; }
+	if (!(word & 0x80000000)) { word <<= 1; bit -= 1; }
+
+	return bit;
+}
+
+/* Implement ffs in terms of fls. */
+tlsf_decl int tlsf_ffs(unsigned int word)
+{
+	return tlsf_fls_generic(word & (~word + 1)) - 1;
+}
+
+tlsf_decl int tlsf_fls(unsigned int word)
+{
+	return tlsf_fls_generic(word) - 1;
+}
+
+#endif
+
+/* Possibly 64-bit version of tlsf_fls. */
+#if defined (TLSF_64BIT)
+tlsf_decl int tlsf_fls_sizet(size_t size)
+{
+	int high = (int)(size >> 32);
+	int bits = 0;
+	if (high)
+	{
+		bits = 32 + tlsf_fls(high);
+	}
+	else
+	{
+		bits = tlsf_fls((int)size & 0xffffffff);
+
+	}
+	return bits;
+}
+#else
+#define tlsf_fls_sizet tlsf_fls
+#endif
+
+#undef tlsf_decl
+
+/*
+** Constants.
+*/
+
+/* Public constants: may be modified. */
+enum tlsf_public
+{
+	/* log2 of number of linear subdivisions of block sizes. Larger
+	** values require more memory in the control structure. Values of
+	** 4 or 5 are typical.
+	*/
+	SL_INDEX_COUNT_LOG2 = 5,
+};
+
+/* Private constants: do not modify. */
+enum tlsf_private
+{
+#if defined (TLSF_64BIT)
+	/* All allocation sizes and addresses are aligned to 8 bytes. */
+	ALIGN_SIZE_LOG2 = 3,
+#else
+	/* All allocation sizes and addresses are aligned to 4 bytes. */
+	ALIGN_SIZE_LOG2 = 2,
+#endif
+	ALIGN_SIZE = (1 << ALIGN_SIZE_LOG2),
+
+	/*
+	** We support allocations of sizes up to (1 << FL_INDEX_MAX) bits.
+	** However, because we linearly subdivide the second-level lists, and
+	** our minimum size granularity is 4 bytes, it doesn't make sense to
+	** create first-level lists for sizes smaller than SL_INDEX_COUNT * 4,
+	** or (1 << (SL_INDEX_COUNT_LOG2 + 2)) bytes, as there we will be
+	** trying to split size ranges into more slots than we have available.
+	** Instead, we calculate the minimum threshold size, and place all
+	** blocks below that size into the 0th first-level list.
+	*/
+
+#if defined (TLSF_64BIT)
+	/*
+	** TODO: We can increase this to support larger sizes, at the expense
+	** of more overhead in the TLSF structure.
+	*/
+	FL_INDEX_MAX = 32,
+#else
+	FL_INDEX_MAX = 30,
+#endif
+	SL_INDEX_COUNT = (1 << SL_INDEX_COUNT_LOG2),
+	FL_INDEX_SHIFT = (SL_INDEX_COUNT_LOG2 + ALIGN_SIZE_LOG2),
+	FL_INDEX_COUNT = (FL_INDEX_MAX - FL_INDEX_SHIFT + 1),
+
+	SMALL_BLOCK_SIZE = (1 << FL_INDEX_SHIFT),
+};
+
+/*
+** Cast and min/max macros.
+*/
+
+#define tlsf_cast(t, exp)	((t) (exp))
+#define tlsf_min(a, b)		((a) < (b) ? (a) : (b))
+#define tlsf_max(a, b)		((a) > (b) ? (a) : (b))
+
+/*
+** Set assert macro, if it has not been provided by the user.
+*/
+#if !defined (tlsf_assert)
+#define tlsf_assert assert
+#endif
+
+/*
+** Static assertion mechanism.
+*/
+
+#define _tlsf_glue2(x, y) x ## y
+#define _tlsf_glue(x, y) _tlsf_glue2(x, y)
+#define tlsf_static_assert(exp) \
+	typedef char _tlsf_glue(static_assert, __LINE__) [(exp) ? 1 : -1]
+
+/* This code has been tested on 32- and 64-bit (LP/LLP) architectures. */
+tlsf_static_assert(sizeof(int) * CHAR_BIT == 32);
+tlsf_static_assert(sizeof(size_t) * CHAR_BIT >= 32);
+tlsf_static_assert(sizeof(size_t) * CHAR_BIT <= 64);
+
+/* SL_INDEX_COUNT must be <= number of bits in sl_bitmap's storage type. */
+tlsf_static_assert(sizeof(unsigned int) * CHAR_BIT >= SL_INDEX_COUNT);
+
+/* Ensure we've properly tuned our sizes. */
+tlsf_static_assert(ALIGN_SIZE == SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
+
+/*
+** Data structures and associated constants.
+*/
+
+/*
+** Block header structure.
+**
+** There are several implementation subtleties involved:
+** - The prev_phys_block field is only valid if the previous block is free.
+** - The prev_phys_block field is actually stored at the end of the
+**   previous block. It appears at the beginning of this structure only to
+**   simplify the implementation.
+** - The next_free / prev_free fields are only valid if the block is free.
+*/
+typedef struct block_header_t//tlsf内存块头结构
+{
+	/* Points to the previous physical block. */
+	struct block_header_t* prev_phys_block;//内存地址上上一个块的位置指针
+	//只存储上一个块的位置，是因为下一个块可以根据这个块的大小算出来
+
+	/* The size of this block, excluding the block header. */
+	size_t size;//这个块的大小，注意是不包括分配时要带的8字节块头大小的
+	//因为块大小是4对齐的，所以用低2位分别表示这个块和上一个块是否是free的
+
+	/* Next and previous free blocks. */
+	struct block_header_t* next_free;//free链表中的下一个块
+	struct block_header_t* prev_free;//free链表中的上一个块
+	//free链表只对free状态的块使用
+} block_header_t;
+
+/*
+** Since block sizes are always at least a multiple of 4, the two least
+** significant bits of the size field are used to store the block status:
+** - bit 0: whether block is busy or free
+** - bit 1: whether previous block is busy or free
+*/
+static const size_t block_header_free_bit = 1 << 0;//这个块是否free
+static const size_t block_header_prev_free_bit = 1 << 1;//上一个块是否free
+
+/*
+** The size of the block header exposed to used blocks is the size field.
+** The prev_phys_block field is stored *inside* the previous free block.
+*/
+static const size_t block_header_overhead = sizeof(size_t);
+
+/* User data starts directly after the size field in a used block. */
+static const size_t block_start_offset =
+	offsetof(block_header_t, size) + sizeof(size_t);
+
+/*
+** A free block must be large enough to store its header minus the size of
+** the prev_phys_block field, and no larger than the number of addressable
+** bits for FL_INDEX.
+*/
+static const size_t block_size_min = 
+	sizeof(block_header_t) - sizeof(block_header_t*);
+static const size_t block_size_max = tlsf_cast(size_t, 1) << FL_INDEX_MAX;
+
+
+/* The TLSF control structure. */
+typedef struct control_t//整个tlsf的控制结构
+{
+	/* Empty lists point at this block to indicate they are free. */
+	block_header_t block_null;//空块
+
+	/* Bitmaps for free lists. */
+	unsigned int fl_bitmap;//一级链表的bitmap，标记每个一级链表是否非空
+	unsigned int sl_bitmap[FL_INDEX_COUNT];//二级链表的bitmap，标记每个二级链表是否非空
+
+	/* Head of free lists. */
+	block_header_t* blocks[FL_INDEX_COUNT][SL_INDEX_COUNT];//二级链表结构
+	//SL_INDEX_COUNT=32表示二级链表将一级链表的一个区间拆分成了32段，也就是要根据最高位后的5个二进制位来判断
+} control_t;
+
+/* A type used for casting when doing pointer arithmetic. */
+typedef ptrdiff_t tlsfptr_t;
+
+/*
+** block_header_t member functions.
+*/
+
+static size_t block_size(const block_header_t* block)//实际块大小
+{
+	return block->size & ~(block_header_free_bit | block_header_prev_free_bit);
+}
+
+static void block_set_size(block_header_t* block, size_t size)//设置块大小
+{
+	const size_t oldsize = block->size;
+	block->size = size | (oldsize & (block_header_free_bit | block_header_prev_free_bit));
+}
+
+static int block_is_last(const block_header_t* block)//这一块是否为最后一块
+{
+	return block_size(block) == 0;
+}
+
+static int block_is_free(const block_header_t* block)//这一块是否空闲
+{
+	return tlsf_cast(int, block->size & block_header_free_bit);
+}
+
+static void block_set_free(block_header_t* block)//设置空闲
+{
+	block->size |= block_header_free_bit;
+}
+
+static void block_set_used(block_header_t* block)//设置使用
+{
+	block->size &= ~block_header_free_bit;
+}
+
+static int block_is_prev_free(const block_header_t* block)//上一块是否空闲
+{
+	return tlsf_cast(int, block->size & block_header_prev_free_bit);
+}
+
+static void block_set_prev_free(block_header_t* block)//设置上一块空闲
+{
+	block->size |= block_header_prev_free_bit;
+}
+
+static void block_set_prev_used(block_header_t* block)//设置上一块使用
+{
+	block->size &= ~block_header_prev_free_bit;
+}
+
+static block_header_t* block_from_ptr(const void* ptr)//给定有效内存地址，获得块指针（向前偏移16字节）
+{
+	return tlsf_cast(block_header_t*,
+		tlsf_cast(unsigned char*, ptr) - block_start_offset);
+}
+
+static void* block_to_ptr(const block_header_t* block)//给定块指针，获得有效内存地址（向后偏移16字节）
+{
+	return tlsf_cast(void*,
+		tlsf_cast(unsigned char*, block) + block_start_offset);
+}
+
+/* Return location of next block after block of given size. */
+static block_header_t* offset_to_block(const void* ptr, size_t size)//获得当前位置+给定偏移量的块指针
+{
+	return tlsf_cast(block_header_t*, tlsf_cast(tlsfptr_t, ptr) + size);
+}
+
+/* Return location of previous block. */
+static block_header_t* block_prev(const block_header_t* block)//获取（物理上的）上一块，要求是空闲块
+{
+	//tlsf_assert(block_is_prev_free(block) && "previous block must be free");
+	return block->prev_phys_block;
+}
+
+/* Return location of next existing block. */
+static block_header_t* block_next(const block_header_t* block)//获取（物理上的）下一块，要求不是最后一块（size=0为最后一块）
+{
+	block_header_t* next = offset_to_block(block_to_ptr(block),
+		block_size(block) - block_header_overhead);
+	//tlsf_assert(!block_is_last(block));
+	return next;
+}
+
+/* Link a new block with its physical neighbor, return the neighbor. */
+static block_header_t* block_link_next(block_header_t* block)//获得（物理上的）下一块，并将其设置为链表中的下一块
+{
+	block_header_t* next = block_next(block);
+	next->prev_phys_block = block;
+	return next;
+}
+
+static void block_mark_as_free(block_header_t* block)//将这一块标记为free，要将其物理上的下一块接入链表，同时修改两个块的used信息
+{
+	/* Link the block to the next block, first. */
+	block_header_t* next = block_link_next(block);
+	block_set_prev_free(next);
+	block_set_free(block);
+}
+
+static void block_mark_as_used(block_header_t* block)//将这一块标记为used，获取链表中的下一块并标记used信息
+{
+	block_header_t* next = block_next(block);
+	block_set_prev_used(next);
+	block_set_used(block);
+}
+
+static size_t align_up(size_t x, size_t align)//将x设置为向上align对齐，要求align是2的幂
+{
+	//tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+	return (x + (align - 1)) & ~(align - 1);
+}
+
+static size_t align_down(size_t x, size_t align)//将x设置为向下align对齐，要求align是2的幂
+{
+	//tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+	return x - (x & (align - 1));
+}
+
+static void* align_ptr(const void* ptr, size_t align)//将指针ptr设置为向上align对齐，要求align是2的幂
+{
+	const tlsfptr_t aligned =
+		(tlsf_cast(tlsfptr_t, ptr) + (align - 1)) & ~(align - 1);
+	//tlsf_assert(0 == (align & (align - 1)) && "must align to a power of two");
+	return tlsf_cast(void*, aligned);
+}
+
+/*
+** Adjust an allocation size to be aligned to word size, and no smaller
+** than internal minimum.
+*/
+static size_t adjust_request_size(size_t size, size_t align)//将所需的大小设置为align大小，并与最小分配大小取max
+{
+	size_t adjust = 0;
+	if (size)
+	{
+		const size_t aligned = align_up(size, align);
+
+		/* aligned sized must not exceed block_size_max or we'll go out of bounds on sl_bitmap */
+		if (aligned < block_size_max) 
+		//block_size_min=24，说明每次分配至少要分配这么多出去
+		{
+			adjust = tlsf_max(aligned, block_size_min);
+		}
+	}
+	return adjust;
+}
+
+/*
+** TLSF utility functions. In most cases, these are direct translations of
+** the documentation found in the white paper.
+*/
+
+static void mapping_insert(size_t size, int* fli, int* sli)//将大小映射到一、二级链表fl和sl
+{
+	int fl, sl;
+	if (size < SMALL_BLOCK_SIZE)
+	//小于256的分配请求单独处理，放在一级链表的0下标
+	{
+		/* Store small blocks in first list. */
+		fl = 0;
+		sl = tlsf_cast(int, size) / (SMALL_BLOCK_SIZE / SL_INDEX_COUNT);
+	}
+	else
+	{
+		fl = tlsf_fls_sizet(size);
+		sl = tlsf_cast(int, size >> (fl - SL_INDEX_COUNT_LOG2)) ^ (1 << SL_INDEX_COUNT_LOG2);
+		fl -= (FL_INDEX_SHIFT - 1);
+		//从256开始的内存块依次从一级链表的1下标开始
+	}
+	*fli = fl;
+	*sli = sl;
+}
+
+/* This version rounds up to the next block size (for allocations) */
+static void mapping_search(size_t size, int* fli, int* sli)//分配时，要先将所需size向上取整到上一个二级块大小
+{
+	if (size >= SMALL_BLOCK_SIZE)
+	{
+		const size_t round = (1 << (tlsf_fls_sizet(size) - SL_INDEX_COUNT_LOG2)) - 1;
+		size += round;
+	}
+	mapping_insert(size, fli, sli);
+}
+
+static block_header_t* search_suitable_block(control_t* control, int* fli, int* sli)
+//找一个大小合适的块
+{
+	int fl = *fli;
+	int sl = *sli;
+
+	/*
+	** First, search for a block in the list associated with the given
+	** fl/sl index.
+	*/
+	unsigned int sl_map = control->sl_bitmap[fl] & (~0U << sl);
+	//先在给定的一级链表中找当前二级链表及以后的块，如果能找到就直接用第一个非空的二级链表中的块
+	if (!sl_map)
+	{
+		/* No block exists. Search in the next largest first-level list. */
+		const unsigned int fl_map = control->fl_bitmap & (~0U << (fl + 1));
+		//如果找不到，向上找第一个非空的一级链表，再找其中第一个非空的二级链表
+		if (!fl_map)
+		{
+			/* No free blocks available, memory has been exhausted. */
+			return 0;
+		}
+
+		fl = tlsf_ffs(fl_map);
+		*fli = fl;
+		sl_map = control->sl_bitmap[fl];
+	}
+	//tlsf_assert(sl_map && "internal error - second level bitmap is null");
+	sl = tlsf_ffs(sl_map);
+	*sli = sl;
+
+	/* Return the first block in the free list. */
+	return control->blocks[fl][sl];//直接取这个链表的第一个块
+}
+
+/* Remove a free block from the free list.*/
+static void remove_free_block(control_t* control, block_header_t* block, int fl, int sl)
+//分配一个非空块，要将其从空闲链表中删除
+{
+	block_header_t* prev = block->prev_free;
+	block_header_t* next = block->next_free;
+	//即使是链表的开头/结尾，也应当指向一个特定的null，而不是什么也不指向
+	//tlsf_assert(prev && "prev_free field can not be null");
+	//tlsf_assert(next && "next_free field can not be null");
+	next->prev_free = prev;
+	prev->next_free = next;
+
+	/* If this block is the head of the free list, set new head. */
+	if (control->blocks[fl][sl] == block)//如果它是它所在的链表的头，要重新设置链表头
+	{
+		control->blocks[fl][sl] = next;
+
+		/* If the new head is null, clear the bitmap. */
+		if (next == &control->block_null)//如果链表删空了，要更新一级和二级bitmap
+		{
+			control->sl_bitmap[fl] &= ~(1U << sl);
+
+			/* If the second bitmap is now empty, clear the fl bitmap. */
+			if (!control->sl_bitmap[fl])
+			{
+				control->fl_bitmap &= ~(1U << fl);
+			}
+		}
+	}
+}
+
+/* Insert a free block into the free block list. */
+static void insert_free_block(control_t* control, block_header_t* block, int fl, int sl)//向某一级链表中插入一个空闲块
+{
+	block_header_t* current = control->blocks[fl][sl];
+	//tlsf_assert(current && "free list cannot have a null entry");
+	//tlsf_assert(block && "cannot insert a null entry into the free list");
+	block->next_free = current;
+	block->prev_free = &control->block_null;
+	current->prev_free = block;
+	//直接插入到链表的开头
+
+	//应当是8对齐的
+	//tlsf_assert(block_to_ptr(block) == align_ptr(block_to_ptr(block), ALIGN_SIZE)
+	//	&& "block not aligned properly");
+	/*
+	** Insert the new block at the head of the list, and mark the first-
+	** and second-level bitmaps appropriately.
+	*/
+	//设置链表起始指针以及一二级bitmap
+	control->blocks[fl][sl] = block;
+	control->fl_bitmap |= (1U << fl);
+	control->sl_bitmap[fl] |= (1U << sl);
+}
+
+/* Remove a given block from the free list. */
+static void block_remove(control_t* control, block_header_t* block)
+//删除一个空闲块，通过块大小查询到一二级链表，再从相应链表中删除这个块
+{
+	int fl, sl;
+	mapping_insert(block_size(block), &fl, &sl);
+	remove_free_block(control, block, fl, sl);
+}
+
+/* Insert a given block into the free list. */
+static void block_insert(control_t* control, block_header_t* block)
+//插入一个空闲块，与删除相反
+{
+	int fl, sl;
+	mapping_insert(block_size(block), &fl, &sl);
+	insert_free_block(control, block, fl, sl);
+}
+
+static int block_can_split(block_header_t* block, size_t size)
+//分配一个块之后，如果块比所需内存大很多，可以split，要求至少大一个block_header_t的大小（32字节）
+{
+	return block_size(block) >= sizeof(block_header_t) + size;
+}
+
+/* Split a block into two, the second of which is free. */
+static block_header_t* block_split(block_header_t* block, size_t size)//块分裂
+{
+	//size是所需块大小，block_header_overhead是额外的头部大大小，剩下的就可以独立为一个新块
+	/* Calculate the amount of space left in the remaining block. */
+	block_header_t* remaining =
+		offset_to_block(block_to_ptr(block), size - block_header_overhead);
+
+	const size_t remain_size = block_size(block) - (size + block_header_overhead);
+
+	//分裂出去的块应当8字节对齐
+	//tlsf_assert(block_to_ptr(remaining) == align_ptr(block_to_ptr(remaining), ALIGN_SIZE)
+	//	&& "remaining block not aligned properly");
+
+	//重设当前块以及新块的块大小
+	//tlsf_assert(block_size(block) == remain_size + size + block_header_overhead);
+	block_set_size(remaining, remain_size);
+	//tlsf_assert(block_size(remaining) >= block_size_min && "block split with invalid size");
+
+	block_set_size(block, size);
+	block_mark_as_free(remaining);
+
+	return remaining;
+}
+
+/* Absorb a free block's storage into an adjacent previous free block. */
+static block_header_t* block_absorb(block_header_t* prev, block_header_t* block)
+{
+	//将当前空闲块合并进物理上连续的前一个块中，要求前一个块必须空闲
+	//tlsf_assert(!block_is_last(prev) && "previous block can't be last");
+	/* Note: Leaves flags untouched. */
+	prev->size += block_size(block) + block_header_overhead;
+	block_link_next(prev);//重设上一块的next指针
+	return prev;
+}
+
+//以下两个合并操作，当前块都是刚刚释放出来的，还没加进链表
+/* Merge a just-freed block with an adjacent previous free block. */
+static block_header_t* block_merge_prev(control_t* control, block_header_t* block)//把刚刚释放出来的当前块和上一个块合并
+{
+	if (block_is_prev_free(block))//要求前一个块空闲才能合并
+	{
+		block_header_t* prev = block_prev(block);
+		//tlsf_assert(prev && "prev physical block can't be null");
+		//tlsf_assert(block_is_free(prev) && "prev block is not free though marked as such");
+		block_remove(control, prev);//合并前先要将前一个块从链表中删除
+		block = block_absorb(prev, block);
+	}
+
+	return block;
+}
+
+/* Merge a just-freed block with an adjacent free block. */
+static block_header_t* block_merge_next(control_t* control, block_header_t* block)//把刚刚释放出来的当前块和下一个块合并
+{
+	block_header_t* next = block_next(block);
+	//tlsf_assert(next && "next physical block can't be null");
+
+	if (block_is_free(next))//要求下一个块空闲才能合并
+	{
+		//tlsf_assert(!block_is_last(block) && "previous block can't be last");
+		block_remove(control, next);//合并前先要将下一个块从链表中删除
+		block = block_absorb(block, next);
+	}
+
+	return block;
+}
+
+/* Trim any trailing block space off the end of a block, return to pool. */
+static void block_trim_free(control_t* control, block_header_t* block, size_t size)
+//把一个块按照所需的size拆分，并加入链表；当前块应当不在链表里
+{
+	//tlsf_assert(block_is_free(block) && "block must be free");
+	if (block_can_split(block, size))
+	{
+		block_header_t* remaining_block = block_split(block, size);
+		//remaining_block是拆下来的块，扔回到链表里
+		block_link_next(block);
+		block_set_prev_free(remaining_block);
+		block_insert(control, remaining_block);
+	}
+}
+
+/* Trim any trailing block space off the end of a used block, return to pool. */
+static void block_trim_used(control_t* control, block_header_t* block, size_t size)
+//把一个正在使用的块按照所需的size拆分，拆分后的新块会与后面的块试图合并
+{
+	//tlsf_assert(!block_is_free(block) && "block must be used");
+	if (block_can_split(block, size))
+	{
+		/* If the next block is free, we must coalesce. */
+		block_header_t* remaining_block = block_split(block, size);
+		block_set_prev_used(remaining_block);
+		//这里不用block_link_next(block)是因为当前块block是used
+		//将remaining_block试图与后面合并
+		remaining_block = block_merge_next(control, remaining_block);
+		block_insert(control, remaining_block);
+	}
+}
+
+static block_header_t* block_trim_free_leading(control_t* control, block_header_t* block, size_t size)
+//拆分之后获取remaining_block
+{
+	block_header_t* remaining_block = block;
+	if (block_can_split(block, size))
+	{
+		/* We want the 2nd block. */
+		remaining_block = block_split(block, size - block_header_overhead);
+		block_set_prev_free(remaining_block);
+
+		block_link_next(block);
+		block_insert(control, block);
+	}
+
+	return remaining_block;
+}
+
+//以下两步就完成了alloc操作
+static block_header_t* block_locate_free(control_t* control, size_t size)
+//给定所需大小，找到一个空闲块，并将其从链表中删除
+{
+	int fl = 0, sl = 0;
+	block_header_t* block = 0;
+
+	if (size)
+	{
+		mapping_search(size, &fl, &sl);
+		
+		/*
+		** mapping_search can futz with the size, so for excessively large sizes it can sometimes wind up 
+		** with indices that are off the end of the block array.
+		** So, we protect against that here, since this is the only callsite of mapping_search.
+		** Note that we don't need to check sl, since it comes from a modulo operation that guarantees it's always in range.
+		*/
+		if (fl < FL_INDEX_COUNT)
+		{
+			block = search_suitable_block(control, &fl, &sl);
+		}
+	}
+
+	if (block)
+	{
+		//tlsf_assert(block_size(block) >= size);
+		remove_free_block(control, block, fl, sl);
+	}
+
+	return block;
+}
+
+static void* block_prepare_used(control_t* control, block_header_t* block, size_t size)
+//紧接前一步，找到了空闲块，把它拆分之后（拆下来的已经扔回链表了），把它标记为used，返回有效内存的指针
+{
+	void* p = 0;
+	if (block)
+	{
+		//tlsf_assert(size && "size must be non-zero");
+		block_trim_free(control, block, size);
+		block_mark_as_used(block);
+		p = block_to_ptr(block);
+	}
+	return p;
+}
+
+/* Clear structure and point all empty lists at the null block. */
+static void control_construct(control_t* control)
+//初始化控制结构，把所有bitmap清空，指针指向null
+{
+	int i, j;
+
+	control->block_null.next_free = &control->block_null;
+	control->block_null.prev_free = &control->block_null;
+
+	control->fl_bitmap = 0;
+	for (i = 0; i < FL_INDEX_COUNT; ++i)
+	{
+		control->sl_bitmap[i] = 0;
+		for (j = 0; j < SL_INDEX_COUNT; ++j)
+		{
+			control->blocks[i][j] = &control->block_null;
+		}
+	}
+}
+
+/*
+** Size of the TLSF structures in a given memory block passed to
+** tlsf_create, equal to the size of a control_t
+*/
+size_t tlsf_size(void)
+{
+	return sizeof(control_t);
+}
+
+size_t tlsf_align_size(void)
+{
+	return ALIGN_SIZE;
+}
+
+size_t tlsf_block_size_min(void)
+{
+	return block_size_min;
+}
+
+size_t tlsf_block_size_max(void)
+{
+	return block_size_max;
+}
+
+/*
+** Overhead of the TLSF structures in a given memory block passed to
+** tlsf_add_pool, equal to the overhead of a free block and the
+** sentinel block.
+*/
+size_t tlsf_pool_overhead(void)
+{
+	return 2 * block_header_overhead;
+}
+
+size_t tlsf_alloc_overhead(void)
+{
+	return block_header_overhead;
+}
+
+pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes)
+//向内存池中添加一段内存，从mem开始的bytes字节
+{
+	block_header_t* block;
+	block_header_t* next;
+
+	const size_t pool_overhead = tlsf_pool_overhead();
+	const size_t pool_bytes = align_down(bytes - pool_overhead, ALIGN_SIZE);
+
+	if (((ptrdiff_t)mem % ALIGN_SIZE) != 0)
+	{
+		//printf("tlsf_add_pool: Memory must be aligned by %u bytes.\n",
+		//	(unsigned int)ALIGN_SIZE);
+		return 0;
+	}
+
+	if (pool_bytes < block_size_min || pool_bytes > block_size_max)
+	{
+//#if defined (TLSF_64BIT)
+//		printf("tlsf_add_pool: Memory size must be between 0x%x and 0x%x00 bytes.\n", 
+//			(unsigned int)(pool_overhead + block_size_min),
+//			(unsigned int)((pool_overhead + block_size_max) / 256));
+//#else
+//		printf("tlsf_add_pool: Memory size must be between %u and %u bytes.\n", 
+//			(unsigned int)(pool_overhead + block_size_min),
+//			(unsigned int)(pool_overhead + block_size_max));
+//#endif
+		return 0;
+	}
+
+	/*
+	** Create the main free block. Offset the start of the block slightly
+	** so that the prev_phys_block field falls outside of the pool -
+	** it will never be used.
+	*/
+
+	//把一整个内存池视为一个空闲的块插入链表
+	//将prev标记为used，这样就不会在试图访问prev时越界
+	block = offset_to_block(mem, -(tlsfptr_t)block_header_overhead);
+	block_set_size(block, pool_bytes);
+	block_set_free(block);
+	block_set_prev_used(block);
+	block_insert(tlsf_cast(control_t*, tlsf), block);
+
+	//额外插入一个大小为0的next块，表示这一段内存池的尾部，这样就不会在试图访问next时越界
+	//注意不要把next和其他块合并了
+	/* Split the block to create a zero-size sentinel block. */
+	next = block_link_next(block);
+	block_set_size(next, 0);
+	block_set_used(next);
+	block_set_prev_free(next);
+
+	return mem;
+}
+
+void tlsf_remove_pool(tlsf_t tlsf, pool_t pool)
+//从内存池中删除一段内存空间，要先检查这段空间是free的，然后直接从free链表中删除
+{
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	block_header_t* block = offset_to_block(pool, -(int)block_header_overhead);
+
+	int fl = 0, sl = 0;
+
+	//tlsf_assert(block_is_free(block) && "block should be free");
+	//tlsf_assert(!block_is_free(block_next(block)) && "next block should not be free");
+	//tlsf_assert(block_size(block_next(block)) == 0 && "next block size should be zero");
+
+	mapping_insert(block_size(block), &fl, &sl);
+	remove_free_block(control, block, fl, sl);
+}
+
+/*
+** TLSF main interface.
+*/
+
+//tlsf结构对外接口的部分
+
+#if _DEBUG
+int test_ffs_fls()
+{
+	/* Verify ffs/fls work properly. */
+	int rv = 0;
+	rv += (tlsf_ffs(0) == -1) ? 0 : 0x1;
+	rv += (tlsf_fls(0) == -1) ? 0 : 0x2;
+	rv += (tlsf_ffs(1) == 0) ? 0 : 0x4;
+	rv += (tlsf_fls(1) == 0) ? 0 : 0x8;
+	rv += (tlsf_ffs(0x80000000) == 31) ? 0 : 0x10;
+	rv += (tlsf_ffs(0x80008000) == 15) ? 0 : 0x20;
+	rv += (tlsf_fls(0x80000008) == 31) ? 0 : 0x40;
+	rv += (tlsf_fls(0x7FFFFFFF) == 30) ? 0 : 0x80;
+
+#if defined (TLSF_64BIT)
+	rv += (tlsf_fls_sizet(0x80000000) == 31) ? 0 : 0x100;
+	rv += (tlsf_fls_sizet(0x100000000) == 32) ? 0 : 0x200;
+	rv += (tlsf_fls_sizet(0xffffffffffffffff) == 63) ? 0 : 0x400;
+#endif
+
+	if (rv)
+	{
+		printf("test_ffs_fls: %x ffs/fls tests failed.\n", rv);
+	}
+	return rv;
+}
+#endif
+
+tlsf_t tlsf_create(void* mem)
+//创建一个tlsf控制结构，位于mem地址处，没有分配内存池
+{
+#if _DEBUG
+	if (test_ffs_fls())
+	{
+		return 0;
+	}
+#endif
+
+	if (((tlsfptr_t)mem % ALIGN_SIZE) != 0)
+	{
+		//printf("tlsf_create: Memory must be aligned to %u bytes.\n",
+		//	(unsigned int)ALIGN_SIZE);
+		return 0;
+	}
+
+	control_construct(tlsf_cast(control_t*, mem));
+
+	return tlsf_cast(tlsf_t, mem);
+}
+
+tlsf_t tlsf_create_with_pool(void* mem, size_t bytes)
+//创建一个tlsf控制结构，位于mem地址处，并给了bytes大小的内存池，除了控制结构以外的空间作为内存池插入
+{
+	tlsf_t tlsf = tlsf_create(mem);
+	tlsf_add_pool(tlsf, (char*)mem + tlsf_size(), bytes - tlsf_size());
+	return tlsf;
+}
+
+void tlsf_destroy(tlsf_t tlsf)
+{
+	/* Nothing to do. */
+	(void)tlsf;
+}
+
+//获取tlsf_t的内存池，默认是从tlsf的地址加上control结构的size
+pool_t tlsf_get_pool(tlsf_t tlsf)
+{
+	return tlsf_cast(pool_t, (char*)tlsf + tlsf_size());
+}
+
+//malloc
+//先将size调整到对齐的大小，然后分配一个块，分配过程先前已经分析了
+void* tlsf_malloc(tlsf_t tlsf, size_t size)
+{
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+	block_header_t* block = block_locate_free(control, adjust);
+	return block_prepare_used(control, block, adjust);
+}
+
+//规定了对齐align的malloc
+void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t size)
+{
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+
+	//核心是在开头切一个空块出来，使得分配出去的地址是align对齐的
+	//所以就要求找到的块大小要足够大，至少要能额外盛下一个align和一个block_header_t的大小（32字节）
+
+	/*
+	** We must allocate an additional minimum block size bytes so that if
+	** our free block will leave an alignment gap which is smaller, we can
+	** trim a leading free block and release it back to the pool. We must
+	** do this because the previous physical block is in use, therefore
+	** the prev_phys_block field is not valid, and we can't simply adjust
+	** the size of that block.
+	*/
+	const size_t gap_minimum = sizeof(block_header_t);
+	const size_t size_with_gap = adjust_request_size(adjust + align + gap_minimum, align);
+
+	/*
+	** If alignment is less than or equals base alignment, we're done.
+	** If we requested 0 bytes, return null, as tlsf_malloc(0) does.
+	*/
+	const size_t aligned_size = (adjust && align > ALIGN_SIZE) ? size_with_gap : adjust;
+
+	block_header_t* block = block_locate_free(control, aligned_size);
+
+	/* This can't be a static assert. */
+	//tlsf_assert(sizeof(block_header_t) == block_size_min + block_header_overhead);
+
+	if (block)
+	{
+		void* ptr = block_to_ptr(block);
+		void* aligned = align_ptr(ptr, align);
+		//aligned是要对齐分配出去的地址，ptr是原来的地址，中间的差记为gap
+		size_t gap = tlsf_cast(size_t,
+			tlsf_cast(tlsfptr_t, aligned) - tlsf_cast(tlsfptr_t, ptr));
+
+		/* If gap size is too small, offset to next aligned boundary. */
+		//gap最小是32，否则切不出来一个更小的块
+		//所以如果小于32的话，要继续增加gap，即将aligned移动到更靠后的位置
+		if (gap && gap < gap_minimum)
+		{
+			const size_t gap_remain = gap_minimum - gap;
+			const size_t offset = tlsf_max(gap_remain, align);
+			const void* next_aligned = tlsf_cast(void*,
+				tlsf_cast(tlsfptr_t, aligned) + offset);
+
+			aligned = align_ptr(next_aligned, align);
+			gap = tlsf_cast(size_t,
+				tlsf_cast(tlsfptr_t, aligned) - tlsf_cast(tlsfptr_t, ptr));
+		}
+
+		if (gap)
+		{
+			//tlsf_assert(gap >= gap_minimum && "gap size too small");
+			block = block_trim_free_leading(control, block, gap);//把前面的gap切下来
+		}
+	}
+
+	return block_prepare_used(control, block, adjust);
+}
+
+void tlsf_free(tlsf_t tlsf, void* ptr)
+//free释放一个块，注意标记为free，再前后合并，然后插入链表
+{
+	/* Don't attempt to free a NULL pointer. */
+	if (ptr)
+	{
+		control_t* control = tlsf_cast(control_t*, tlsf);
+		block_header_t* block = block_from_ptr(ptr);
+		//tlsf_assert(!block_is_free(block) && "block already marked as free");
+		block_mark_as_free(block);
+		block = block_merge_prev(control, block);
+		block = block_merge_next(control, block);
+		block_insert(control, block);
+	}
+}
+
+/*
+** The TLSF block information provides us with enough information to
+** provide a reasonably intelligent implementation of realloc, growing or
+** shrinking the currently allocated block as required.
+**
+** This routine handles the somewhat esoteric edge cases of realloc:
+** - a non-zero size with a null pointer will behave like malloc
+** - a zero size with a non-null pointer will behave like free
+** - a request that cannot be satisfied will leave the original buffer
+**   untouched
+** - an extended buffer size will leave the newly-allocated area with
+**   contents undefined
+*/
+void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size)
+{
+	control_t* control = tlsf_cast(control_t*, tlsf);
+	void* p = 0;
+
+	/* Zero-size requests are treated as free. */
+	if (ptr && size == 0)
+	{
+		tlsf_free(tlsf, ptr);
+	}
+	/* Requests with NULL pointers are treated as malloc. */
+	else if (!ptr)
+	{
+		p = tlsf_malloc(tlsf, size);
+	}
+	else
+	{
+		block_header_t* block = block_from_ptr(ptr);
+		block_header_t* next = block_next(block);
+
+		const size_t cursize = block_size(block);
+		const size_t combined = cursize + block_size(next) + block_header_overhead;
+		const size_t adjust = adjust_request_size(size, ALIGN_SIZE);
+
+		//tlsf_assert(!block_is_free(block) && "block already marked as free");
+
+		/*
+		** If the next block is used, or when combined with the current
+		** block, does not offer enough space, we must reallocate and copy.
+		*/
+		if (adjust > cursize && (!block_is_free(next) || adjust > combined))
+		//重新释放再申请新的
+		{
+			p = tlsf_malloc(tlsf, size);
+			if (p)
+			{
+				const size_t minsize = tlsf_min(cursize, size);
+				memcpy(p, ptr, minsize);
+				tlsf_free(tlsf, ptr);
+			}
+		}
+		else
+		//把当前块和物理上的下一块合并（如果空闲的话），再在原址直接切出新的块
+		{
+			/* Do we need to expand to the next block? */
+			if (adjust > cursize)
+			{
+				block_merge_next(control, block);
+				block_mark_as_used(block);
+			}
+
+			/* Trim the resulting block and return the original pointer. */
+			block_trim_used(control, block, adjust);
+			p = ptr;
+		}
+	}
+
+	return p;
+}
+

--- a/crates/tlsf_c_allocator/src/tlsf.h
+++ b/crates/tlsf_c_allocator/src/tlsf.h
@@ -1,0 +1,83 @@
+#ifndef INCLUDED_tlsf
+#define INCLUDED_tlsf
+
+/*
+** Two Level Segregated Fit memory allocator, version 3.1.
+** Written by Matthew Conte
+**	http://tlsf.baisoku.org
+**
+** Based on the original documentation by Miguel Masmano:
+**	http://www.gii.upv.es/tlsf/main/docs
+**
+** This implementation was written to the specification
+** of the document, therefore no GPL restrictions apply.
+** 
+** Copyright (c) 2006-2016, Matthew Conte
+** All rights reserved.
+** 
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are met:
+**     * Redistributions of source code must retain the above copyright
+**       notice, this list of conditions and the following disclaimer.
+**     * Redistributions in binary form must reproduce the above copyright
+**       notice, this list of conditions and the following disclaimer in the
+**       documentation and/or other materials provided with the distribution.
+**     * Neither the name of the copyright holder nor the
+**       names of its contributors may be used to endorse or promote products
+**       derived from this software without specific prior written permission.
+** 
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+** ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL MATTHEW CONTE BE LIABLE FOR ANY
+** DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+** (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+** LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+** ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+** SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stddef.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* tlsf_t: a TLSF structure. Can contain 1 to N pools. */
+/* pool_t: a block of memory that TLSF can manage. */
+typedef void* tlsf_t;
+typedef void* pool_t;
+
+/* Create/destroy a memory pool. */
+tlsf_t tlsf_create(void* mem);//创建tlsf结构
+tlsf_t tlsf_create_with_pool(void* mem, size_t bytes);//创建指定大小的内存池的tlsf结构
+void tlsf_destroy(tlsf_t tlsf);//回收tlsf结构
+pool_t tlsf_get_pool(tlsf_t tlsf);//获取当前tlsf结构的内存池
+
+/* Add/remove memory pools. */
+pool_t tlsf_add_pool(tlsf_t tlsf, void* mem, size_t bytes);//添加一个内存池（指定大小和起始地址）
+void tlsf_remove_pool(tlsf_t tlsf, pool_t pool);//删除一个内存池
+
+/* malloc/memalign/realloc/free replacements. */
+void* tlsf_malloc(tlsf_t tlsf, size_t bytes);//申请一段内存
+void* tlsf_memalign(tlsf_t tlsf, size_t align, size_t bytes);//申请一段内存，要求对齐到align
+void* tlsf_realloc(tlsf_t tlsf, void* ptr, size_t size);//重新分配
+void tlsf_free(tlsf_t tlsf, void* ptr);//回收
+
+/* Returns internal block size, not original request size */
+size_t tlsf_block_size(void* ptr);
+
+/* Overheads/limits of internal structures. */
+size_t tlsf_size(void);
+size_t tlsf_align_size(void);
+size_t tlsf_block_size_min(void);
+size_t tlsf_block_size_max(void);
+size_t tlsf_pool_overhead(void);
+size_t tlsf_alloc_overhead(void);
+
+#if defined(__cplusplus)
+};
+#endif
+
+#endif

--- a/modules/axalloc/src/lib.rs
+++ b/modules/axalloc/src/lib.rs
@@ -13,8 +13,7 @@ extern crate alloc;
 
 mod page;
 
-use allocator::{AllocResult, BaseAllocator, ByteAllocator, PageAllocator};
-use allocator::{BitmapPageAllocator, SlabByteAllocator};
+use allocator::*;
 use core::alloc::{GlobalAlloc, Layout};
 use spinlock::SpinNoIrq;
 
@@ -30,10 +29,10 @@ pub use page::GlobalPage;
 /// there is no memory, asks the page allocator for more memory and adds it to
 /// the byte allocator.
 ///
-/// Currently, [`SlabByteAllocator`] is used as the byte allocator, while
+/// Currently, [`TLSFAllocator`] is used as the byte allocator, while
 /// [`BitmapPageAllocator`] is used as the page allocator.
 pub struct GlobalAllocator {
-    balloc: SpinNoIrq<SlabByteAllocator>,
+    balloc: SpinNoIrq<TLSFAllocator>,
     palloc: SpinNoIrq<BitmapPageAllocator<PAGE_SIZE>>,
 }
 
@@ -41,7 +40,7 @@ impl GlobalAllocator {
     /// Creates an empty [`GlobalAllocator`].
     pub const fn new() -> Self {
         Self {
-            balloc: SpinNoIrq::new(SlabByteAllocator::new()),
+            balloc: SpinNoIrq::new(TLSFAllocator::new()),
             palloc: SpinNoIrq::new(BitmapPageAllocator::new()),
         }
     }


### PR DESCRIPTION
This PR do the following:
- Add crate `basic_allocator`, which implements 3 allocator strategy: `first_fit, best_fit, worst_fit`;
- Add crate `tisf_c_allocator`, which implements the `TLSF` algorithm written by C code;
- Add crate `tlsf_allocator`, which implements the `TLSF` algorithm written by rust code;
- Add user mode test in `crates/allocator`, which includes 2 test bench with rust code and 3 test bench with C code.