### PR TITLE
Libc: epoll and  more libc function

### DIFF
--- a/crates/axio/src/lib.rs
+++ b/crates/axio/src/lib.rs
@@ -251,7 +251,7 @@ where
 }
 
 /// Struct for poll result.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PollState {
     /// Object can be read now.
     pub readable: bool,

--- a/ulib/c_libax/include/dirent.h
+++ b/ulib/c_libax/include/dirent.h
@@ -1,0 +1,41 @@
+#ifndef _DIRENT_H
+#define _DIRENT_H
+
+#include <sys/types.h>
+
+struct __dirstream {
+    long long tell;
+    int fd;
+    int buf_pos;
+    int buf_end;
+    int lock[1];
+    char buf[2048];
+};
+
+typedef struct __dirstream DIR;
+
+struct dirent {
+    ino_t d_ino;
+    off_t d_off;
+    unsigned short d_reclen;
+    unsigned char d_type;
+    char d_name[256];
+};
+
+int closedir(DIR *);
+DIR *fdopendir(int);
+int dirfd(DIR *);
+
+#define DT_UNKNOWN 0
+#define DT_FIFO    1
+#define DT_CHR     2
+#define DT_DIR     4
+#define DT_BLK     6
+#define DT_REG     8
+#define DT_LNK     10
+#define DT_SOCK    12
+#define DT_WHT     14
+#define IFTODT(x)  ((x) >> 12 & 017)
+#define DTTOIF(x)  ((x) << 12)
+
+#endif //_DIRENT_H

--- a/ulib/c_libax/include/libgen.h
+++ b/ulib/c_libax/include/libgen.h
@@ -1,0 +1,15 @@
+#ifndef _LIBGEN_H
+#define _LIBGEN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *dirname(char *);
+char *basename(char *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ulib/c_libax/include/stdio.h
+++ b/ulib/c_libax/include/stdio.h
@@ -42,6 +42,7 @@ extern FILE *const stderr;
 
 #if defined(AX_CONFIG_ALLOC) && defined(AX_CONFIG_FS)
 FILE *fopen(const char *filename, const char *mode);
+char *fgets(char *__restrict, int, FILE *__restrict);
 #endif
 
 int fflush(FILE *);

--- a/ulib/c_libax/include/stdlib.h
+++ b/ulib/c_libax/include/stdlib.h
@@ -16,6 +16,11 @@ void *realloc(void *memblock, size_t size);
 _Noreturn void abort(void);
 char *getenv(const char *name);
 
+#ifdef AX_CONFIG_FP_SIMD
+float strtof(const char *__restrict, char **__restrict);
+double strtod(const char *__restrict, char **__restrict);
+#endif
+
 long strtol(const char *__restrict, char **__restrict, int);
 unsigned long strtoul(const char *nptr, char **endptr, int base);
 long long strtoll(const char *nptr, char **endptr, int base);

--- a/ulib/c_libax/include/string.h
+++ b/ulib/c_libax/include/string.h
@@ -20,8 +20,13 @@ char *strncat(char *restrict d, const char *restrict s, size_t n);
 int strcmp(const char *l, const char *r);
 int strncmp(const char *l, const char *r, size_t n);
 
+int strcoll(const char *, const char *);
+
 size_t strcspn(const char *s1, const char *s2);
 size_t strspn(const char *s, const char *c);
+char *strpbrk(const char *, const char *);
+
+char *strchrnul(const char *, int);
 
 char *strrchr(const char *str, int c);
 char *strchr(const char *str, int c);

--- a/ulib/c_libax/include/sys/epoll.h
+++ b/ulib/c_libax/include/sys/epoll.h
@@ -1,0 +1,60 @@
+#ifndef _SYS_EPOLL_H
+#define _SYS_EPOLL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <fcntl.h>
+#include <stdint.h>
+
+#define EPOLL_CLOEXEC  O_CLOEXEC
+#define EPOLL_NONBLOCK O_NONBLOCK
+
+enum EPOLL_EVENTS { __EPOLL_DUMMY };
+#define EPOLLIN        0x001
+#define EPOLLPRI       0x002
+#define EPOLLOUT       0x004
+#define EPOLLRDNORM    0x040
+#define EPOLLNVAL      0x020
+#define EPOLLRDBAND    0x080
+#define EPOLLWRNORM    0x100
+#define EPOLLWRBAND    0x200
+#define EPOLLMSG       0x400
+#define EPOLLERR       0x008
+#define EPOLLHUP       0x010
+#define EPOLLRDHUP     0x2000
+#define EPOLLEXCLUSIVE (1U << 28)
+#define EPOLLWAKEUP    (1U << 29)
+#define EPOLLONESHOT   (1U << 30)
+#define EPOLLET        (1U << 31)
+
+#define EPOLL_CTL_ADD 1
+#define EPOLL_CTL_DEL 2
+#define EPOLL_CTL_MOD 3
+
+typedef union epoll_data {
+    void *ptr;
+    int fd;
+    uint32_t u32;
+    uint64_t u64;
+} epoll_data_t;
+
+struct epoll_event {
+    uint32_t events;
+    epoll_data_t data;
+}
+#ifdef __x86_64__
+__attribute__((__packed__))
+#endif
+;
+
+int epoll_create(int __size);
+int epoll_ctl(int, int, int, struct epoll_event *);
+int epoll_wait(int, struct epoll_event *, int, int);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //_SYS_EPOLL_H

--- a/ulib/c_libax/include/time.h
+++ b/ulib/c_libax/include/time.h
@@ -34,4 +34,8 @@ time_t time(time_t *t);
 int clock_gettime(clockid_t _clk, struct timespec *ts);
 int nanosleep(const struct timespec *requested_time, struct timespec *remaining);
 
+#ifdef AX_CONFIG_FP_SIMD
+double difftime(time_t, time_t);
+#endif
+
 #endif

--- a/ulib/c_libax/src/dirent.c
+++ b/ulib/c_libax/src/dirent.c
@@ -1,0 +1,48 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifdef AX_CONFIG_ALLOC
+int closedir(DIR *dir)
+{
+    int ret = close(dir->fd);
+    free(dir);
+    return ret;
+}
+
+DIR *fdopendir(int fd)
+{
+    DIR *dir;
+    struct stat st;
+
+    if (fstat(fd, &st) < 0) {
+        return 0;
+    }
+    if (fcntl(fd, F_GETFL) & O_PATH) {
+        errno = EBADF;
+        return 0;
+    }
+    if (!S_ISDIR(st.st_mode)) {
+        errno = ENOTDIR;
+        return 0;
+    }
+    if (!(dir = calloc(1, sizeof(*dir)))) {
+        return 0;
+    }
+
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+    dir->fd = fd;
+    return dir;
+}
+
+#endif
+
+int dirfd(DIR *d)
+{
+    return d->fd;
+}

--- a/ulib/c_libax/src/env.c
+++ b/ulib/c_libax/src/env.c
@@ -1,0 +1,14 @@
+#include <string.h>
+#include <unistd.h>
+
+char **environ = 0;
+
+char *getenv(const char *name)
+{
+    size_t l = strchrnul(name, '=') - name;
+    if (l && !name[l] && environ)
+        for (char **e = environ; *e; e++)
+            if (!strncmp(name, *e, l) && l[*e] == '=')
+                return *e + l + 1;
+    return 0;
+}

--- a/ulib/c_libax/src/epoll.c
+++ b/ulib/c_libax/src/epoll.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <sys/epoll.h>
+
+#include <libax.h>
+
+int epoll_create(int size)
+{
+    return ax_epoll_create(size);
+}
+
+int epoll_ctl(int fd, int op, int fd2, struct epoll_event *ev)
+{
+    return ax_epoll_ctl(fd, op, fd2, ev);
+}
+
+int epoll_wait(int fd, struct epoll_event *ev, int cnt, int to)
+{
+    return ax_epoll_wait(fd, ev, cnt, to);
+}

--- a/ulib/c_libax/src/libgen.c
+++ b/ulib/c_libax/src/libgen.c
@@ -1,0 +1,33 @@
+#include <libgen.h>
+#include <string.h>
+
+char *dirname(char *s)
+{
+    size_t i;
+    if (!s || !*s)
+        return ".";
+    i = strlen(s) - 1;
+    for (; s[i] == '/'; i--)
+        if (!i)
+            return "/";
+    for (; s[i] != '/'; i--)
+        if (!i)
+            return ".";
+    for (; s[i] == '/'; i--)
+        if (!i)
+            return "/";
+    s[i + 1] = 0;
+    return s;
+}
+
+char *basename(char *s)
+{
+    size_t i;
+    if (!s || !*s)
+        return ".";
+    i = strlen(s) - 1;
+    for (; i && s[i] == '/'; i--) s[i] = 0;
+    for (; i && s[i - 1] != '/'; i--)
+        ;
+    return s + i;
+}

--- a/ulib/c_libax/src/math.c
+++ b/ulib/c_libax/src/math.c
@@ -93,4 +93,5 @@ double floor(double x)
         return x + y - 1;
     return x + y;
 }
+
 #endif

--- a/ulib/c_libax/src/stdio.c
+++ b/ulib/c_libax/src/stdio.c
@@ -204,4 +204,28 @@ FILE *fopen(const char *filename, const char *mode)
     return f;
 }
 
+char *fgets(char *restrict s, int n, FILE *restrict f)
+{
+    if (n == 0)
+        return NULL;
+    if (n == 1) {
+        *s = '\0';
+        return s;
+    }
+
+    int cnt = 0;
+    while (cnt < n - 1) {
+        char c;
+        if (ax_read(f->fd, (void *)&c, 1) > 0) {
+            if (c != '\n')
+                s[cnt++] = c;
+            else
+                break;
+        } else
+            break;
+    }
+    s[cnt] = '\0';
+    return s;
+}
+
 #endif

--- a/ulib/c_libax/src/stdlib.c
+++ b/ulib/c_libax/src/stdlib.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <libax.h>
 
@@ -36,6 +37,9 @@ void *calloc(size_t m, size_t n)
 
 void *realloc(void *memblock, size_t size)
 {
+    if (!memblock)
+        return malloc(size);
+
     size_t o_size = *(size_t *)(memblock - 8);
 
     void *mem = ax_malloc(size);
@@ -49,6 +53,8 @@ void *realloc(void *memblock, size_t size)
 
 void free(void *addr)
 {
+    if (!addr)
+        return;
     return ax_free(addr);
 }
 
@@ -58,13 +64,6 @@ _Noreturn void abort(void)
 {
     ax_panic();
     __builtin_unreachable();
-}
-
-// TODO:
-char *getenv(const char *name)
-{
-    unimplemented();
-    return 0;
 }
 
 // TODO:
@@ -377,3 +376,16 @@ long long atoll(const char *s)
     while (isdigit(*s)) n = 10 * n - (*s++ - '0');
     return neg ? n : -n;
 }
+
+#ifdef AX_CONFIG_FP_SIMD
+float strtof(const char *restrict s, char **restrict p)
+{
+    return ax_strtof(s, p);
+}
+
+double strtod(const char *restrict s, char **restrict p)
+{
+    return ax_strtod(s, p);
+}
+
+#endif

--- a/ulib/c_libax/src/string.c
+++ b/ulib/c_libax/src/string.c
@@ -131,6 +131,11 @@ int strncmp(const char *_l, const char *_r, size_t n)
     return *l - *r;
 }
 
+int strcoll(const char *l, const char *r)
+{
+    return strcmp(l, r);
+}
+
 #define BITOP(a, b, op) \
     ((a)[(size_t)(b) / (8 * sizeof *(a))] op(size_t) 1 << ((size_t)(b) % (8 * sizeof *(a))))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -171,6 +176,23 @@ size_t strspn(const char *s, const char *c)
     for (; *s && BITOP(byteset, *(unsigned char *)s, &); s++)
         ;
     return s - a;
+}
+
+char *strpbrk(const char *s, const char *b)
+{
+    s += strcspn(s, b);
+    return *s ? (char *)s : 0;
+}
+
+char *strchrnul(const char *s, int c)
+{
+    c = (unsigned char)c;
+    if (!c)
+        return (char *)s + strlen(s);
+
+    for (; *s && *(unsigned char *)s != c; s++)
+        ;
+    return (char *)s;
 }
 
 char *strchr(const char *s, int c)

--- a/ulib/c_libax/src/time.c
+++ b/ulib/c_libax/src/time.c
@@ -177,3 +177,10 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
 {
     return ax_nanosleep(req, rem);
 }
+
+#ifdef AX_CONFIG_FP_SIMD
+double difftime(time_t t1, time_t t0)
+{
+    return t1 - t0;
+}
+#endif

--- a/ulib/libax/build.rs
+++ b/ulib/libax/build.rs
@@ -68,6 +68,7 @@ typedef struct {{
             "fd.*",
             "timeval",
             "pthread_.*",
+            "epoll_event",
         ];
         let allow_vars = [
             "O_.*",
@@ -79,6 +80,8 @@ typedef struct {{
             "_SC_.*",
             "SO_.*",
             "SOL_.*",
+            "EPOLL_CTL_.*",
+            "EPOLL.*",
         ];
 
         #[derive(Debug)]

--- a/ulib/libax/cbindgen.toml
+++ b/ulib/libax/cbindgen.toml
@@ -8,6 +8,7 @@ sys_includes = [
     "sys/stat.h",
     "stdio.h",
     "time.h",
+    "sys/epoll.h",
     "sys/socket.h",
     "sys/select.h",
     "sys/time.h",
@@ -20,6 +21,7 @@ includes = ["axconfig.h"]
 "sockaddr" = "struct sockaddr"
 "timespec" = "struct timespec"
 "timeval" = "struct timeval"
+"epoll_event" = "struct epoll_event"
 
 [fn]
 no_return = "__attribute__((noreturn))"

--- a/ulib/libax/ctypes.h
+++ b/ulib/libax/ctypes.h
@@ -1,14 +1,14 @@
 #include <fcntl.h>
-#include <stddef.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/select.h>
-#include <netinet/in.h>
 #include <netdb.h>
-#include <stdio.h>
-#include <setjmp.h>
-#include <unistd.h>
+#include <netinet/in.h>
 #include <pthread.h>
-   
+#include <setjmp.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <sys/epoll.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>

--- a/ulib/libax/src/cbindings/io_mpx/epoll.rs
+++ b/ulib/libax/src/cbindings/io_mpx/epoll.rs
@@ -1,0 +1,207 @@
+//! `epoll` implementation.
+//!
+//! TODO: do not support `EPOLLET` flag
+
+use crate::cbindings::{
+    ctypes,
+    fd_ops::{add_file_like, get_file_like, FileLike},
+};
+use crate::debug;
+use crate::sync::Mutex;
+use axerrno::{LinuxError, LinuxResult};
+use axhal::time::current_time;
+
+use alloc::collections::btree_map::Entry;
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use core::{ffi::c_int, time::Duration};
+
+pub struct EpollInstance {
+    events: Mutex<BTreeMap<usize, ctypes::epoll_event>>,
+}
+
+unsafe impl Send for ctypes::epoll_event {}
+unsafe impl Sync for ctypes::epoll_event {}
+
+impl EpollInstance {
+    // TODO: parse flags
+    pub fn new(_flags: usize) -> Self {
+        Self {
+            events: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    fn from_fd(fd: c_int) -> LinuxResult<Arc<Self>> {
+        get_file_like(fd)?
+            .into_any()
+            .downcast::<EpollInstance>()
+            .map_err(|_| LinuxError::EINVAL)
+    }
+
+    fn control(&self, op: usize, fd: usize, event: &ctypes::epoll_event) -> LinuxResult<usize> {
+        match get_file_like(fd as c_int) {
+            Ok(_) => {}
+            Err(e) => return Err(e),
+        }
+
+        match op as u32 {
+            ctypes::EPOLL_CTL_ADD => {
+                if let Entry::Vacant(e) = self.events.lock().entry(fd) {
+                    e.insert(*event);
+                } else {
+                    return Err(LinuxError::EEXIST);
+                }
+            }
+            ctypes::EPOLL_CTL_MOD => {
+                let mut events = self.events.lock();
+                if let Entry::Occupied(mut ocp) = events.entry(fd) {
+                    ocp.insert(*event);
+                } else {
+                    return Err(LinuxError::ENOENT);
+                }
+            }
+            ctypes::EPOLL_CTL_DEL => {
+                let mut events = self.events.lock();
+                if let Entry::Occupied(ocp) = events.entry(fd) {
+                    ocp.remove_entry();
+                } else {
+                    return Err(LinuxError::ENOENT);
+                }
+            }
+            _ => {
+                return Err(LinuxError::EINVAL);
+            }
+        }
+        Ok(0)
+    }
+
+    fn poll_all(&self, events: &mut [ctypes::epoll_event]) -> LinuxResult<usize> {
+        let ready_list = self.events.lock();
+        let mut events_num = 0;
+
+        for (infd, ev) in ready_list.iter() {
+            match get_file_like(*infd as c_int)?.poll() {
+                Err(_) => {
+                    if (ev.events & ctypes::EPOLLERR) != 0 {
+                        events[events_num].events = ctypes::EPOLLERR;
+                        events[events_num].data = ev.data;
+                        events_num += 1;
+                    }
+                }
+                Ok(state) => {
+                    if state.readable && (ev.events & ctypes::EPOLLIN != 0) {
+                        events[events_num].events = ctypes::EPOLLIN;
+                        events[events_num].data = ev.data;
+                        events_num += 1;
+                    }
+
+                    if state.writable && (ev.events & ctypes::EPOLLOUT != 0) {
+                        events[events_num].events = ctypes::EPOLLOUT;
+                        events[events_num].data = ev.data;
+                        events_num += 1;
+                    }
+                }
+            }
+        }
+        Ok(events_num)
+    }
+}
+
+impl FileLike for EpollInstance {
+    fn read(&self, _buf: &mut [u8]) -> LinuxResult<usize> {
+        Err(LinuxError::ENOSYS)
+    }
+
+    fn write(&self, _buf: &[u8]) -> LinuxResult<usize> {
+        Err(LinuxError::ENOSYS)
+    }
+
+    fn stat(&self) -> LinuxResult<ctypes::stat> {
+        let st_mode = 0o600u32; // rw-------
+        Ok(ctypes::stat {
+            st_ino: 1,
+            st_nlink: 1,
+            st_mode,
+            ..Default::default()
+        })
+    }
+
+    fn into_any(self: Arc<Self>) -> alloc::sync::Arc<dyn core::any::Any + Send + Sync> {
+        self
+    }
+
+    fn poll(&self) -> LinuxResult<axio::PollState> {
+        Err(LinuxError::ENOSYS)
+    }
+
+    fn set_nonblocking(&self, _nonblocking: bool) -> LinuxResult {
+        Ok(())
+    }
+}
+
+/// `ax_epoll_create()` creates a new epoll instance.
+///
+/// `ax_epoll_create()` returns a file descriptor referring to the new epoll instance.
+#[no_mangle]
+pub unsafe extern "C" fn ax_epoll_create(size: c_int) -> c_int {
+    debug!("ax_epoll_create <= {}", size);
+    ax_call_body!(ax_epoll_create, {
+        if size < 0 {
+            return Err(LinuxError::EINVAL);
+        }
+        let epoll_instance = EpollInstance::new(0);
+        add_file_like(Arc::new(epoll_instance))
+    })
+}
+
+/// Control interface for an epoll file descriptor
+#[no_mangle]
+pub unsafe extern "C" fn ax_epoll_ctl(
+    epfd: c_int,
+    op: c_int,
+    fd: c_int,
+    event: *mut ctypes::epoll_event,
+) -> c_int {
+    debug!("ax_epoll_ctl <= epfd: {} op: {} fd: {}", epfd, op, fd);
+    ax_call_body!(ax_epoll_ctl, {
+        let ret =
+            EpollInstance::from_fd(epfd)?.control(op as usize, fd as usize, &(*event))? as c_int;
+        Ok(ret)
+    })
+}
+
+/// `ax_epoll_wait()` waits for events on the epoll instance referred to by the file descriptor epfd.
+#[no_mangle]
+pub unsafe extern "C" fn ax_epoll_wait(
+    epfd: c_int,
+    events: *mut ctypes::epoll_event,
+    maxevents: c_int,
+    timeout: c_int,
+) -> c_int {
+    debug!(
+        "ax_epoll_wait <= epfd: {}, maxevents: {}, timeout: {}",
+        epfd, maxevents, timeout
+    );
+
+    ax_call_body!(ax_epoll_wait, {
+        if maxevents <= 0 {
+            return Err(LinuxError::EINVAL);
+        }
+        let events = core::slice::from_raw_parts_mut(events, maxevents as usize);
+        let deadline = (!timeout.is_negative())
+            .then(|| current_time() + Duration::from_millis(timeout as u64));
+        let epoll_instance = EpollInstance::from_fd(epfd)?;
+        loop {
+            let events_num = epoll_instance.poll_all(events)?;
+            if events_num > 0 {
+                return Ok(events_num as c_int);
+            }
+
+            if deadline.map_or(false, |ddl| current_time() >= ddl) {
+                debug!("    timeout!");
+                return Ok(0);
+            }
+            crate::thread::yield_now();
+        }
+    })
+}

--- a/ulib/libax/src/cbindings/io_mpx/mod.rs
+++ b/ulib/libax/src/cbindings/io_mpx/mod.rs
@@ -1,7 +1,12 @@
 //! I/O multiplexing:
 //!
 //! * [`select`](select::ax_select)
+//! * [`epoll_create`](epoll::ax_epoll_create)
+//! * [`epoll_ctl`](epoll::ax_epoll_ctl)
+//! * [`epoll_wait`](epoll::ax_epoll_wait)
 
+mod epoll;
 mod select;
 
+pub use self::epoll::{ax_epoll_create, ax_epoll_ctl, ax_epoll_wait};
 pub use self::select::ax_select;

--- a/ulib/libax/src/cbindings/mod.rs
+++ b/ulib/libax/src/cbindings/mod.rs
@@ -25,6 +25,8 @@ mod pipe;
 mod pthread;
 #[cfg(feature = "net")]
 mod socket;
+#[cfg(feature = "fp_simd")]
+mod strtod;
 
 mod errno;
 mod setjmp;
@@ -82,7 +84,10 @@ pub use self::pthread::{ax_getpid, ax_pthread_create, ax_pthread_exit, ax_pthrea
 pub use self::pipe::ax_pipe;
 
 #[cfg(feature = "alloc")]
-pub use self::io_mpx::ax_select;
+pub use self::io_mpx::{ax_epoll_create, ax_epoll_ctl, ax_epoll_wait, ax_select};
+
+#[cfg(feature = "fp_simd")]
+pub use self::strtod::{ax_strtod, ax_strtof};
 
 pub use self::errno::ax_errno_string;
 pub use self::stdio::{ax_print_str, ax_println_str};

--- a/ulib/libax/src/cbindings/strtod.rs
+++ b/ulib/libax/src/cbindings/strtod.rs
@@ -1,0 +1,131 @@
+use core::ffi::{c_char, c_double, c_float, c_int};
+
+macro_rules! strto_float_impl {
+    ($type:ident, $s:expr, $endptr:expr) => {{
+        let mut s = $s;
+        let endptr = $endptr;
+
+        // TODO: Handle named floats: NaN, Inf...
+
+        while isspace(*s as c_int) {
+            s = s.offset(1);
+        }
+
+        let mut result: $type = 0.0;
+        let mut radix = 10;
+
+        let result_sign = match *s as u8 {
+            b'-' => {
+                s = s.offset(1);
+                -1.0
+            }
+            b'+' => {
+                s = s.offset(1);
+                1.0
+            }
+            _ => 1.0,
+        };
+
+        if *s as u8 == b'0' && *s.offset(1) as u8 == b'x' {
+            s = s.offset(2);
+            radix = 16;
+        }
+
+        while let Some(digit) = (*s as u8 as char).to_digit(radix) {
+            result *= radix as $type;
+            result += digit as $type;
+            s = s.offset(1);
+        }
+
+        if *s as u8 == b'.' {
+            s = s.offset(1);
+
+            let mut i = 1.0;
+            while let Some(digit) = (*s as u8 as char).to_digit(radix) {
+                i *= radix as $type;
+                result += digit as $type / i;
+                s = s.offset(1);
+            }
+        }
+
+        let s_before_exponent = s;
+
+        let exponent = match (*s as u8, radix) {
+            (b'e' | b'E', 10) | (b'p' | b'P', 16) => {
+                s = s.offset(1);
+
+                let is_exponent_positive = match *s as u8 {
+                    b'-' => {
+                        s = s.offset(1);
+                        false
+                    }
+                    b'+' => {
+                        s = s.offset(1);
+                        true
+                    }
+                    _ => true,
+                };
+
+                // Exponent digits are always in base 10.
+                if (*s as u8 as char).is_digit(10) {
+                    let mut exponent_value = 0;
+
+                    while let Some(digit) = (*s as u8 as char).to_digit(10) {
+                        exponent_value *= 10;
+                        exponent_value += digit;
+                        s = s.offset(1);
+                    }
+
+                    let exponent_base = match radix {
+                        10 => 10u128,
+                        16 => 2u128,
+                        _ => unreachable!(),
+                    };
+
+                    if is_exponent_positive {
+                        Some(exponent_base.pow(exponent_value) as $type)
+                    } else {
+                        Some(1.0 / (exponent_base.pow(exponent_value) as $type))
+                    }
+                } else {
+                    // Exponent had no valid digits after 'e'/'p' and '+'/'-', rollback
+                    s = s_before_exponent;
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        // Return pointer should be *mut
+        if !endptr.is_null() {
+            *endptr = s as *mut _;
+        }
+
+        if let Some(exponent) = exponent {
+            result_sign * result * exponent
+        } else {
+            result_sign * result
+        }
+    }};
+}
+
+fn isspace(c: c_int) -> bool {
+    c == c_int::from(b' ')
+        || c == c_int::from(b'\t')
+        || c == c_int::from(b'\n')
+        || c == c_int::from(b'\r')
+        || c == 0x0b
+        || c == 0x0c
+}
+
+/// `strtod` implementation
+#[no_mangle]
+pub unsafe extern "C" fn ax_strtod(s: *const c_char, endptr: *mut *mut c_char) -> c_double {
+    strto_float_impl!(c_double, s, endptr)
+}
+
+/// `strtof`implementation
+#[no_mangle]
+pub unsafe extern "C" fn ax_strtof(s: *const c_char, endptr: *mut *mut c_char) -> c_float {
+    strto_float_impl!(c_float, s, endptr)
+}


### PR DESCRIPTION
- Add epoll implementation
  - `epoll_create`, `epoll_ctl`, `epoll_wait`
- More libc functions especially `strto`-float
  - [x] `strtof`
  - [x] `strtod`
  - [ ] `strtold`. Something wrong with `long double` type in riscv64.
  - other conversion function like `strtol` remains the same because their "C" implementations are more concise.