### PR TITLE
add support of new platform raspi4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
 name = "axruntime"
 version = "0.1.0"
 dependencies = [
+ "aarch64-cpu",
  "axalloc",
  "axconfig",
  "axdisplay",

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SMP ?= 1
 MODE ?= release
 LOG ?= warn
 
+# PLATFORM = raspi4-aarch64
 A ?= apps/helloworld
 APP ?= $(A)
 APP_FEATURES ?=
@@ -67,7 +68,11 @@ GDB ?= gdb-multiarch
 OUT_DIR ?= $(APP)
 
 APP_NAME := $(shell basename $(APP))
-LD_SCRIPT := $(CURDIR)/modules/axhal/linker_$(ARCH).lds
+ifeq ($(PLATFORM), raspi4-aarch64)
+	LD_SCRIPT := $(CURDIR)/modules/axhal/linker_$(ARCH)_raspi4.lds
+else
+	LD_SCRIPT := $(CURDIR)/modules/axhal/linker_$(ARCH).lds
+endif
 OUT_ELF := $(OUT_DIR)/$(APP_NAME)_$(PLATFORM).elf
 OUT_BIN := $(OUT_DIR)/$(APP_NAME)_$(PLATFORM).bin
 
@@ -138,3 +143,219 @@ clean_c:
 	rm -rf $(APP)/*.o
 
 .PHONY: all build disasm run justrun debug clippy fmt fmt_c test test_no_fail_fast clean clean_c doc disk_image
+
+include ../common/docker.mk
+include ../common/format.mk
+include ../common/operating_system.mk
+
+##--------------------------------------------------------------------------------------------------
+## Optional, user-provided configuration values
+##--------------------------------------------------------------------------------------------------
+
+# Default to the RPi4.
+BSP ?= rpi4
+
+# Default to a serial device name that is common in Linux.
+DEV_SERIAL ?= /dev/ttyUSB0
+
+
+##--------------------------------------------------------------------------------------------------
+## BSP-specific configuration values
+##--------------------------------------------------------------------------------------------------
+QEMU_MISSING_STRING = "This board is not yet supported for QEMU."
+
+ifeq ($(BSP),rpi3)
+    TARGET            = aarch64-unknown-none-softfloat
+    KERNEL_BIN        = kernel8.img
+    QEMU_BINARY       = qemu-system-aarch64
+    QEMU_MACHINE_TYPE = raspi3
+    QEMU_RELEASE_ARGS = -serial stdio -display none
+    OBJDUMP_BINARY    = aarch64-none-elf-objdump
+    NM_BINARY         = aarch64-none-elf-nm
+    READELF_BINARY    = aarch64-none-elf-readelf
+    OPENOCD_ARG       = -f /openocd/tcl/interface/ftdi/olimex-arm-usb-tiny-h.cfg -f /openocd/rpi3.cfg
+    JTAG_BOOT_IMAGE   = ../X1_JTAG_boot/jtag_boot_rpi3.img
+    LD_SCRIPT_PATH    = $(shell pwd)/src/bsp/raspberrypi
+    RUSTC_MISC_ARGS   = -C target-cpu=cortex-a53
+else ifeq ($(BSP),rpi4)
+    TARGET            = aarch64-unknown-none-softfloat
+	KERNEL_BIN		  := $(OUT_BIN)
+#    KERNEL_BIN        = kernel8.img
+    QEMU_BINARY       = qemu-system-aarch64
+    QEMU_MACHINE_TYPE =
+    QEMU_RELEASE_ARGS = -serial stdio -display none
+    OBJDUMP_BINARY    = aarch64-none-elf-objdump
+    NM_BINARY         = aarch64-none-elf-nm
+    READELF_BINARY    = aarch64-none-elf-readelf
+    OPENOCD_ARG       = -f /openocd/tcl/interface/ftdi/olimex-arm-usb-tiny-h.cfg -f /openocd/rpi4.cfg
+    JTAG_BOOT_IMAGE   = ../X1_JTAG_boot/jtag_boot_rpi4.img
+    LD_SCRIPT_PATH    = $(shell pwd)/src/bsp/raspberrypi
+    RUSTC_MISC_ARGS   = -C target-cpu=cortex-a72
+endif
+
+# Export for build.rs.
+export LD_SCRIPT_PATH
+
+
+
+##--------------------------------------------------------------------------------------------------
+## Targets and Prerequisites
+##--------------------------------------------------------------------------------------------------
+KERNEL_MANIFEST      = Cargo.toml
+KERNEL_LINKER_SCRIPT = kernel.ld
+LAST_BUILD_CONFIG    = target/$(BSP).build_config
+
+# KERNEL_ELF      = target/$(TARGET)/release/kernel
+KERNEL_ELF			:= $(OUT_ELF)
+# This parses cargo's dep-info file.
+# https://doc.rust-lang.org/cargo/guide/build-cache.html#dep-info-files
+KERNEL_ELF_DEPS = $(filter-out %: ,$(file < $(KERNEL_ELF).d)) $(KERNEL_MANIFEST) $(LAST_BUILD_CONFIG)
+
+
+
+##--------------------------------------------------------------------------------------------------
+## Command building blocks
+##--------------------------------------------------------------------------------------------------
+RUSTFLAGS = $(RUSTC_MISC_ARGS)                   \
+    -C link-arg=--library-path=$(LD_SCRIPT_PATH) \
+    -C link-arg=--script=$(KERNEL_LINKER_SCRIPT)
+
+RUSTFLAGS_PEDANTIC = $(RUSTFLAGS) \
+    -D warnings                   \
+    -D missing_docs
+
+FEATURES      = --features bsp_$(BSP)
+COMPILER_ARGS = --target=$(TARGET) \
+    $(FEATURES)                    \
+    --release
+
+RUSTC_CMD   = cargo rustc $(COMPILER_ARGS)
+DOC_CMD     = cargo doc $(COMPILER_ARGS)
+CLIPPY_CMD  = cargo clippy $(COMPILER_ARGS)
+OBJCOPY_CMD = rust-objcopy \
+    --strip-all            \
+    -O binary
+
+EXEC_QEMU          = $(QEMU_BINARY) -M $(QEMU_MACHINE_TYPE)
+EXEC_TEST_DISPATCH = ruby ../common/tests/dispatch.rb
+EXEC_MINIPUSH      = ruby ../common/serial/minipush.rb
+
+##------------------------------------------------------------------------------
+## Dockerization
+##------------------------------------------------------------------------------
+DOCKER_CMD            = docker run -t --rm -v $(shell pwd):/work/tutorial -w /work/tutorial
+DOCKER_CMD_INTERACT   = $(DOCKER_CMD) -i
+DOCKER_ARG_DIR_COMMON = -v $(shell pwd)/../common:/work/common
+DOCKER_ARG_DIR_JTAG   = -v $(shell pwd)/../X1_JTAG_boot:/work/X1_JTAG_boot
+DOCKER_ARG_DEV        = --privileged -v /dev:/dev
+DOCKER_ARG_NET        = --network host
+
+# DOCKER_IMAGE defined in include file (see top of this file).
+DOCKER_QEMU  = $(DOCKER_CMD_INTERACT) $(DOCKER_IMAGE)
+DOCKER_TOOLS = $(DOCKER_CMD) $(DOCKER_IMAGE)
+DOCKER_TEST  = $(DOCKER_CMD) $(DOCKER_ARG_DIR_COMMON) $(DOCKER_IMAGE)
+DOCKER_GDB   = $(DOCKER_CMD_INTERACT) $(DOCKER_ARG_NET) $(DOCKER_IMAGE)
+
+# Dockerize commands, which require USB device passthrough, only on Linux.
+ifeq ($(shell uname -s),Linux)
+    DOCKER_CMD_DEV = $(DOCKER_CMD_INTERACT) $(DOCKER_ARG_DEV)
+
+    DOCKER_CHAINBOOT = $(DOCKER_CMD_DEV) $(DOCKER_ARG_DIR_COMMON) $(DOCKER_IMAGE)
+    DOCKER_JTAGBOOT  = $(DOCKER_CMD_DEV) $(DOCKER_ARG_DIR_COMMON) $(DOCKER_ARG_DIR_JTAG) $(DOCKER_IMAGE)
+    DOCKER_OPENOCD   = $(DOCKER_CMD_DEV) $(DOCKER_ARG_NET) $(DOCKER_IMAGE)
+else
+    DOCKER_OPENOCD   = echo "Not yet supported on non-Linux systems."; \#
+endif
+
+
+
+##--------------------------------------------------------------------------------------------------
+## Targets
+##--------------------------------------------------------------------------------------------------
+.PHONY: all doc qemu chainboot clippy clean readelf objdump nm check
+
+all: $(KERNEL_BIN)
+
+##------------------------------------------------------------------------------
+## Save the configuration as a file, so make understands if it changed.
+##------------------------------------------------------------------------------
+$(LAST_BUILD_CONFIG):
+	@rm -f target/*.build_config
+	@mkdir -p target
+	@touch $(LAST_BUILD_CONFIG)
+
+##------------------------------------------------------------------------------
+## Run the kernel in QEMU
+##------------------------------------------------------------------------------
+ifeq ($(QEMU_MACHINE_TYPE),) # QEMU is not supported for the board.
+
+qemu:
+	$(call color_header, "$(QEMU_MISSING_STRING)")
+
+else # QEMU is supported.
+
+qemu: $(KERNEL_BIN)
+	$(call color_header, "Launching QEMU")
+	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_BIN)
+
+endif
+
+##------------------------------------------------------------------------------
+## Push the kernel to the real HW target
+##------------------------------------------------------------------------------
+chainboot: $(KERNEL_BIN)
+	@$(DOCKER_CHAINBOOT) $(EXEC_MINIPUSH) $(DEV_SERIAL) $(KERNEL_BIN)
+
+
+##------------------------------------------------------------------------------
+## Run readelf
+##------------------------------------------------------------------------------
+readelf: $(KERNEL_ELF)
+	$(call color_header, "Launching readelf")
+	@$(DOCKER_TOOLS) $(READELF_BINARY) --headers $(KERNEL_ELF)
+
+##------------------------------------------------------------------------------
+## Run objdump
+##------------------------------------------------------------------------------
+objdump: $(KERNEL_ELF)
+	$(call color_header, "Launching objdump")
+	@$(DOCKER_TOOLS) $(OBJDUMP_BINARY) --disassemble --demangle \
+                --section .text   \
+                --section .rodata \
+                $(KERNEL_ELF) | rustfilt
+
+##------------------------------------------------------------------------------
+## Run nm
+##------------------------------------------------------------------------------
+nm: $(KERNEL_ELF)
+	$(call color_header, "Launching nm")
+	@$(DOCKER_TOOLS) $(NM_BINARY) --demangle --print-size $(KERNEL_ELF) | sort | rustfilt
+
+
+
+##--------------------------------------------------------------------------------------------------
+## Debugging targets
+##--------------------------------------------------------------------------------------------------
+.PHONY: jtagboot openocd gdb gdb-opt0
+
+##------------------------------------------------------------------------------
+## Push the JTAG boot image to the real HW target
+##------------------------------------------------------------------------------
+jtagboot:
+	@$(DOCKER_JTAGBOOT) $(EXEC_MINIPUSH) $(DEV_SERIAL) $(JTAG_BOOT_IMAGE)
+
+##------------------------------------------------------------------------------
+## Start OpenOCD session
+##------------------------------------------------------------------------------
+openocd:
+	$(call color_header, "Launching OpenOCD")
+	@$(DOCKER_OPENOCD) openocd $(OPENOCD_ARG)
+
+##------------------------------------------------------------------------------
+## Start GDB session
+##------------------------------------------------------------------------------
+gdb: RUSTC_MISC_ARGS += -C debuginfo=2
+gdb-opt0: RUSTC_MISC_ARGS += -C debuginfo=2 -C opt-level=0
+gdb gdb-opt0: $(KERNEL_ELF)
+	$(call color_header, "Launching GDB")
+	@$(DOCKER_GDB) gdb-multiarch -q $(KERNEL_ELF)

--- a/crates/page_table_entry/src/arch/aarch64.rs
+++ b/crates/page_table_entry/src/arch/aarch64.rs
@@ -72,7 +72,7 @@ impl DescriptorAttr {
         if matches!(mem_type, MemType::Normal) {
             bits |= Self::INNER.bits() | Self::SHAREABLE.bits();
         }
-        Self::from_bits_truncate(bits)
+        Self::from_bits_retain(bits)
     }
 
     fn mem_type(&self) -> MemType {

--- a/doc/raspi4.md
+++ b/doc/raspi4.md
@@ -1,0 +1,11 @@
+# How to run ArceOS on raspi4
+
+You have to download this tutorial first:
+
+https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials
+
+And follow this tutorial run the 06_uart_chainloader chapter.
+
+Then move your ArceOS to its root directory.
+
+Then choose `PLATFORM = raspi4-aarch64` in Makefile and use the command `make chainboot` to transmit the arceos.bin to your raspi4.

--- a/modules/axconfig/Cargo.toml
+++ b/modules/axconfig/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://rcore-os.github.io/arceos/axconfig/index.html"
 platform-pc-x86 = []
 platform-qemu-virt-riscv = []
 platform-qemu-virt-aarch64 = []
+platform-raspi4-aarch64 = []
 default = []
 
 [dependencies]

--- a/modules/axconfig/src/lib.rs
+++ b/modules/axconfig/src/lib.rs
@@ -37,6 +37,13 @@ cfg_if::cfg_if! {
         #[rustfmt::skip]
         #[path = "config_qemu_virt_aarch64.rs"]
         mod config;
+    } else if #[cfg(all(
+        any(target_arch = "aarch64", not(target_os = "none")),
+        feature = "platform-raspi4-aarch64"
+    ))] {
+        #[rustfmt::skip]
+        #[path = "config_raspi4_aarch64.rs"]
+        mod config;
     } else {
         #[rustfmt::skip]
         #[path = "config_dummy.rs"]

--- a/modules/axconfig/src/platform/raspi4-aarch64.toml
+++ b/modules/axconfig/src/platform/raspi4-aarch64.toml
@@ -1,0 +1,21 @@
+# Architecture identifier.
+arch = "aarch64"
+# Platform identifier.
+platform = "raspi4-aarch64"
+
+# Base address of the whole physical memory.
+phys-memory-base = "0x0"
+# Size of the whole physical memory.
+phys-memory-size = "0x800_0000"     # 128M
+# Base physical address of the kernel image.
+kernel-base-paddr = "0x8_0000"
+# Base virtual address of the kernel image.
+kernel-base-vaddr = "0xffff_0000_0008_0000"
+# Linear mapping offset, for quick conversions between physical and virtual
+# addresses.
+phys-virt-offset = "0xffff_0000_0000_0000"
+# MMIO regions with format (`base_paddr`, `size`).
+mmio-regions = [
+    ["0xFE20_1000", "0x1000"],      # PL011 UART
+    ["0xFF84_1000", "0x8000"],      # GICv2
+]

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -14,6 +14,7 @@ devfs = ["dep:axfs_devfs"]
 ramfs = ["dep:axfs_ramfs"]
 fatfs = ["dep:fatfs"]
 myfs = ["dep:crate_interface"]
+use-ramdisk = []
 
 default = ["devfs", "ramfs", "fatfs"]
 

--- a/modules/axfs/src/fs/fatfs.rs
+++ b/modules/axfs/src/fs/fatfs.rs
@@ -26,6 +26,22 @@ unsafe impl<'a> Send for DirWrapper<'a> {}
 unsafe impl<'a> Sync for DirWrapper<'a> {}
 
 impl FatFileSystem {
+    #[cfg(feature = "use-ramdisk")]
+    pub fn new(mut disk: Disk) -> Self {
+        #[cfg(feature = "use-ramdisk")]
+        {
+            let opts = fatfs::FormatVolumeOptions::new();
+            fatfs::format_volume(&mut disk, opts).expect("format volume");
+        }
+        let inner = fatfs::FileSystem::new(disk, fatfs::FsOptions::new())
+            .expect("failed to initialize FAT filesystem");
+        Self {
+            inner,
+            root_dir: UnsafeCell::new(None),
+        }
+    }
+
+    #[cfg(not(feature = "use-ramdisk"))]
     pub fn new(disk: Disk) -> Self {
         let inner = fatfs::FileSystem::new(disk, fatfs::FsOptions::new())
             .expect("failed to initialize FAT filesystem");

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -20,6 +20,10 @@ platform-qemu-virt-aarch64 = [
     "axconfig/platform-qemu-virt-aarch64",
     "dep:page_table_entry", "dep:ratio",
 ]
+platform-raspi4-aarch64 = [
+    "axconfig/platform-raspi4-aarch64",
+    "dep:page_table_entry", "dep:ratio",
+]
 default = []
 
 [dependencies]

--- a/modules/axhal/build.rs
+++ b/modules/axhal/build.rs
@@ -6,7 +6,10 @@ fn main() {
 }
 
 fn gen_linker_script(arch: &str) -> Result<()> {
+    #[cfg(not(feature = "platform-raspi4-aarch64"))]
     let fname = format!("linker_{}.lds", arch);
+    #[cfg(feature = "platform-raspi4-aarch64")]
+    let fname = format!("linker_{}_raspi4.lds", arch);
     let output_arch = if arch == "x86_64" {
         "i386:x86-64"
     } else if arch.contains("riscv") {

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -93,3 +93,8 @@ pub fn flush_icache_all() {
 pub fn set_exception_vector_base(vbar_el1: usize) {
     VBAR_EL1.set(vbar_el1 as _);
 }
+
+/// Flushes the data cache at addr
+pub fn flush_dcache(addr: usize) {
+    unsafe { asm!("dc ivac, {0:x}; dsb sy; isb", in(reg) addr) };
+}

--- a/modules/axhal/src/platform/mod.rs
+++ b/modules/axhal/src/platform/mod.rs
@@ -19,6 +19,12 @@ cfg_if::cfg_if! {
     ))] {
         mod qemu_virt_aarch64;
         pub use self::qemu_virt_aarch64::*;
+    } else if #[cfg(all(
+        target_arch = "aarch64",
+        feature = "platform-raspi4-aarch64"
+    ))] {
+        mod raspi4_aarch64;
+        pub use self::raspi4_aarch64::*;
     } else {
         mod dummy;
         pub use self::dummy::*;

--- a/modules/axhal/src/platform/raspi4_aarch64/boot.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/boot.rs
@@ -1,0 +1,203 @@
+use aarch64_cpu::{asm, asm::barrier, registers::*};
+use memory_addr::PhysAddr;
+use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
+
+use axconfig::TASK_STACK_SIZE;
+
+#[link_section = ".bss.stack"]
+static mut BOOT_STACK: [u8; TASK_STACK_SIZE] = [0; TASK_STACK_SIZE];
+
+#[link_section = ".data.boot_page_table"]
+static mut BOOT_PT_L0: [A64PTE; 512] = [A64PTE::empty(); 512];
+
+#[link_section = ".data.boot_page_table"]
+static mut BOOT_PT_L1: [A64PTE; 512] = [A64PTE::empty(); 512];
+
+unsafe fn switch_to_el1() {
+    SPSel.write(SPSel::SP::ELx);
+    let current_el = CurrentEL.read(CurrentEL::EL);
+    if current_el >= 2 {
+        if current_el == 3 {
+            // Set EL2 to 64bit and enable the HVC instruction.
+            SCR_EL3.write(
+                SCR_EL3::NS::NonSecure + SCR_EL3::HCE::HvcEnabled + SCR_EL3::RW::NextELIsAarch64,
+            );
+            // Set the return address and exception level.
+            SPSR_EL3.write(
+                SPSR_EL3::M::EL1h
+                    + SPSR_EL3::D::Masked
+                    + SPSR_EL3::A::Masked
+                    + SPSR_EL3::I::Masked
+                    + SPSR_EL3::F::Masked,
+            );
+            ELR_EL3.set(LR.get());
+        }
+        // Disable EL1 timer traps and the timer offset.
+        CNTHCTL_EL2.modify(CNTHCTL_EL2::EL1PCEN::SET + CNTHCTL_EL2::EL1PCTEN::SET);
+        CNTVOFF_EL2.set(0);
+        // Set EL1 to 64bit.
+        HCR_EL2.write(HCR_EL2::RW::EL1IsAarch64);
+        // Set the return address and exception level.
+        SPSR_EL2.write(
+            SPSR_EL2::M::EL1h
+                + SPSR_EL2::D::Masked
+                + SPSR_EL2::A::Masked
+                + SPSR_EL2::I::Masked
+                + SPSR_EL2::F::Masked,
+        );
+        // SP_EL1.set(BOOT_STACK.as_ptr_range().end as u64);
+        ELR_EL2.set(LR.get());
+        asm::eret();
+    }
+}
+
+unsafe fn init_boot_page_table() {
+    // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
+    BOOT_PT_L0[0] = A64PTE::new_table(PhysAddr::from(BOOT_PT_L1.as_ptr() as usize));
+    // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
+    BOOT_PT_L1[0] = A64PTE::new_page(
+        PhysAddr::from(0),
+        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
+        true,
+    );
+    // 0x0000_4000_0000..0x0000_8000_0000, 1G block, normal memory
+    BOOT_PT_L1[1] = A64PTE::new_page(
+        PhysAddr::from(0x4000_0000),
+        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
+        true,
+    );
+    // 0x0000_8000_0000..0x0000_C000_0000, 1G block, normal memory
+    BOOT_PT_L1[2] = A64PTE::new_page(
+        PhysAddr::from(0x8000_0000),
+        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
+        true,
+    );
+    // 0x0000_C000_0000..0x0001_0000_0000, 1G block, DEVICE memory
+    BOOT_PT_L1[3] = A64PTE::new_page(
+        PhysAddr::from(0xc000_0000),
+        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
+        true,
+    );
+}
+
+unsafe fn init_mmu() {
+    // Device-nGnRE memory
+    let attr0 = MAIR_EL1::Attr0_Device::nonGathering_nonReordering_EarlyWriteAck;
+    // Normal memory
+    let attr1 = MAIR_EL1::Attr1_Normal_Inner::WriteBack_NonTransient_ReadWriteAlloc
+        + MAIR_EL1::Attr1_Normal_Outer::WriteBack_NonTransient_ReadWriteAlloc;
+    MAIR_EL1.write(attr0 + attr1); // 0xff_04
+
+    // Enable TTBR0 and TTBR1 walks, page size = 4K, vaddr size = 48 bits, paddr size = 40 bits.
+    let tcr_flags0 = TCR_EL1::EPD0::EnableTTBR0Walks
+        + TCR_EL1::TG0::KiB_4
+        + TCR_EL1::SH0::Inner
+        + TCR_EL1::ORGN0::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+        + TCR_EL1::IRGN0::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+        + TCR_EL1::T0SZ.val(16);
+    let tcr_flags1 = TCR_EL1::EPD1::EnableTTBR1Walks
+        + TCR_EL1::TG1::KiB_4
+        + TCR_EL1::SH1::Inner
+        + TCR_EL1::ORGN1::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+        + TCR_EL1::IRGN1::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+        + TCR_EL1::T1SZ.val(16);
+    TCR_EL1.write(TCR_EL1::IPS::Bits_48 + tcr_flags0 + tcr_flags1);
+    barrier::isb(barrier::SY);
+
+    // Set both TTBR0 and TTBR1
+    let root_paddr = PhysAddr::from(BOOT_PT_L0.as_ptr() as usize).as_usize() as _;
+    TTBR0_EL1.set(root_paddr);
+    TTBR1_EL1.set(root_paddr);
+
+    // Flush the entire TLB
+    crate::arch::flush_tlb(None);
+
+    // Enable the MMU and turn on I-cache and D-cache
+    SCTLR_EL1.modify(SCTLR_EL1::M::Enable + SCTLR_EL1::C::Cacheable + SCTLR_EL1::I::Cacheable);
+    barrier::isb(barrier::SY);
+}
+
+unsafe fn enable_fp() {
+    if cfg!(feature = "fp_simd") {
+        CPACR_EL1.write(CPACR_EL1::FPEN::TrapNothing);
+        barrier::isb(barrier::SY);
+    }
+}
+
+/// The earliest entry point for the primary CPU.
+#[naked]
+#[no_mangle]
+#[link_section = ".text.boot"]
+unsafe extern "C" fn _start() -> ! {
+    // PC = 0x8_0000
+    // X0 = dtb
+    core::arch::asm!("
+        mrs     x19, mpidr_el1
+        and     x19, x19, #0xffffff     // get current CPU id
+        mov     x20, x0                 // save DTB pointer
+
+        adrp    x8, {boot_stack}        // setup boot stack
+        add     x8, x8, {boot_stack_size}
+        mov     sp, x8
+        msr     sp_el1, x8
+        msr     sp_el0, xzr
+
+        bl      {switch_to_el1}         // switch to EL1
+        bl      {init_boot_page_table}
+        bl      {init_mmu}              // setup MMU
+        bl      {enable_fp}             // enable fp/neon
+
+        mov     x8, {phys_virt_offset}  // set SP to the high address
+        add     sp, sp, x8
+
+        mov     x0, x19                 // call rust_entry(cpu_id, dtb)
+        mov     x1, x20
+        ldr     x8, ={entry}
+        blr     x8
+        b      .",
+        switch_to_el1 = sym switch_to_el1,
+        init_boot_page_table = sym init_boot_page_table,
+        init_mmu = sym init_mmu,
+        enable_fp = sym enable_fp,
+        boot_stack = sym BOOT_STACK,
+        boot_stack_size = const TASK_STACK_SIZE,
+        phys_virt_offset = const axconfig::PHYS_VIRT_OFFSET,
+        entry = sym super::rust_entry,
+        options(noreturn),
+    )
+}
+
+/// The earliest entry point for the secondary CPUs.
+#[cfg(feature = "smp")]
+#[naked]
+#[no_mangle]
+#[link_section = ".text.boot"]
+unsafe extern "C" fn _start_secondary() -> ! {
+    core::arch::asm!("
+        mrs     x19, mpidr_el1
+        and     x19, x19, #0xffffff     // get current CPU id
+
+        mov     x8, sp
+        msr     sp_el1, x8
+        msr     sp_el0, xzr
+
+        bl      {switch_to_el1}
+        bl      {init_mmu}
+        bl      {enable_fp}
+
+        mov     x8, {phys_virt_offset}  // set SP to the high address
+        add     sp, sp, x8
+
+        mov     x0, x19                 // call rust_entry_secondary(cpu_id)
+        ldr     x8, ={entry}
+        blr     x8
+        b      .",
+        switch_to_el1 = sym switch_to_el1,
+        init_mmu = sym init_mmu,
+        enable_fp = sym enable_fp,
+        phys_virt_offset = const axconfig::PHYS_VIRT_OFFSET,
+        entry = sym super::rust_entry_secondary,
+        options(noreturn),
+    )
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/generic_timer.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/generic_timer.rs
@@ -1,0 +1,60 @@
+#![allow(unused_imports)]
+
+use aarch64_cpu::registers::{CNTFRQ_EL0, CNTPCT_EL0, CNTP_CTL_EL0, CNTP_TVAL_EL0};
+use ratio::Ratio;
+use tock_registers::interfaces::{Readable, Writeable};
+
+static mut CNTPCT_TO_NANOS_RATIO: Ratio = Ratio::zero();
+static mut NANOS_TO_CNTPCT_RATIO: Ratio = Ratio::zero();
+
+/// Returns the current clock time in hardware ticks.
+#[inline]
+pub fn current_ticks() -> u64 {
+    CNTPCT_EL0.get()
+}
+
+/// Converts hardware ticks to nanoseconds.
+#[inline]
+pub fn ticks_to_nanos(ticks: u64) -> u64 {
+    unsafe { CNTPCT_TO_NANOS_RATIO.mul_trunc(ticks) }
+}
+
+/// Converts nanoseconds to hardware ticks.
+#[inline]
+pub fn nanos_to_ticks(nanos: u64) -> u64 {
+    unsafe { NANOS_TO_CNTPCT_RATIO.mul_trunc(nanos) }
+}
+
+/// Set a one-shot timer.
+///
+/// A timer interrupt will be triggered at the given deadline (in nanoseconds).
+#[cfg(feature = "irq")]
+pub fn set_oneshot_timer(deadline_ns: u64) {
+    let cnptct = CNTPCT_EL0.get();
+    let cnptct_deadline = nanos_to_ticks(deadline_ns);
+    if cnptct < cnptct_deadline {
+        let interval = cnptct_deadline - cnptct;
+        debug_assert!(interval <= u32::MAX as u64);
+        CNTP_TVAL_EL0.set(interval);
+    } else {
+        CNTP_TVAL_EL0.set(0);
+    }
+}
+
+/// Early stage initialization: stores the timer frequency.
+pub(super) fn init_early() {
+    let freq = CNTFRQ_EL0.get();
+    unsafe {
+        CNTPCT_TO_NANOS_RATIO = Ratio::new(crate::time::NANOS_PER_SEC as u32, freq as u32);
+        NANOS_TO_CNTPCT_RATIO = CNTPCT_TO_NANOS_RATIO.inverse();
+    }
+}
+
+pub(super) fn init_percpu() {
+    #[cfg(feature = "irq")]
+    {
+        CNTP_CTL_EL0.write(CNTP_CTL_EL0::ENABLE::SET);
+        CNTP_TVAL_EL0.set(0);
+        super::irq::set_enable(super::irq::TIMER_IRQ_NUM, true);
+    }
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/gic.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/gic.rs
@@ -1,0 +1,55 @@
+use crate::{irq::IrqHandler, mem::phys_to_virt};
+use arm_gic::gic_v2::{GicCpuInterface, GicDistributor};
+use memory_addr::PhysAddr;
+use spinlock::SpinNoIrq;
+
+/// The maximum number of IRQs.
+pub const MAX_IRQ_COUNT: usize = 1024;
+
+/// The timer IRQ number.
+pub const TIMER_IRQ_NUM: usize = 30; // physical timer, type=PPI, id=14
+
+// const GIC_BASE: usize = 0x0800_0000;
+const GICD_BASE: PhysAddr = PhysAddr::from(0xFF84_1000);
+const GICC_BASE: PhysAddr = PhysAddr::from(0xFF84_2000);
+
+static GICD: SpinNoIrq<GicDistributor> =
+    SpinNoIrq::new(GicDistributor::new(phys_to_virt(GICD_BASE).as_mut_ptr()));
+
+// per-CPU, no lock
+static GICC: GicCpuInterface = GicCpuInterface::new(phys_to_virt(GICC_BASE).as_mut_ptr());
+
+/// Enables or disables the given IRQ.
+pub fn set_enable(irq_num: usize, enabled: bool) {
+    GICD.lock().set_enable(irq_num as _, enabled);
+}
+
+/// Registers an IRQ handler for the given IRQ.
+///
+/// It also enables the IRQ if the registration succeeds. It returns `false` if
+/// the registration failed.
+pub fn register_handler(irq_num: usize, handler: IrqHandler) -> bool {
+    crate::irq::register_handler_common(irq_num, handler)
+}
+
+/// Dispatches the IRQ.
+///
+/// This function is called by the common interrupt handler. It looks
+/// up in the IRQ handler table and calls the corresponding handler. If
+/// necessary, it also acknowledges the interrupt controller after handling.
+pub fn dispatch_irq(_unused: usize) {
+    GICC.handle_irq(|irq_num| crate::irq::dispatch_irq_common(irq_num as _));
+}
+
+/// Initializes GICD, GICC on the primary CPU.
+pub(super) fn init_primary() {
+    // info!("Initialize GICv2...");
+    GICD.lock().init();
+    GICC.init();
+}
+
+/// Initializes GICC on secondary CPUs.
+#[cfg(feature = "smp")]
+pub(super) fn init_secondary() {
+    GICC.init();
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/mem.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/mem.rs
@@ -1,0 +1,45 @@
+use crate::mem::*;
+
+/// Number of physical memory regions.
+pub(crate) fn memory_regions_num() -> usize {
+    common_memory_regions_num() + 2
+}
+
+/// Returns the physical memory region at the given index, or [`None`] if the
+/// index is out of bounds.
+pub(crate) fn memory_region_at(idx: usize) -> Option<MemRegion> {
+    use core::cmp::Ordering;
+    match idx.cmp(&common_memory_regions_num()) {
+        Ordering::Less => common_memory_region_at(idx),
+        Ordering::Equal => {
+            // free memory
+            extern "C" {
+                fn ekernel();
+            }
+            let start = virt_to_phys((ekernel as usize).into()).align_up_4k();
+            let end = PhysAddr::from(axconfig::PHYS_MEMORY_END).align_down_4k();
+            Some(MemRegion {
+                paddr: start,
+                size: end.as_usize() - start.as_usize(),
+                flags: MemRegionFlags::FREE | MemRegionFlags::READ | MemRegionFlags::WRITE,
+                name: "free memory",
+            })
+        }
+        Ordering::Greater => extern_memory_region_at(idx),
+        // Ordering::Greater => None,
+    }
+}
+
+pub(crate) fn extern_memory_region_at(idx: usize) -> Option<MemRegion> {
+    let extern_memeory_id = common_memory_regions_num() + 1;
+    if idx == extern_memeory_id {
+        Some(MemRegion {
+            paddr: 0x0.into(),
+            size: 0x1000,
+            flags: MemRegionFlags::FREE | MemRegionFlags::READ | MemRegionFlags::WRITE,
+            name: "spintable",
+        })
+    } else {
+        None
+    }
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/mod.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/mod.rs
@@ -1,0 +1,69 @@
+mod boot;
+mod generic_timer;
+pub mod pl011;
+mod psci;
+
+#[cfg(feature = "irq")]
+mod gic;
+
+#[cfg(feature = "smp")]
+pub mod mp;
+
+pub mod mem;
+
+pub mod console {
+    pub use super::pl011::*;
+}
+
+pub mod time {
+    pub use super::generic_timer::*;
+}
+
+pub mod misc {
+    pub use super::psci::system_off as terminate;
+}
+
+#[cfg(feature = "irq")]
+pub mod irq {
+    pub use super::gic::*;
+}
+
+extern "C" {
+    fn exception_vector_base();
+    fn rust_main(cpu_id: usize, dtb: usize);
+    #[cfg(feature = "smp")]
+    fn rust_main_secondary(cpu_id: usize);
+}
+
+unsafe extern "C" fn rust_entry(cpu_id: usize, dtb: usize) {
+    crate::mem::clear_bss();
+    crate::arch::set_exception_vector_base(exception_vector_base as usize);
+    crate::cpu::init_primary(cpu_id);
+    self::pl011::init();
+    self::generic_timer::init_early();
+    rust_main(cpu_id, dtb);
+}
+
+#[cfg(feature = "smp")]
+unsafe extern "C" fn rust_entry_secondary(cpu_id: usize) {
+    crate::arch::set_exception_vector_base(exception_vector_base as usize);
+    crate::cpu::init_secondary(cpu_id);
+    rust_main_secondary(cpu_id);
+}
+
+/// Initializes the platform devices for the primary CPU.
+///
+/// For example, the interrupt controller and the timer.
+pub fn platform_init() {
+    #[cfg(feature = "irq")]
+    self::gic::init_primary();
+    self::generic_timer::init_percpu();
+}
+
+/// Initializes the platform devices for secondary CPUs.
+#[cfg(feature = "smp")]
+pub fn platform_init_secondary() {
+    #[cfg(feature = "irq")]
+    self::gic::init_secondary();
+    self::generic_timer::init_percpu();
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/mp.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/mp.rs
@@ -1,0 +1,10 @@
+use crate::mem::{virt_to_phys, PhysAddr, VirtAddr};
+
+/// Starts the given secondary CPU with its boot stack.
+pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
+    extern "C" {
+        fn _start_secondary();
+    }
+    let entry = virt_to_phys(VirtAddr::from(_start_secondary as usize));
+    super::psci::cpu_on(cpu_id, entry.as_usize(), stack_top.as_usize());
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/pl011.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/pl011.rs
@@ -1,0 +1,120 @@
+//! PL011 UART.
+
+use memory_addr::{PhysAddr, VirtAddr};
+use spinlock::SpinNoIrq;
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_structs,
+    registers::{ReadOnly, ReadWrite, WriteOnly},
+};
+
+use crate::mem::phys_to_virt;
+
+const UART_BASE: PhysAddr = PhysAddr::from(0xFE20_1000);
+#[allow(unused)]
+pub const UART_IRQ_NUM: usize = 153; // type=SPI, id=1
+
+static UART: SpinNoIrq<Pl011Uart> = SpinNoIrq::new(Pl011Uart::new(phys_to_virt(UART_BASE)));
+
+register_structs! {
+    Pl011UartRegs {
+        /// Data Register.
+        (0x00 => dr: ReadWrite<u32>),
+        (0x04 => _reserved0),
+        /// Flag Register.
+        (0x18 => fr: ReadOnly<u32>),
+        (0x1c => _reserved1),
+        /// Control register.
+        (0x30 => cr: ReadWrite<u32>),
+        /// Interrupt FIFO Level Select Register.
+        (0x34 => ifls: ReadWrite<u32>),
+        /// Interrupt Mask Set Clear Register.
+        (0x38 => imsc: ReadWrite<u32>),
+        /// Raw Interrupt Status Register.
+        (0x3c => ris: ReadOnly<u32>),
+        /// Masked Interrupt Status Register.
+        (0x40 => mis: ReadOnly<u32>),
+        /// Interrupt Clear Register.
+        (0x44 => icr: WriteOnly<u32>),
+        (0x48 => @END),
+    }
+}
+
+struct Pl011Uart {
+    base_vaddr: VirtAddr,
+}
+
+impl Pl011Uart {
+    const fn new(base_vaddr: VirtAddr) -> Self {
+        Self { base_vaddr }
+    }
+
+    const fn regs(&self) -> &Pl011UartRegs {
+        unsafe { &*(self.base_vaddr.as_ptr() as *const _) }
+    }
+
+    fn init(&mut self) {
+        // clear all irqs
+        self.regs().icr.set(0x3ff);
+
+        // set fifo trigger level
+        self.regs().ifls.set(0); // 1/8 rxfifo, 1/8 txfifo.
+
+        // enable rx interrupt
+        self.regs().imsc.set(1 << 4); // rxim
+
+        // enable receive
+        self.regs().cr.set((1 << 0) | (1 << 8) | (1 << 9)); // tx enable, rx enable, uart enable
+    }
+
+    fn putchar(&mut self, c: u8) {
+        while self.regs().fr.get() & (1 << 5) != 0 {}
+        self.regs().dr.set(c as u32);
+    }
+
+    fn getchar(&mut self) -> Option<u8> {
+        if self.regs().fr.get() & (1 << 4) == 0 {
+            Some(self.regs().dr.get() as u8)
+        } else {
+            None
+        }
+    }
+
+    fn handle(&mut self) {
+        let pending = self.regs().mis.get() as u32;
+        self.regs().icr.set(0x7ff); // clear all interrupts
+        if (pending & (1 << 4)) | (pending & (1 << 6)) != 0 {
+            // 16 = RXMIS, 64 = RTMIS
+            while let Some(c) = self.getchar() {
+                self.putchar(c)
+            }
+        }
+    }
+}
+
+/// Writes a byte to the console.
+pub fn putchar(c: u8) {
+    let mut uart = UART.lock();
+    match c {
+        b'\n' => {
+            uart.putchar(b'\r');
+            uart.putchar(b'\n');
+        }
+        c => uart.putchar(c),
+    }
+}
+
+/// Reads a byte from the console, or returns [`None`] if no input is available.
+pub fn getchar() -> Option<u8> {
+    UART.lock().getchar()
+}
+
+pub(super) fn init() {
+    UART.lock().init();
+    #[cfg(feature = "irq")]
+    super::irq::set_enable(UART_IRQ_NUM, true);
+}
+
+pub fn handle() {
+    UART.lock().handle();
+}

--- a/modules/axhal/src/platform/raspi4_aarch64/psci.rs
+++ b/modules/axhal/src/platform/raspi4_aarch64/psci.rs
@@ -1,0 +1,42 @@
+#![allow(dead_code)]
+
+//! ARM Power State Coordination Interface.
+
+use core::arch::asm;
+
+const PSCI_CPU_ON: u32 = 0x8400_0003;
+const PSCI_SYSTEM_OFF: u32 = 0x8400_0008;
+
+fn psci_hvc_call(func: u32, arg0: usize, arg1: usize, arg2: usize) -> usize {
+    let ret;
+    unsafe {
+        asm!(
+            "hvc #0",
+            inlateout("x0") func as usize => ret,
+            in("x1") arg0,
+            in("x2") arg1,
+            in("x3") arg2,
+        )
+    }
+    ret
+}
+
+/// Shutdown the whole system, including all CPUs.
+pub fn system_off() -> ! {
+    info!("Shutting down...");
+    psci_hvc_call(PSCI_SYSTEM_OFF, 0, 0, 0);
+    warn!("It should shutdown!");
+    loop {
+        crate::arch::halt();
+    }
+}
+
+/// Starts a secondary CPU with the given ID.
+///
+/// When the CPU is started, it will jump to the given entry and set the
+/// corresponding register to the given argument.
+pub fn cpu_on(id: usize, entry: usize, arg: usize) {
+    debug!("Starting core {}...", id);
+    assert_eq!(psci_hvc_call(PSCI_CPU_ON, id, entry, arg), 0);
+    debug!("Started core {}!", id);
+}

--- a/modules/axruntime/Cargo.toml
+++ b/modules/axruntime/Cargo.toml
@@ -16,11 +16,12 @@ irq = ["axhal/irq", "axtask?/irq"]
 multitask = ["alloc", "axtask/multitask"]
 smp = ["axhal/smp", "spinlock/smp"]
 
-fs = ["alloc", "paging", "axdriver/virtio-blk", "dep:axfs"] # TODO: remove "paging"
+fs = ["alloc", "paging", "axdriver/ramdisk", "dep:axfs", "axfs/use-ramdisk"] # TODO: remove "paging"
 net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet"]
 display = ["alloc", "paging", "axdriver/virtio-gpu", "dep:axdisplay"]
 
 default = ["axtask?/default"]
+platform-raspi4-aarch64 = []
 
 [dependencies]
 percpu = { path = "../../crates/percpu" }
@@ -37,3 +38,5 @@ axfs = { path = "../axfs", optional = true }
 axnet = { path = "../axnet", optional = true }
 axdisplay = { path = "../axdisplay", optional = true }
 axtask = { path = "../axtask", default-features = false, optional = true }
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+aarch64-cpu = "9.3"

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(doc_auto_cfg)]
+#![feature(asm_const)]
 
 #[macro_use]
 extern crate axlog;
@@ -223,8 +224,10 @@ fn init_allocator() {
 
 #[cfg(feature = "paging")]
 fn remap_kernel_memory() -> Result<(), axhal::paging::PagingError> {
-    use axhal::mem::{memory_regions, phys_to_virt};
-    use axhal::paging::PageTable;
+    use axhal::{
+        mem::{memory_regions, phys_to_virt},
+        paging::PageTable,
+    };
     use lazy_init::LazyInit;
 
     static KERNEL_PAGE_TABLE: LazyInit<PageTable> = LazyInit::new();

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -7,6 +7,7 @@ static mut SECONDARY_BOOT_STACK: [[u8; TASK_STACK_SIZE]; SMP - 1] = [[0; TASK_ST
 
 static ENTERED_CPUS: AtomicUsize = AtomicUsize::new(1);
 
+#[cfg(all(feature = "smp", not(feature = "platform-raspi4-aarch64")))]
 pub fn start_secondary_cpus(primary_cpu_id: usize) {
     let mut logic_cpu_id = 0;
     for i in 0..SMP {
@@ -24,6 +25,52 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
             }
         }
     }
+}
+
+#[cfg(all(feature = "smp", feature = "platform-raspi4-aarch64"))]
+use aarch64_cpu::asm;
+#[cfg(all(feature = "smp", feature = "platform-raspi4-aarch64"))]
+use core::ptr::write_volatile;
+
+extern "C" {
+    fn _start_secondary();
+}
+
+#[cfg(all(feature = "smp", feature = "platform-raspi4-aarch64"))]
+#[no_mangle]
+#[link_section = ".text.boot"]
+unsafe extern "C" fn modify_stack_and_start() {
+    core::arch::asm!("
+        mrs     x19, mpidr_el1
+        and     x19, x19, #0xffffff             // get current CPU id
+        lsl     x20, x19, #18
+        ldr     x21, ={secondary_boot_stack}    // core0 store the stack start adress at this address
+        mov     x8, {phys_virt_offset} 
+        sub     x21, x21, x8
+        add     sp, x21, x20
+        b       {start_secondary}",
+        secondary_boot_stack = sym SECONDARY_BOOT_STACK,
+        start_secondary = sym _start_secondary,
+        phys_virt_offset = const axconfig::PHYS_VIRT_OFFSET,
+    );
+}
+
+#[no_mangle]
+pub static CPU_SPIN_TABLE: [usize; 4] = [0xd8, 0xe0, 0xe8, 0xf0];
+
+#[cfg(all(feature = "smp", feature = "platform-raspi4-aarch64"))]
+pub fn start_secondary_cpus(primary_cpu_id: usize) {
+    let entry_address = virt_to_phys(VirtAddr::from(modify_stack_and_start as usize)).as_usize();
+    for (i, _) in CPU_SPIN_TABLE.iter().enumerate().take(SMP) {
+        if i != primary_cpu_id {
+            let release_addr = CPU_SPIN_TABLE[i] as *mut usize;
+            unsafe {
+                write_volatile(release_addr, entry_address);
+            }
+            axhal::arch::flush_dcache(release_addr as usize);
+        }
+    }
+    asm::sev();
 }
 
 /// The main entry point of the ArceOS runtime for secondary CPUs.

--- a/ulib/libax/Cargo.toml
+++ b/ulib/libax/Cargo.toml
@@ -65,6 +65,7 @@ log-level-trace = ["axlog/log-level-trace"]
 platform-pc-x86 = ["axhal/platform-pc-x86", "bus-pci"]
 platform-qemu-virt-riscv = ["axhal/platform-qemu-virt-riscv", "bus-mmio"]
 platform-qemu-virt-aarch64 = ["axhal/platform-qemu-virt-aarch64", "bus-mmio"]
+platform-raspi4-aarch64 = ["axhal/platform-raspi4-aarch64", "axruntime/platform-raspi4-aarch64", "axdriver?/bus-mmio"]
 
 default = ["axtask?/sched_fifo"]
 


### PR DESCRIPTION
Add the support of platform raspi4 (It can support apps except those using virtio-net, virtio-gpu, or virtio-blk)
doc/raspi4 has the guide about how to simply run ArceOS on a raspberry 4B board.