### PR TITLE
Libc: More libc functions for Redis

### DIFF
--- a/ulib/c_libax/include/stddef.h
+++ b/ulib/c_libax/include/stddef.h
@@ -9,12 +9,19 @@ typedef uintptr_t size_t;
 typedef intptr_t ssize_t;
 typedef ssize_t ptrdiff_t;
 
+typedef long clock_t;
 typedef int clockid_t;
 
 #ifdef __cplusplus
 #define NULL 0L
 #else
 #define NULL ((void *)0)
+#endif
+
+#if __GNUC__ > 3
+#define offsetof(type, member) __builtin_offsetof(type, member)
+#else
+#define offsetof(type, member) ((size_t)((char *)&(((type *)0)->member) - (char *)0))
 #endif
 
 #endif // __STDDEF_H__

--- a/ulib/c_libax/include/stdio.h
+++ b/ulib/c_libax/include/stdio.h
@@ -4,6 +4,10 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+
 #define FILE_BUF_SIZE 1024
 // TODO: complete this struct
 struct IO_FILE {
@@ -39,6 +43,8 @@ extern FILE *const stderr;
 #define UNGET  8
 
 #define FILENAME_MAX 4096
+#define BUFSIZ       1024
+#define L_tmpnam     20
 
 #if defined(AX_CONFIG_ALLOC) && defined(AX_CONFIG_FS)
 FILE *fopen(const char *filename, const char *mode);
@@ -47,14 +53,15 @@ char *fgets(char *__restrict, int, FILE *__restrict);
 
 int fflush(FILE *);
 
-int getchar();
+int getchar(void);
 
 int fputc(int, FILE *);
 int putc(int, FILE *);
 int putchar(int);
-
 int fputs(const char *__restrict, FILE *__restrict);
 int puts(const char *s);
+
+int sscanf(const char *__restrict, const char *__restrict, ...);
 
 int printf(const char *__restrict, ...);
 int fprintf(FILE *__restrict, const char *__restrict, ...);
@@ -64,6 +71,38 @@ int snprintf(char *__restrict, size_t, const char *__restrict, ...);
 int vfprintf(FILE *__restrict, const char *__restrict, va_list);
 int vsprintf(char *__restrict, const char *__restrict, va_list);
 int vsnprintf(char *__restrict, size_t, const char *__restrict, va_list);
+
+size_t fread(void *__restrict, size_t, size_t, FILE *__restrict);
+size_t fwrite(const void *__restrict, size_t, size_t, FILE *__restrict);
+
+int fclose(FILE *);
+
+int rename(const char *__old, const char *__new);
+
+int fileno(FILE *__stream);
+int feof(FILE *__stream);
+int fseek(FILE *__stream, long __off, int __whence);
+long ftello(FILE *__stream);
+char *tmpnam(char *);
+
+void clearerr(FILE *);
+int ferror(FILE *);
+FILE *freopen(const char *__restrict, const char *__restrict, FILE *__restrict);
+int fscanf(FILE *__restrict, const char *__restrict, ...);
+long ftell(FILE *);
+int getc(FILE *);
+int remove(const char *);
+int setvbuf(FILE *__restrict, char *__restrict, int, size_t);
+FILE *tmpfile(void);
+int ungetc(int, FILE *);
+
+ssize_t getdelim(char **__restrict, size_t *__restrict, int, FILE *__restrict);
+ssize_t getline(char **__restrict, size_t *__restrict, FILE *__restrict);
+
+int __uflow(FILE *f);
+int getc_unlocked(FILE *);
+
+FILE *fdopen(int, const char *);
 
 void perror(const char *);
 

--- a/ulib/c_libax/include/string.h
+++ b/ulib/c_libax/include/string.h
@@ -44,6 +44,8 @@ void *memmove(void *dest, const void *src, size_t n);
 
 int memcmp(const void *vl, const void *vr, size_t n);
 
+int strerror_r(int, char *, size_t);
+
 #ifdef AX_CONFIG_ALLOC
 char *strdup(const char *__s);
 #endif

--- a/ulib/c_libax/include/sys/resource.h
+++ b/ulib/c_libax/include/sys/resource.h
@@ -33,7 +33,31 @@ struct rlimit {
 #define RUSAGE_SELF     0
 #define RUSAGE_CHILDREN -1
 
+struct rusage {
+    struct timeval ru_utime;
+    struct timeval ru_stime;
+    /* linux extentions, but useful */
+    long ru_maxrss;
+    long ru_ixrss;
+    long ru_idrss;
+    long ru_isrss;
+    long ru_minflt;
+    long ru_majflt;
+    long ru_nswap;
+    long ru_inblock;
+    long ru_oublock;
+    long ru_msgsnd;
+    long ru_msgrcv;
+    long ru_nsignals;
+    long ru_nvcsw;
+    long ru_nivcsw;
+    /* room for more... */
+    long __reserved[16];
+};
+
 int setrlimit(int __resource, struct rlimit *__rlimits);
 int getrlimit(int __resource, struct rlimit *__rlimits);
+
+int getrusage(int __who, struct rusage *__usage);
 
 #endif

--- a/ulib/c_libax/include/sys/socket.h
+++ b/ulib/c_libax/include/sys/socket.h
@@ -1,7 +1,129 @@
 #ifndef __SOCKET_H__
 #define __SOCKET_H__
 
+#include <endian.h>
+#include <limits.h>
 #include <stddef.h>
+
+typedef unsigned short sa_family_t;
+typedef unsigned int socklen_t;
+
+struct msghdr {
+    void *msg_name;
+    socklen_t msg_namelen;
+    struct iovec *msg_iov;
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __BIG_ENDIAN
+    int __pad1;
+#endif
+    int msg_iovlen;
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __LITTLE_ENDIAN
+    int __pad1;
+#endif
+    void *msg_control;
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __BIG_ENDIAN
+    int __pad2;
+#endif
+    socklen_t msg_controllen;
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __LITTLE_ENDIAN
+    int __pad2;
+#endif
+    int msg_flags;
+};
+
+struct cmsghdr {
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __BIG_ENDIAN
+    int __pad1;
+#endif
+    socklen_t cmsg_len;
+#if __LONG_MAX > 0x7fffffff && __BYTE_ORDER == __LITTLE_ENDIAN
+    int __pad1;
+#endif
+    int cmsg_level;
+    int cmsg_type;
+};
+
+struct sockaddr {
+    sa_family_t sa_family;
+    char sa_data[14];
+};
+
+struct sockaddr_storage {
+    sa_family_t ss_family;
+    char __ss_padding[128 - sizeof(long) - sizeof(sa_family_t)];
+    unsigned long __ss_align;
+};
+
+typedef unsigned socklen_t;
+
+#if defined(AX_CONFIG_NET)
+int socket(int, int, int);
+int shutdown(int, int);
+
+int bind(int, const struct sockaddr *, socklen_t);
+int connect(int, const struct sockaddr *, socklen_t);
+int listen(int, int);
+int accept(int, struct sockaddr *__restrict, socklen_t *__restrict);
+int accept4(int, struct sockaddr *__restrict, socklen_t *__restrict, int);
+
+ssize_t send(int, const void *, size_t, int);
+ssize_t recv(int, void *, size_t, int);
+ssize_t sendto(int, const void *, size_t, int, const struct sockaddr *, socklen_t);
+ssize_t recvfrom(int, void *__restrict, size_t, int, struct sockaddr *__restrict,
+                 socklen_t *__restrict);
+ssize_t sendmsg(int, const struct msghdr *, int);
+
+int getsockopt(int, int, int, void *__restrict, socklen_t *__restrict);
+int setsockopt(int, int, int, const void *, socklen_t);
+
+int getsockname(int sockfd, struct sockaddr *restrict addr, socklen_t *restrict addrlen);
+int getpeername(int sockfd, struct sockaddr *restrict addr, socklen_t *restrict addrlen);
+
+#endif
+
+#define SO_BINDTODEVICE            25
+#define SO_ATTACH_FILTER           26
+#define SO_DETACH_FILTER           27
+#define SO_GET_FILTER              SO_ATTACH_FILTER
+#define SO_PEERNAME                28
+#define SO_ACCEPTCONN              30
+#define SO_PEERSEC                 31
+#define SO_PASSSEC                 34
+#define SO_MARK                    36
+#define SO_RXQ_OVFL                40
+#define SO_WIFI_STATUS             41
+#define SCM_WIFI_STATUS            SO_WIFI_STATUS
+#define SO_PEEK_OFF                42
+#define SO_NOFCS                   43
+#define SO_LOCK_FILTER             44
+#define SO_SELECT_ERR_QUEUE        45
+#define SO_BUSY_POLL               46
+#define SO_MAX_PACING_RATE         47
+#define SO_BPF_EXTENSIONS          48
+#define SO_INCOMING_CPU            49
+#define SO_ATTACH_BPF              50
+#define SO_DETACH_BPF              SO_DETACH_FILTER
+#define SO_ATTACH_REUSEPORT_CBPF   51
+#define SO_ATTACH_REUSEPORT_EBPF   52
+#define SO_CNX_ADVICE              53
+#define SCM_TIMESTAMPING_OPT_STATS 54
+#define SO_MEMINFO                 55
+#define SO_INCOMING_NAPI_ID        56
+#define SO_COOKIE                  57
+#define SCM_TIMESTAMPING_PKTINFO   58
+#define SO_PEERGROUPS              59
+#define SO_ZEROCOPY                60
+#define SO_TXTIME                  61
+#define SCM_TXTIME                 SO_TXTIME
+#define SO_BINDTOIFINDEX           62
+#define SO_DETACH_REUSEPORT_BPF    68
+#define SO_PREFER_BUSY_POLL        69
+#define SO_BUSY_POLL_BUDGET        70
+
+#define MSG_NOSIGNAL 0x4000
+
+#define SHUT_RD   0
+#define SHUT_WR   1
+#define SHUT_RDWR 2
 
 #ifndef SOCK_STREAM
 #define SOCK_STREAM 1
@@ -145,6 +267,10 @@
 #define SO_PROTOCOL    38
 #define SO_DOMAIN      39
 
+#define SO_SECURITY_AUTHENTICATION       22
+#define SO_SECURITY_ENCRYPTION_TRANSPORT 23
+#define SO_SECURITY_ENCRYPTION_NETWORK   24
+
 #define SOL_SOCKET 1
 
 #define SOL_IP     0
@@ -176,40 +302,14 @@
 #define SOL_TLS       282
 #define SOL_XDP       283
 
-typedef unsigned short sa_family_t;
-struct sockaddr {
-    sa_family_t sa_family;
-    char sa_data[14];
-};
-
-struct sockaddr_storage {
-    sa_family_t ss_family;
-    char __ss_padding[128 - sizeof(long) - sizeof(sa_family_t)];
-    unsigned long __ss_align;
-};
-
-typedef unsigned socklen_t;
-
-#if defined(AX_CONFIG_NET)
-int socket(int, int, int);
-int shutdown(int, int);
-
-int bind(int, const struct sockaddr *, socklen_t);
-int connect(int, const struct sockaddr *, socklen_t);
-int listen(int, int);
-int accept(int, struct sockaddr *__restrict, socklen_t *__restrict);
-
-ssize_t send(int, const void *, size_t, int);
-ssize_t recv(int, void *, size_t, int);
-ssize_t sendto(int, const void *, size_t, int, const struct sockaddr *, socklen_t);
-ssize_t recvfrom(int, void *__restrict, size_t, int, struct sockaddr *__restrict,
-                 socklen_t *__restrict);
-
-int getsockopt(int, int, int, void *__restrict, socklen_t *__restrict);
-int setsockopt(int, int, int, const void *, socklen_t);
-
-int getsockname(int sockfd, struct sockaddr *restrict addr, socklen_t *restrict addrlen);
-int getpeername(int sockfd, struct sockaddr *restrict addr, socklen_t *restrict addrlen);
-
+#ifndef SO_RCVTIMEO_OLD
+#define SO_RCVTIMEO_OLD 20
 #endif
+#ifndef SO_SNDTIMEO_OLD
+#define SO_SNDTIMEO_OLD 21
+#endif
+
+#define SO_RCVTIMEO SO_RCVTIMEO_OLD
+#define SO_SNDTIMEO SO_SNDTIMEO_OLD
+
 #endif

--- a/ulib/c_libax/include/sys/stat.h
+++ b/ulib/c_libax/include/sys/stat.h
@@ -70,7 +70,9 @@ int fstat(int fd, struct stat *buf);
 int lstat(const char *path, struct stat *buf);
 
 int fchmod(int fd, mode_t mode);
-
+int chmod(const char *file, mode_t mode);
 int mkdir(const char *pathname, mode_t mode);
+mode_t umask(mode_t mask);
+int fstatat(int, const char *__restrict, struct stat *__restrict, int);
 
 #endif

--- a/ulib/c_libax/include/sys/time.h
+++ b/ulib/c_libax/include/sys/time.h
@@ -3,6 +3,11 @@
 
 #include <stdint.h>
 
+#define ITIMER_REAL    0
+#define ITIMER_VIRTUAL 1
+#define ITIMER_PROF    2
+
+extern long timezone;
 typedef long time_t;
 
 struct timeval {
@@ -20,6 +25,11 @@ typedef struct timespec timespec;
 struct timezone {
     int tz_minuteswest; /* (minutes west of Greenwich) */
     int tz_dsttime;     /* (type of DST correction) */
+};
+
+struct itimerval {
+    struct timeval it_interval;
+    struct timeval it_value;
 };
 
 int gettimeofday(struct timeval *tv, struct timezone *tz);

--- a/ulib/c_libax/include/sys/uio.h
+++ b/ulib/c_libax/include/sys/uio.h
@@ -1,0 +1,13 @@
+#ifndef _SYS_UIO_H
+#define _SYS_UIO_H
+
+#include <stddef.h>
+
+struct iovec {
+    void *iov_base; /* Pointer to data.  */
+    size_t iov_len; /* Length of data.  */
+};
+
+ssize_t writev(int, const struct iovec *, int);
+
+#endif

--- a/ulib/c_libax/include/sys/utsname.h
+++ b/ulib/c_libax/include/sys/utsname.h
@@ -1,0 +1,27 @@
+#ifndef _SYS_UTSNAME_H
+#define _SYS_UTSNAME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct utsname {
+    char sysname[65];
+    char nodename[65];
+    char release[65];
+    char version[65];
+    char machine[65];
+#ifdef _GNU_SOURCE
+    char domainname[65];
+#else
+    char __domainname[65];
+#endif
+};
+
+int uname(struct utsname *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/ulib/c_libax/include/sys/wait.h
+++ b/ulib/c_libax/include/sys/wait.h
@@ -1,0 +1,12 @@
+#ifndef _SYS_WAIT_H
+#define _SYS_WAIT_H
+
+#include <sys/resource.h>
+#include <sys/types.h>
+
+#define WNOHANG 1
+
+pid_t waitpid(pid_t __pid, int *__stat_loc, int __options);
+pid_t wait3(int *, int, struct rusage *);
+
+#endif

--- a/ulib/c_libax/include/syslog.h
+++ b/ulib/c_libax/include/syslog.h
@@ -1,0 +1,45 @@
+#ifndef _SYSLOG_H
+#define _SYSLOG_H
+
+#define LOG_EMERG   0
+#define LOG_ALERT   1
+#define LOG_CRIT    2
+#define LOG_ERR     3
+#define LOG_WARNING 4
+#define LOG_NOTICE  5
+#define LOG_INFO    6
+#define LOG_DEBUG   7
+
+#define LOG_PID    0x01
+#define LOG_CONS   0x02
+#define LOG_ODELAY 0x04
+#define LOG_NDELAY 0x08
+#define LOG_NOWAIT 0x10
+#define LOG_PERROR 0x20
+
+#define LOG_KERN     (0 << 3)
+#define LOG_USER     (1 << 3)
+#define LOG_MAIL     (2 << 3)
+#define LOG_DAEMON   (3 << 3)
+#define LOG_AUTH     (4 << 3)
+#define LOG_SYSLOG   (5 << 3)
+#define LOG_LPR      (6 << 3)
+#define LOG_NEWS     (7 << 3)
+#define LOG_UUCP     (8 << 3)
+#define LOG_CRON     (9 << 3)
+#define LOG_AUTHPRIV (10 << 3)
+#define LOG_FTP      (11 << 3)
+
+#define LOG_LOCAL0 (16 << 3)
+#define LOG_LOCAL1 (17 << 3)
+#define LOG_LOCAL2 (18 << 3)
+#define LOG_LOCAL3 (19 << 3)
+#define LOG_LOCAL4 (20 << 3)
+#define LOG_LOCAL5 (21 << 3)
+#define LOG_LOCAL6 (22 << 3)
+#define LOG_LOCAL7 (23 << 3)
+
+void syslog(int, const char *, ...);
+void openlog(const char *, int, int);
+
+#endif

--- a/ulib/c_libax/include/time.h
+++ b/ulib/c_libax/include/time.h
@@ -6,6 +6,9 @@
 
 typedef long time_t;
 
+extern long timezone;
+extern const char __utc[];
+
 #define CLOCK_REALTIME  0
 #define CLOCK_MONOTONIC 1
 #define CLOCKS_PER_SEC  1000000L
@@ -30,9 +33,22 @@ size_t strftime(char *__restrict__ _Buf, size_t _SizeInBytes, const char *__rest
 struct tm *gmtime(const time_t *timer);
 
 struct tm *localtime(const time_t *timep);
+struct tm *localtime_r(const time_t *__restrict__ __timer, struct tm *__restrict__ __tp);
+
 time_t time(time_t *t);
 int clock_gettime(clockid_t _clk, struct timespec *ts);
 int nanosleep(const struct timespec *requested_time, struct timespec *remaining);
+void tzset(void);
+
+int setitimer(int which, const struct itimerval *restrict new, struct itimerval *restrict old);
+char *ctime_r(const time_t *t, char *buf);
+clock_t clock(void);
+
+#ifdef AX_CONFIG_FP_SIMD
+double difftime(time_t, time_t);
+#endif
+
+time_t mktime(struct tm *);
 
 #ifdef AX_CONFIG_FP_SIMD
 double difftime(time_t, time_t);

--- a/ulib/c_libax/include/unistd.h
+++ b/ulib/c_libax/include/unistd.h
@@ -4,6 +4,14 @@
 #include <stddef.h>
 #include <sys/stat.h>
 
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+#define X_OK 1
+#define F_OK 0
+#define W_OK 2
+
 #ifdef AX_CONFIG_ALLOC
 int close(int fd);
 ssize_t read(int fd, void *buf, size_t count);
@@ -20,6 +28,7 @@ int access(const char *pathname, int mode);
 char *getcwd(char *buf, size_t size);
 off_t lseek(int fd, off_t offset, int whence);
 int fsync(int fd);
+int fdatasync(int);
 int fchown(int fd, uid_t owner, gid_t group);
 #endif
 
@@ -27,6 +36,7 @@ unsigned sleep(unsigned seconds);
 int usleep(unsigned int useconds);
 
 uid_t geteuid(void);
+uid_t getuid(void);
 pid_t getpid(void);
 
 #ifdef AX_CONFIG_PIPE
@@ -41,6 +51,14 @@ int dup3(int, int, int);
 #endif
 
 long int sysconf(int name);
+int execve(const char *__path, char *const *__argv, char *const *__envp);
+pid_t setsid(void);
+int isatty(int __fd);
+pid_t fork(void);
+
+int chdir(const char *__path);
+int truncate(const char *path, off_t length);
+_Noreturn void _exit(int __status);
 
 #define _SC_ARG_MAX                      0
 #define _SC_CHILD_MAX                    1

--- a/ulib/c_libax/src/resource.c
+++ b/ulib/c_libax/src/resource.c
@@ -57,3 +57,10 @@ int setrlimit(int resource, struct rlimit *rlimits)
     }
     return 0;
 }
+
+// TODO
+int getrusage(int __who, struct rusage *__usage)
+{
+    unimplemented();
+    return 0;
+}

--- a/ulib/c_libax/src/socket.c
+++ b/ulib/c_libax/src/socket.c
@@ -70,7 +70,8 @@ int getsockopt(int fd, int level, int optname, void *restrict optval, socklen_t 
 
 int setsockopt(int fd, int level, int optname, const void *optval, socklen_t optlen)
 {
-    unimplemented();
+    unimplemented("fd: %d, level: %d, optname: %d, optval: %d, optlen: %d", fd, level, optname,
+                  *(int *)optval, optlen);
     return 0;
 }
 
@@ -83,4 +84,18 @@ int getpeername(int sockfd, struct sockaddr *restrict addr, socklen_t *restrict 
 {
     return ax_getpeername(sockfd, addr, addrlen);
 }
+
+// TODO
+int accept4(int fd, struct sockaddr *restrict addr, socklen_t *restrict len, int __flags)
+{
+    unimplemented();
+}
+
+// TODO
+ssize_t sendmsg(int fd, const struct msghdr *msg, int flags)
+{
+    unimplemented();
+    return 0;
+}
+
 #endif

--- a/ulib/c_libax/src/stat.c
+++ b/ulib/c_libax/src/stat.c
@@ -1,5 +1,8 @@
 #include <stdio.h>
+#include <sys/stat.h>
 #include <sys/types.h>
+
+#include <libax.h>
 
 // TODO:
 int fchmod(int fd, mode_t mode)
@@ -10,6 +13,26 @@ int fchmod(int fd, mode_t mode)
 
 // TODO:
 int mkdir(const char *pathname, mode_t mode)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int chmod(const char *__file, mode_t __mode)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+mode_t umask(mode_t mask)
+{
+    return ax_umask(mask);
+}
+
+// TODO
+int fstatat(int, const char *__restrict, struct stat *__restrict, int)
 {
     unimplemented();
     return 0;

--- a/ulib/c_libax/src/stdio.c
+++ b/ulib/c_libax/src/stdio.c
@@ -74,15 +74,11 @@ static int out(FILE *f, const char *s, size_t l)
     return ret;
 }
 
-// int getchar()
-// {
-//     char byte = 0;
-//     if (1 == read(stdin, &byte, 1)) {
-//         return byte;
-//     } else {
-//         return EOF;
-//     }
-// }
+int getchar(void)
+{
+    unimplemented();
+    return 0;
+}
 
 int fflush(FILE *f)
 {
@@ -228,4 +224,166 @@ char *fgets(char *restrict s, int n, FILE *restrict f)
     return s;
 }
 
+// TODO
+int sscanf(const char *restrict __s, const char *restrict __format, ...)
+{
+    unimplemented();
+    return 0;
+}
+
+size_t fread(void *restrict destv, size_t size, size_t nmemb, FILE *restrict f)
+{
+    return (size_t)ax_read(f->fd, destv, size * nmemb) / size;
+}
+
+size_t fwrite(const void *restrict src, size_t size, size_t nmemb, FILE *restrict f)
+{
+    return (size_t)ax_write(f->fd, src, size * nmemb) / size;
+}
+
+int fputs(const char *restrict s, FILE *restrict f)
+{
+    size_t l = strlen(s);
+    return (fwrite(s, 1, l, f) == l) - 1;
+}
+
+int fclose(FILE *f)
+{
+    return ax_close(f->fd);
+}
 #endif
+
+// TODO
+int rename(const char *__old, const char *__new)
+{
+    unimplemented();
+    return 0;
+}
+
+int fileno(FILE *f)
+{
+    return f->fd;
+}
+
+int feof(FILE *f)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int fseek(FILE *__stream, long __off, int __whence)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+long ftello(FILE *__stream)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+char *tmpnam(char *)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+void clearerr(FILE *f)
+{
+    unimplemented();
+}
+
+// TODO
+int ferror(FILE *f)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+FILE *freopen(const char *restrict, const char *restrict, FILE *restrict)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int fscanf(FILE *restrict, const char *restrict, ...)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+long ftell(FILE *)
+{
+    unimplemented();
+    return 0;
+}
+
+int getc(FILE *)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int remove(const char *)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int setvbuf(FILE *restrict f, char *restrict buf, int type, size_t size)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+FILE *tmpfile(void)
+{
+    unimplemented();
+    return NULL;
+}
+
+int ungetc(int c, FILE *f)
+{
+    unimplemented();
+    return 0;
+}
+
+ssize_t getdelim(char **restrict s, size_t *restrict n, int delim, FILE *restrict f)
+{
+    unimplemented();
+    return 0;
+}
+
+ssize_t getline(char **restrict s, size_t *restrict n, FILE *restrict f)
+{
+    return getdelim(s, n, '\n', f);
+}
+
+int __uflow(FILE *f)
+{
+    unimplemented();
+    return 0;
+}
+
+int getc_unlocked(FILE *)
+{
+    unimplemented();
+    return 0;
+}
+
+FILE *fdopen(int fd, const char *mode)
+{
+    unimplemented();
+    return NULL;
+}

--- a/ulib/c_libax/src/string.c
+++ b/ulib/c_libax/src/string.c
@@ -1,6 +1,8 @@
 #include <ctype.h>
+#include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <libax.h>
@@ -464,3 +466,18 @@ char *strdup(const char *s)
     return memcpy(d, s, l + 1);
 }
 #endif
+
+int strerror_r(int err, char *buf, size_t buflen)
+{
+    char *msg = strerror(err);
+    size_t l = strlen(msg);
+    if (l >= buflen) {
+        if (buflen) {
+            memcpy(buf, msg, buflen - 1);
+            buf[buflen - 1] = 0;
+        }
+        return ERANGE;
+    }
+    memcpy(buf, msg, l + 1);
+    return 0;
+}

--- a/ulib/c_libax/src/syslog.c
+++ b/ulib/c_libax/src/syslog.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <syslog.h>
+
+// TODO
+void syslog(int __pri, const char *__fmt, ...)
+{
+    unimplemented();
+    return;
+}
+
+// TODO
+void openlog(const char *__ident, int __option, int __facility)
+{
+    unimplemented();
+    return;
+}

--- a/ulib/c_libax/src/time.c
+++ b/ulib/c_libax/src/time.c
@@ -7,6 +7,9 @@
 
 #include <libax.h>
 
+long timezone = 0;
+const char __utc[] = "UTC";
+
 const int SEC_PER_MIN = 60;
 const int SEC_PER_HOUR = 3600;
 const int MIN_PER_HOUR = 60;
@@ -178,9 +181,44 @@ int nanosleep(const struct timespec *req, struct timespec *rem)
     return ax_nanosleep(req, rem);
 }
 
+// TODO
+void tzset()
+{
+    unimplemented();
+    return;
+}
+
+// TODO
+int setitimer(int _which, const struct itimerval *restrict _new, struct itimerval *restrict _old)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+char *ctime_r(const time_t *t, char *buf)
+{
+    unimplemented();
+    return NULL;
+}
+
+// TODO
+clock_t clock(void)
+{
+    unimplemented();
+    return 0;
+}
+
 #ifdef AX_CONFIG_FP_SIMD
 double difftime(time_t t1, time_t t0)
 {
     return t1 - t0;
 }
 #endif
+
+// TODO
+time_t mktime(struct tm *tm)
+{
+    unimplemented();
+    return 0;
+}

--- a/ulib/c_libax/src/uio.c
+++ b/ulib/c_libax/src/uio.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <sys/uio.h>
+
+#include <libax.h>
+
+ssize_t writev(int fd, const struct iovec *iovec, int count)
+{
+    return ax_writev(fd, iovec, count);
+}

--- a/ulib/c_libax/src/unistd.c
+++ b/ulib/c_libax/src/unistd.c
@@ -23,6 +23,13 @@ pid_t getpid(void)
 #endif
 }
 
+// TODO
+uid_t getuid(void)
+{
+    unimplemented();
+    return 0;
+}
+
 unsigned int sleep(unsigned int seconds)
 {
     struct timespec ts;
@@ -123,6 +130,13 @@ int fsync(int fd)
     return 0;
 }
 
+// TODO
+int fdatasync(int __fildes)
+{
+    unimplemented();
+    return 0;
+}
+
 // TODO:
 int fchown(int fd, uid_t owner, gid_t group)
 {
@@ -194,3 +208,52 @@ int dup3(int old, int new, int flags)
 }
 
 #endif
+
+// TODO
+_Noreturn void _exit(int __status)
+{
+    unimplemented();
+    abort();
+}
+
+// TODO
+int execve(const char *__path, char *const *__argv, char *const *__envp)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+pid_t setsid(void)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int isatty(int fd)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+pid_t fork(void)
+{
+    unimplemented();
+    return -1;
+}
+
+// TODO
+int chdir(const char *__path)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+int truncate(const char *path, off_t length)
+{
+    unimplemented();
+    return 0;
+}

--- a/ulib/c_libax/src/utsname.c
+++ b/ulib/c_libax/src/utsname.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <sys/utsname.h>
+
+// TODO
+int uname(struct utsname *)
+{
+    unimplemented();
+    return 0;
+}

--- a/ulib/c_libax/src/wait.c
+++ b/ulib/c_libax/src/wait.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+
+// TODO
+pid_t waitpid(pid_t __pid, int *__stat_loc, int __options)
+{
+    unimplemented();
+    return 0;
+}
+
+// TODO
+pid_t wait3(int *, int, struct rusage *)
+{
+    unimplemented();
+    return 0;
+}

--- a/ulib/libax/build.rs
+++ b/ulib/libax/build.rs
@@ -69,6 +69,7 @@ typedef struct {{
             "timeval",
             "pthread_.*",
             "epoll_event",
+            "iovec",
         ];
         let allow_vars = [
             "O_.*",

--- a/ulib/libax/cbindgen.toml
+++ b/ulib/libax/cbindgen.toml
@@ -22,6 +22,7 @@ includes = ["axconfig.h"]
 "timespec" = "struct timespec"
 "timeval" = "struct timeval"
 "epoll_event" = "struct epoll_event"
+"iovec" = "struct iovec"
 
 [fn]
 no_return = "__attribute__((noreturn))"

--- a/ulib/libax/ctypes.h
+++ b/ulib/libax/ctypes.h
@@ -11,4 +11,5 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <unistd.h>

--- a/ulib/libax/src/cbindings/mod.rs
+++ b/ulib/libax/src/cbindings/mod.rs
@@ -27,9 +27,12 @@ mod pthread;
 mod socket;
 #[cfg(feature = "fp_simd")]
 mod strtod;
+#[cfg(feature = "alloc")]
+mod uio;
 
 mod errno;
 mod setjmp;
+mod stat;
 mod stdio;
 mod sys;
 mod time;
@@ -89,7 +92,11 @@ pub use self::io_mpx::{ax_epoll_create, ax_epoll_ctl, ax_epoll_wait, ax_select};
 #[cfg(feature = "fp_simd")]
 pub use self::strtod::{ax_strtod, ax_strtof};
 
+#[cfg(feature = "alloc")]
+pub use self::uio::ax_writev;
+
 pub use self::errno::ax_errno_string;
+pub use self::stat::ax_umask;
 pub use self::stdio::{ax_print_str, ax_println_str};
 pub use self::sys::ax_sysconf;
 pub use self::time::{ax_clock_gettime, ax_nanosleep};

--- a/ulib/libax/src/cbindings/setjmp.rs
+++ b/ulib/libax/src/cbindings/setjmp.rs
@@ -1,8 +1,8 @@
+use core::ffi::c_int;
+
 use super::ctypes;
 
 /// `setjmp` implementation
-///
-/// TODO: only aarch64 is supported currently
 #[naked]
 #[no_mangle]
 unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
@@ -40,6 +40,199 @@ unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
         ret",
         options(noreturn),
     );
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!(
+        "mov [rdi], rbx
+        mov [rdi + 8], rbp
+        mov [rdi + 16], r12
+        mov [rdi + 24], r13
+        mov [rdi + 32], r14
+        mov [rdi + 40], r15
+        lea rdx, [rsp + 8]
+        mov [rdi + 48], rdx
+        mov rdx, [rsp]
+        mov [rdi + 56], rdx
+        xor rax, rax
+        ret",
+        options(noreturn),
+    );
+    #[cfg(all(target_arch = "riscv64", feature = "fp_simd"))]
+    core::arch::asm!(
+        "sd s0,    0(a0)
+        sd s1,    8(a0)
+        sd s2,    16(a0)
+        sd s3,    24(a0)
+        sd s4,    32(a0)
+        sd s5,    40(a0)
+        sd s6,    48(a0)
+        sd s7,    56(a0)
+        sd s8,    64(a0)
+        sd s9,    72(a0)
+        sd s10,   80(a0)
+        sd s11,   88(a0)
+        sd sp,    96(a0)
+        sd ra,    104(a0)
+
+        fsd fs0,  112(a0)
+        fsd fs1,  120(a0)
+        fsd fs2,  128(a0)
+        fsd fs3,  136(a0)
+        fsd fs4,  144(a0)
+        fsd fs5,  152(a0)
+        fsd fs6,  160(a0)
+        fsd fs7,  168(a0)
+        fsd fs8,  176(a0)
+        fsd fs9,  184(a0)
+        fsd fs10, 192(a0)
+        fsd fs11, 200(a0)
+
+        li a0, 0
+        ret",
+        options(noreturn),
+    );
+    #[cfg(all(target_arch = "riscv64", not(feature = "fp_simd")))]
+    core::arch::asm!(
+        "sd s0,    0(a0)
+        sd s1,    8(a0)
+        sd s2,    16(a0)
+        sd s3,    24(a0)
+        sd s4,    32(a0)
+        sd s5,    40(a0)
+        sd s6,    48(a0)
+        sd s7,    56(a0)
+        sd s8,    64(a0)
+        sd s9,    72(a0)
+        sd s10,   80(a0)
+        sd s11,   88(a0)
+        sd sp,    96(a0)
+        sd ra,    104(a0)
+
+        li a0, 0
+        ret",
+        options(noreturn),
+    );
+    #[cfg(not(any(
+        target_arch = "aarch64",
+        target_arch = "x86_64",
+        target_arch = "riscv64"
+    )))]
     core::arch::asm!("ret", options(noreturn))
+}
+
+/// `longjmp` implementation
+#[naked]
+#[no_mangle]
+unsafe extern "C" fn longjmp(_buf: *mut ctypes::__jmp_buf_tag, _val: c_int) -> ! {
+    #[cfg(all(target_arch = "aarch64", feature = "fp_simd"))]
+    core::arch::asm!(
+        "ldp x19, x20, [x0,#0]
+        ldp x21, x22, [x0,#16]
+        ldp x23, x24, [x0,#32]
+        ldp x25, x26, [x0,#48]
+        ldp x27, x28, [x0,#64]
+        ldp x29, x30, [x0,#80]
+        ldr x2, [x0,#104]
+        mov sp, x2
+        ldp d8 , d9, [x0,#112]
+        ldp d10, d11, [x0,#128]
+        ldp d12, d13, [x0,#144]
+        ldp d14, d15, [x0,#160]
+    
+        cmp w1, 0
+        csinc w0, w1, wzr, ne
+        br x30",
+        options(noreturn),
+    );
+    #[cfg(all(target_arch = "aarch64", not(feature = "fp_simd")))]
+    core::arch::asm!(
+        "ldp x19, x20, [x0,#0]
+        ldp x21, x22, [x0,#16]
+        ldp x23, x24, [x0,#32]
+        ldp x25, x26, [x0,#48]
+        ldp x27, x28, [x0,#64]
+        ldp x29, x30, [x0,#80]
+        ldr x2, [x0,#104]
+        mov sp, x2
+    
+        cmp w1, 0
+        csinc w0, w1, wzr, ne
+        br x30",
+        options(noreturn),
+    );
+    #[cfg(target_arch = "x86_64")]
+    core::arch::asm!(
+        "mov rax,rsi
+        test rax,rax
+        jnz 1f
+        inc rax
+    1:
+        mov rbx, [rdi]
+        mov rbp, [rdi + 8]
+        mov r12, [rdi + 16]
+        mov r13, [rdi + 24]
+        mov r14, [rdi + 32]
+        mov r15, [rdi + 40]
+        mov rdx, [rdi + 48]
+        mov rsp, rdx 
+        mov rdx, [rdi + 56]
+        jmp rdx",
+        options(noreturn),
+    );
+    #[cfg(all(target_arch = "riscv64", feature = "fp_simd"))]
+    core::arch::asm!(
+        "ld s0,    0(a0)
+        ld s1,    8(a0)
+        ld s2,    16(a0)
+        ld s3,    24(a0)
+        ld s4,    32(a0)
+        ld s5,    40(a0)
+        ld s6,    48(a0)
+        ld s7,    56(a0)
+        ld s8,    64(a0)
+        ld s9,    72(a0)
+        ld s10,   80(a0)
+        ld s11,   88(a0)
+        ld sp,    96(a0)
+        ld ra,    104(a0)
+    
+        fld fs0,  112(a0)
+        fld fs1,  120(a0)
+        fld fs2,  128(a0)
+        fld fs3,  136(a0)
+        fld fs4,  144(a0)
+        fld fs5,  152(a0)
+        fld fs6,  160(a0)
+        fld fs7,  168(a0)
+        fld fs8,  176(a0)
+        fld fs9,  184(a0)
+        fld fs10, 192(a0)
+        fld fs11, 200(a0)
+    
+        seqz a0, a1
+        add a0, a0, a1
+        ret",
+        options(noreturn),
+    );
+    #[cfg(all(target_arch = "riscv64", not(feature = "fp_simd")))]
+    core::arch::asm!(
+        "ld s0,    0(a0)
+        ld s1,    8(a0)
+        ld s2,    16(a0)
+        ld s3,    24(a0)
+        ld s4,    32(a0)
+        ld s5,    40(a0)
+        ld s6,    48(a0)
+        ld s7,    56(a0)
+        ld s8,    64(a0)
+        ld s9,    72(a0)
+        ld s10,   80(a0)
+        ld s11,   88(a0)
+        ld sp,    96(a0)
+        ld ra,    104(a0)
+    
+        seqz a0, a1
+        add a0, a0, a1
+        ret",
+        options(noreturn),
+    );
 }

--- a/ulib/libax/src/cbindings/stat.rs
+++ b/ulib/libax/src/cbindings/stat.rs
@@ -1,0 +1,15 @@
+use super::ctypes::mode_t;
+use crate::debug;
+
+static mut MASK: mode_t = 0o666;
+
+/// Set umask for open operations
+///
+/// Currenly only a fake implementation
+#[no_mangle]
+pub unsafe extern "C" fn ax_umask(mask: mode_t) -> mode_t {
+    let old = MASK;
+    MASK = mask & 0o777;
+    debug!("umask set but not used: {}", mask);
+    old
+}

--- a/ulib/libax/src/cbindings/uio.rs
+++ b/ulib/libax/src/cbindings/uio.rs
@@ -1,0 +1,31 @@
+use alloc::vec::Vec;
+use core::ffi::{c_int, c_void};
+
+use super::{ax_write, ctypes, errno::set_errno};
+use axerrno::LinuxError;
+
+/// `writev` implementation
+#[no_mangle]
+pub unsafe extern "C" fn ax_writev(
+    fd: c_int,
+    iov: *const ctypes::iovec,
+    iocnt: c_int,
+) -> ctypes::ssize_t {
+    debug!("ax_writev <= fd: {}", fd);
+    ax_call_body!(ax_writev, {
+        if !(0..=1024).contains(&iocnt) {
+            set_errno(LinuxError::EINVAL as _);
+            return Err(LinuxError::EINVAL);
+        }
+        let iovs = core::slice::from_raw_parts(iov, iocnt as usize);
+        let mut vec = Vec::new();
+        for iov in iovs.iter() {
+            vec.extend_from_slice(core::slice::from_raw_parts_mut(
+                iov.iov_base as *mut u8,
+                iov.iov_len,
+            ));
+        }
+
+        Ok(ax_write(fd, vec.as_ptr() as *const c_void, vec.len()))
+    })
+}


### PR DESCRIPTION
This pr contains part 1 of libc functions needed in Redis, including:
- uio: 
  - `ssize writev()`: Implemented by `ax_write`
- stat:
  - `umask()`: uses a fake implementation.
- `setjmp` and `longjmp` implementation for all three architecture.
- Other "unimplemented()" libc function declarations are included.