### PR TITLE
Microkernel: some minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 actual.out
 qemu.log
 tools/fat32-pack/target
+/modules/axuser/user.elf

--- a/make_disk.sh
+++ b/make_disk.sh
@@ -7,7 +7,7 @@ set -e
 ARCH=riscv64
 RELEASE=riscv64gc-unknown-none-elf
 
-rm disk.img
+rm disk.img || true;
 make disk_img
 make A=apps/microkernel/net_deamon MICRO=y ARCH=$ARCH build_user
 make A=apps/microkernel/apps MICRO_TEST=shell MICRO=y ARCH=$ARCH build_user


### PR DESCRIPTION
There are some minor issues in `.gitignore` file and a helper script file.
+ One temporary file was not included in `.gitignore`
+ `make_disk.sh` did not run properly when `disk.img` was not present.