### PR TITLE
x86_64 virtio:get irqnum support for x86_64 virtio dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "acpi"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654f48ab3178632ea535be1765073b990895cb62f70a7e5671975d7150c26d15"
+dependencies = [
+ "bit_field",
+ "log",
+ "rsdp",
+]
+
+[[package]]
 name = "allocator"
 version = "0.1.0"
 dependencies = [
  "bitmap-allocator",
  "buddy_system_allocator",
  "slab_allocator",
+]
+
+[[package]]
+name = "aml"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f8cba7d4260ea05671dda81029f6f718b54402a4ec926a0d9a41bdbb96b415"
+dependencies = [
+ "bit_field",
+ "bitvec",
+ "byteorder",
+ "log",
+ "spinning_top",
 ]
 
 [[package]]
@@ -279,6 +303,8 @@ name = "axhal"
 version = "0.1.0"
 dependencies = [
  "aarch64-cpu",
+ "acpi",
+ "aml",
  "arm_gic",
  "arm_pl011",
  "axalloc",
@@ -457,6 +483,18 @@ name = "bitmaps"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703642b98a00b3b90513279a8ede3fcfa479c126c5fb46e78f3051522f021403"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "buddy_system_allocator"
@@ -770,6 +808,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "getrandom"
@@ -1203,6 +1247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1337,15 @@ dependencies = [
  "bit_field",
  "critical-section",
  "embedded-hal",
+]
+
+[[package]]
+name = "rsdp"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d3add2fc55ef37511bcf81a08ee7a09eff07b23aae38b06a29024a38c604b1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1450,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1488,6 +1556,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1818,6 +1892,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/modules/axconfig/src/platform/pc-x86.toml
+++ b/modules/axconfig/src/platform/pc-x86.toml
@@ -21,6 +21,7 @@ mmio-regions = [
     ["0xfec0_0000", "0x1000"],      # IO APIC
     ["0xfed0_0000", "0x1000"],      # HPET
     ["0xfee0_0000", "0x1000"],      # Local APIC
+    ["0xe_0000", "0x2_0000"],       #ACPI
 ]
 # VirtIO MMIO regions with format (`base_paddr`, `size`).
 virtio-mmio-regions = []

--- a/modules/axconfig/src/platform/pc-x86.toml
+++ b/modules/axconfig/src/platform/pc-x86.toml
@@ -21,12 +21,10 @@ mmio-regions = [
     ["0xfec0_0000", "0x1000"],      # IO APIC
     ["0xfed0_0000", "0x1000"],      # HPET
     ["0xfee0_0000", "0x1000"],      # Local APIC
-    ["0xe_0000", "0x2_0000"],       #ACPI
+    ["0xe_0000", "0x2_0000"],       # ACPI
 ]
 # VirtIO MMIO regions with format (`base_paddr`, `size`).
 virtio-mmio-regions = []
-# Base physical address of the PCIe ECAM space (should read from ACPI 'MCFG' table).
-pci-ecam-base = "0xb000_0000"
 # End PCI bus number.
 pci-bus-end = "0xff"
 # PCI device memory ranges (not used on x86).

--- a/modules/axconfig/src/platform/pc-x86.toml
+++ b/modules/axconfig/src/platform/pc-x86.toml
@@ -25,6 +25,8 @@ mmio-regions = [
 ]
 # VirtIO MMIO regions with format (`base_paddr`, `size`).
 virtio-mmio-regions = []
+# Base physical address of the PCIe ECAM space (should read from ACPI 'MCFG' table).
+pci-ecam-base = "0xb000_0000"
 # End PCI bus number.
 pci-bus-end = "0xff"
 # PCI device memory ranges (not used on x86).

--- a/modules/axdriver/src/bus/pci.rs
+++ b/modules/axdriver/src/bus/pci.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, AllDevices};
-use axhal::mem::{phys_to_virt, PhysAddr};
+use axhal::mem::phys_to_virt;
 use driver_pci::{
     BarInfo, Cam, Command, DeviceFunction, HeaderType, MemoryBarType, PciRangeAllocator, PciRoot,
 };
@@ -85,8 +85,8 @@ fn config_pci_device(
 impl AllDevices {
     pub(crate) fn probe_bus_devices(&mut self) {
         cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
-                let pci_ecam_base = PhysAddr::from(axhal::get_ecam_address().unwrap() as usize);
+            if #[cfg(all(target_arch = "x86_64",feature="alloc"))] {
+                let pci_ecam_base = axhal::get_ecam_address().unwrap();
             } else {
                 let pci_ecam_base = axconfig::PCI_ECAM_BASE.into();
             }

--- a/modules/axdriver/src/bus/pci.rs
+++ b/modules/axdriver/src/bus/pci.rs
@@ -85,8 +85,8 @@ fn config_pci_device(
 impl AllDevices {
     pub(crate) fn probe_bus_devices(&mut self) {
         cfg_if::cfg_if! {
-            if #[cfg(all(target_arch = "x86_64",feature="alloc"))] {
-                let pci_ecam_base = axhal::get_ecam_address().unwrap();
+            if #[cfg(all(target_arch = "x86_64",feature = "virtio"))] {
+                let pci_ecam_base = axhal::pci::get_ecam_address().unwrap();
             } else {
                 let pci_ecam_base = axconfig::PCI_ECAM_BASE.into();
             }

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -50,6 +50,8 @@ x86 = "0.52"
 x86_64 = "0.14"
 x2apic = "0.4"
 raw-cpuid = "11.0"
+acpi = "4.1.1"
+aml = "0.16.4"
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
 riscv = "0.10"

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -2,7 +2,7 @@ mod context;
 mod gdt;
 mod idt;
 
-#[cfg(target_os = "none")]
+// #[cfg(target_os = "none")]
 mod trap;
 
 use core::arch::asm;

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -2,7 +2,7 @@ mod context;
 mod gdt;
 mod idt;
 
-// #[cfg(target_os = "none")]
+#[cfg(target_os = "none")]
 mod trap;
 
 use core::arch::asm;

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -14,7 +14,7 @@ use x86_64::instructions::interrupts;
 pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
 pub use self::idt::IdtStruct;
-pub use self::trap::{IRQ_VECTOR_START, IRQ_VECTOR_END};
+pub use self::trap::{IRQ_VECTOR_END, IRQ_VECTOR_START};
 pub use x86_64::structures::tss::TaskStateSegment;
 
 /// Allows the current CPU to respond to interrupts.

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -14,7 +14,7 @@ use x86_64::instructions::interrupts;
 pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
 pub use self::idt::IdtStruct;
-pub use self::trap::{irq_to_vector, vector_to_irq};
+pub use self::trap::{IRQ_VECTOR_START, IRQ_VECTOR_END};
 pub use x86_64::structures::tss::TaskStateSegment;
 
 /// Allows the current CPU to respond to interrupts.

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -14,8 +14,8 @@ use x86_64::instructions::interrupts;
 pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
 pub use self::idt::IdtStruct;
+pub use self::trap::{irq_to_vector, vector_to_irq};
 pub use x86_64::structures::tss::TaskStateSegment;
-pub use self::trap::{irq_to_vector,vector_to_irq};
 
 /// Allows the current CPU to respond to interrupts.
 #[inline]

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -2,7 +2,7 @@ mod context;
 mod gdt;
 mod idt;
 
-#[cfg(target_os = "none")]
+// #[cfg(target_os = "none")]
 mod trap;
 
 use core::arch::asm;
@@ -15,6 +15,7 @@ pub use self::context::{ExtendedState, FxsaveArea, TaskContext, TrapFrame};
 pub use self::gdt::GdtStruct;
 pub use self::idt::IdtStruct;
 pub use x86_64::structures::tss::TaskStateSegment;
+pub use self::trap::{irq_to_vector,vector_to_irq};
 
 /// Allows the current CPU to respond to interrupts.
 #[inline]

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -4,7 +4,9 @@ use super::context::TrapFrame;
 
 core::arch::global_asm!(include_str!("trap.S"));
 
+/// start value of irq vector
 pub const IRQ_VECTOR_START: u8 = 0x20;
+/// end value of irq vector
 pub const IRQ_VECTOR_END: u8 = 0xff;
 
 #[no_mangle]

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -44,3 +44,12 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
         }
     }
 }
+
+/// map external IRQ to vector
+pub fn irq_to_vector(irq:u8)->usize{
+    (irq + IRQ_VECTOR_START )as usize
+}
+/// map vector to external IRQ
+pub fn vector_to_irq(vector:usize)->u8{
+    vector as u8 - IRQ_VECTOR_START
+}

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -46,10 +46,10 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
 }
 
 /// map external IRQ to vector
-pub fn irq_to_vector(irq:u8)->usize{
-    (irq + IRQ_VECTOR_START )as usize
+pub fn irq_to_vector(irq: u8) -> usize {
+    (irq + IRQ_VECTOR_START) as usize
 }
 /// map vector to external IRQ
-pub fn vector_to_irq(vector:usize)->u8{
+pub fn vector_to_irq(vector: usize) -> u8 {
     vector as u8 - IRQ_VECTOR_START
 }

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -4,8 +4,8 @@ use super::context::TrapFrame;
 
 core::arch::global_asm!(include_str!("trap.S"));
 
-const IRQ_VECTOR_START: u8 = 0x20;
-const IRQ_VECTOR_END: u8 = 0xff;
+pub const IRQ_VECTOR_START: u8 = 0x20;
+pub const IRQ_VECTOR_END: u8 = 0xff;
 
 #[no_mangle]
 fn x86_trap_handler(tf: &mut TrapFrame) {
@@ -45,11 +45,3 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
     }
 }
 
-/// map external IRQ to vector
-pub fn irq_to_vector(irq: u8) -> usize {
-    (irq + IRQ_VECTOR_START) as usize
-}
-/// map vector to external IRQ
-pub fn vector_to_irq(vector: usize) -> u8 {
-    vector as u8 - IRQ_VECTOR_START
-}

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -46,4 +46,3 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
         }
     }
 }
-

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -78,6 +78,7 @@ pub use self::platform::platform_init;
 #[cfg(feature = "smp")]
 pub use self::platform::platform_init_secondary;
 
+/// PCI related operations
 pub mod pci {
     #[cfg(all(target_arch = "x86_64", feature = "axalloc"))]
     pub use super::platform::acpi::get_ecam_address;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -31,12 +31,15 @@
 #![feature(naked_functions)]
 #![feature(const_maybe_uninit_zeroed)]
 #![feature(doc_auto_cfg)]
+#![feature(allocator_api)]
+#![feature(alloc_layout_extra)]
 
 #[allow(unused_imports)]
 #[macro_use]
 extern crate log;
+extern crate alloc;
 
-mod platform;
+pub mod platform;
 
 pub mod arch;
 pub mod cpu;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -78,5 +78,5 @@ pub use self::platform::platform_init;
 #[cfg(feature = "smp")]
 pub use self::platform::platform_init_secondary;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", frature = "alloc"))]
 pub use self::platform::acpi::get_ecam_address;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -77,3 +77,6 @@ pub use self::platform::platform_init;
 
 #[cfg(feature = "smp")]
 pub use self::platform::platform_init_secondary;
+
+#[cfg(target_arch = "x86_64")]
+pub use self::platform::acpi::get_ecam_address;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -36,7 +36,7 @@
 #[macro_use]
 extern crate log;
 
-pub mod platform;
+mod platform;
 
 pub mod arch;
 pub mod cpu;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -78,5 +78,9 @@ pub use self::platform::platform_init;
 #[cfg(feature = "smp")]
 pub use self::platform::platform_init_secondary;
 
-#[cfg(all(target_arch = "x86_64", frature = "alloc"))]
-pub use self::platform::acpi::get_ecam_address;
+pub mod pci {
+    #[cfg(all(target_arch = "x86_64", feature = "axalloc"))]
+    pub use super::platform::acpi::get_ecam_address;
+    #[cfg(all(target_arch = "x86_64", feature = "irq", feature = "axalloc"))]
+    pub use super::platform::acpi::get_pci_irq_vector;
+}

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -31,13 +31,10 @@
 #![feature(naked_functions)]
 #![feature(const_maybe_uninit_zeroed)]
 #![feature(doc_auto_cfg)]
-#![feature(allocator_api)]
-#![feature(alloc_layout_extra)]
 
 #[allow(unused_imports)]
 #[macro_use]
 extern crate log;
-extern crate alloc;
 
 pub mod platform;
 

--- a/modules/axhal/src/platform/dummy/mod.rs
+++ b/modules/axhal/src/platform/dummy/mod.rs
@@ -91,3 +91,16 @@ pub fn platform_init() {}
 /// Initializes the platform devices for secondary CPUs.
 #[cfg(feature = "smp")]
 pub fn platform_init_secondary() {}
+
+pub mod acpi {
+    #[cfg(feature = "irq")]
+    pub fn get_pci_irq_vector(bus: u8, device: u8, function: u8) -> Option<usize> {
+        None
+    }
+
+    use crate::mem::PhysAddr;
+    /// Get PCIe ECAM space physical address.
+    pub fn get_ecam_address() -> Option<PhysAddr> {
+        None
+    }
+}

--- a/modules/axhal/src/platform/pc_x86/acpi.rs
+++ b/modules/axhal/src/platform/pc_x86/acpi.rs
@@ -328,6 +328,6 @@ pub fn get_pci_irq_vector(bus: u8, device: u8, function: u8) -> Option<usize> {
 }
 
 /// Get PCIe ECAM space physical address.
-pub fn get_ecam_address() -> Option<u64> {
-    unsafe { ACPI.get_ecam_address() }
+pub fn get_ecam_address() -> Option<PhysAddr> {
+    unsafe { ACPI.get_ecam_address() }.map(|ecam_addr| PhysAddr::from(ecam_addr))
 }

--- a/modules/axhal/src/platform/pc_x86/acpi.rs
+++ b/modules/axhal/src/platform/pc_x86/acpi.rs
@@ -203,9 +203,9 @@ struct Acpi {
 #[allow(dead_code)]
 enum X86IrqModel {
     /// PIC model
-    PIC,
+    Pic,
     /// APIC model
-    APIC,
+    Apic,
 }
 
 impl Acpi {
@@ -224,7 +224,7 @@ impl Acpi {
         if self.aml_context.parse_table(slice).is_err() {
             return false;
         }
-        self.set_irq_model(X86IrqModel::APIC)
+        self.set_irq_model(X86IrqModel::Apic)
     }
 
     /// Set IRQ model that ACPI uses by invoking ACPI global method _PIC.
@@ -235,8 +235,8 @@ impl Acpi {
     /// We may need a lock for ACPI in the future as more ACPI state altering method implemented.
     fn set_irq_model(&mut self, irq_model: X86IrqModel) -> bool {
         let value = match irq_model {
-            X86IrqModel::PIC => 0,
-            X86IrqModel::APIC => 1,
+            X86IrqModel::Pic => 0,
+            X86IrqModel::Apic => 1,
         };
         let mut arg = aml::value::Args::EMPTY;
         if arg.store_arg(0, aml::AmlValue::Integer(value)).is_err() {
@@ -320,7 +320,6 @@ pub(crate) fn init() {
 
 /// Get PCI IRQ and map it to vector used in OS.
 /// Temporarily allow unused here because irq support for virtio hasn't ready yet.
-#[allow(dead_code)]
 #[cfg(feature = "irq")]
 pub fn get_pci_irq_vector(bus: u8, device: u8, function: u8) -> Option<usize> {
     unsafe { ACPI.get_pci_irq_desc(bus, device, function) }
@@ -329,5 +328,5 @@ pub fn get_pci_irq_vector(bus: u8, device: u8, function: u8) -> Option<usize> {
 
 /// Get PCIe ECAM space physical address.
 pub fn get_ecam_address() -> Option<PhysAddr> {
-    unsafe { ACPI.get_ecam_address() }.map(|ecam_addr| PhysAddr::from(ecam_addr))
+    unsafe { ACPI.get_ecam_address() }.map(|ecam_addr| PhysAddr::from(ecam_addr as usize))
 }

--- a/modules/axhal/src/platform/pc_x86/acpi.rs
+++ b/modules/axhal/src/platform/pc_x86/acpi.rs
@@ -220,8 +220,7 @@ impl Acpi {
         let dsdt = self.rsdp.dsdt.as_ref().unwrap();
         let paddr = PhysAddr::from(dsdt.address);
         let vaddr = phys_to_virt(paddr).as_mut_ptr();
-        let slice =
-            unsafe { core::slice::from_raw_parts_mut(vaddr, dsdt.length as usize) };
+        let slice = unsafe { core::slice::from_raw_parts_mut(vaddr, dsdt.length as usize) };
         if self.aml_context.parse_table(slice).is_err() {
             return false;
         }

--- a/modules/axhal/src/platform/pc_x86/acpi.rs
+++ b/modules/axhal/src/platform/pc_x86/acpi.rs
@@ -1,0 +1,330 @@
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::format;
+use core::alloc::{AllocError, Layout};
+use core::ptr::NonNull;
+
+use acpi::{AcpiTables, PhysicalMapping};
+use aml::{AmlContext, AmlName, DebugVerbosity};
+use aml::pci_routing::{IrqDescriptor, PciRoutingTable, Pin};
+
+use axalloc::global_allocator;
+use lazy_init::LazyInit;
+use memory_addr::PhysAddr;
+use crate::mem::phys_to_virt;
+
+use crate::arch::irq_to_vector;
+
+#[derive(Clone)]
+struct LocalAcpiHandler;
+
+impl acpi::AcpiHandler for LocalAcpiHandler {
+    unsafe fn map_physical_region<T>(
+        &self,
+        physical_address: usize,
+        size: usize,
+    ) -> PhysicalMapping<Self, T> {
+        let vaddr = phys_to_virt(PhysAddr::from(physical_address)).as_usize();
+        PhysicalMapping::new(
+            physical_address,
+            NonNull::new_unchecked(vaddr as *mut i32 as *mut _),
+            size,
+            size,
+            self.clone(),
+        )
+    }
+    fn unmap_physical_region<T>(_region: &PhysicalMapping<Self, T>) {}
+}
+
+struct LocalAmlHandler;
+
+impl aml::Handler for LocalAmlHandler {
+    fn read_u8(&self, address: usize) -> u8 {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_ptr();
+        unsafe { vaddr.read_volatile() }
+    }
+
+    fn read_u16(&self, address: usize) -> u16 {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_ptr() as *const u16;
+        unsafe { vaddr.read_volatile() }
+    }
+
+    fn read_u32(&self, address: usize) -> u32 {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_ptr() as *const u32;
+        unsafe { vaddr.read_volatile() }
+    }
+
+    fn read_u64(&self, address: usize) -> u64 {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_ptr() as *const u64;
+        unsafe { vaddr.read_volatile() }
+    }
+
+    fn write_u8(&mut self, address: usize, value: u8) {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_mut_ptr();
+        unsafe { vaddr.write_volatile(value) }
+    }
+
+    fn write_u16(&mut self, address: usize, value: u16) {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_mut_ptr() as *mut u16;
+        unsafe { vaddr.write_volatile(value) }
+    }
+
+    fn write_u32(&mut self, address: usize, value: u32) {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_mut_ptr() as *mut u32;
+        unsafe { vaddr.write_volatile(value) }
+    }
+
+    fn write_u64(&mut self, address: usize, value: u64) {
+        let vaddr = phys_to_virt(PhysAddr::from(address)).as_mut_ptr() as *mut u64;
+        unsafe { vaddr.write_volatile(value) }
+    }
+
+    fn read_io_u8(&self, port: u16) -> u8 {
+        unsafe { x86::io::inb(port) }
+    }
+
+    fn read_io_u16(&self, port: u16) -> u16 {
+        unsafe { x86::io::inw(port) }
+    }
+
+    fn read_io_u32(&self, port: u16) -> u32 {
+        unsafe { x86::io::inl(port) }
+    }
+
+    fn write_io_u8(&self, port: u16, value: u8) {
+        unsafe {
+            x86::io::outb(port, value);
+        }
+    }
+
+    fn write_io_u16(&self, port: u16, value: u16) {
+        unsafe {
+            x86::io::outw(port, value);
+        }
+    }
+
+    fn write_io_u32(&self, port: u16, value: u32) {
+        unsafe {
+            x86::io::outl(port, value);
+        }
+    }
+
+    fn read_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u8 {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u8;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.read_volatile() }
+    }
+
+    fn read_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u16 {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u16;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.read_volatile() }
+    }
+
+    fn read_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16) -> u32 {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u32;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.read_volatile() }
+    }
+
+    fn write_pci_u8(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u8) {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u8;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.write_volatile(value) }
+    }
+
+    fn write_pci_u16(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u16) {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u16;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.write_volatile(value) }
+    }
+
+    fn write_pci_u32(&self, segment: u16, bus: u8, device: u8, function: u8, offset: u16, value: u32) {
+        let paddr = unsafe {
+            ACPI.get_pci_config_regions_addr(segment, bus, device, function)
+                .unwrap()
+        };
+        let vaddr = phys_to_virt(PhysAddr::from(paddr as usize)).as_usize() as *mut u32;
+        let address = unsafe { vaddr.add(offset as usize) };
+        unsafe { address.write_volatile(value) }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LocalAllocator;
+
+unsafe impl core::alloc::Allocator for LocalAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        match layout.size() {
+            0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+            size => {
+                let raw_ptr = global_allocator()
+                    .alloc(layout.size(), layout.align())
+                    .unwrap() as *mut u8;
+                let ptr = NonNull::new(raw_ptr).ok_or(AllocError)?;
+                Ok(NonNull::slice_from_raw_parts(ptr, size))
+            }
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() != 0 {
+            global_allocator().dealloc(ptr.as_ptr() as usize, layout.size(), layout.align())
+        }
+    }
+}
+
+struct Acpi {
+    rsdp: AcpiTables<LocalAcpiHandler>,
+    aml_context: AmlContext,
+}
+
+/// irq model used in ACPI
+pub enum X86IrqModel {
+    /// PIC model
+    PIC,
+    /// APIC model
+    APIC,
+}
+
+impl Acpi {
+    pub unsafe fn new() -> Self {
+        Acpi {
+            rsdp: AcpiTables::search_for_rsdp_bios(LocalAcpiHandler).unwrap(),
+            aml_context: AmlContext::new(Box::new(LocalAmlHandler), DebugVerbosity::None),
+        }
+    }
+
+    fn init(&mut self) -> bool {
+        let dsdt = self.rsdp.dsdt.as_ref().unwrap();
+        let paddr = PhysAddr::from(dsdt.address);
+        let vaddr = phys_to_virt(paddr).as_ptr();
+        let slice = unsafe {
+            core::slice::from_raw_parts_mut(vaddr as *mut u8, dsdt.length as usize)
+        };
+        if self.aml_context.parse_table(slice).is_err() {
+            return false;
+        }
+        self.set_irq_model(X86IrqModel::APIC)
+    }
+
+    /// Set IRQ model that ACPI uses by invoking ACPI global method _PIC.
+    ///
+    /// This method changes the routing tables (PIC or APIC) to return when calling _PRT methods.
+    /// Since this method changes ACPI state, it could lead to concurrent problem.
+    /// But currently it is only invoked in init thus runs by primary cpu only.
+    /// We may need a lock for ACPI in the future as more ACPI state altering method implemented.
+    fn set_irq_model(&mut self, irq_model: X86IrqModel) -> bool {
+        let value = match irq_model {
+            X86IrqModel::PIC => 0,
+            X86IrqModel::APIC => 1,
+        };
+        let mut arg = aml::value::Args::EMPTY;
+        if arg.store_arg(0, aml::AmlValue::Integer(value)).is_err() {
+            return false;
+        }
+        let result = self
+            .aml_context
+            .invoke_method(&AmlName::from_str("\\_PIC").unwrap(), arg);
+        if let Err(err) = result {
+            error!("set_irq_model failed:{:#?}", err);
+            return false;
+        }
+        true
+    }
+
+    /// Get PCI IRQ by invoking device _PRT method.
+    ///
+    /// Each PCI bus that ACPI provides interrupt routing information for appears as a device
+    /// in the ACPI namespace.
+    /// Each of these devices contains a _PRT method that returns an array of objects describing
+    /// the interrupt routing for slots on that PCI bus.
+    fn get_pci_irq_desc(&mut self, bus: u8, device: u8, function: u8) -> Option<IrqDescriptor> {
+        match AmlName::from_str(format!("\\_SB.PCI{bus_id}._PRT", bus_id = bus).as_str()) {
+            Ok(prt_path) => {
+                match PciRoutingTable::from_prt_path(&prt_path, &mut self.aml_context) {
+                    Ok(table) => {
+                        if let Ok(irq_descriptor) = table.route(
+                            device as u16,
+                            function as u16,
+                            Pin::IntA,
+                            &mut self.aml_context,
+                        ) {
+                            Some(irq_descriptor)
+                        } else {
+                            None
+                        }
+                    }
+                    Err(_) => None,
+                }
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Get base physical address of the PCIe ECAM space from ACPI MCFG table.
+    ///
+    /// Currently the ACPI crate does not export MCFG internal structure, thus we can not get ECAM
+    /// space address directly. This method get configuration space address of bdf(0:0:0) instead.
+    fn get_ecam_address(&mut self) -> Option<u64> {
+        if let Ok(config) = acpi::mcfg::PciConfigRegions::new(&self.rsdp) {
+            return Some(config.physical_address(0, 0, 0, 0).unwrap() );
+        }
+        None
+    }
+
+    /// Get PCIe configuration space physical address of device function.
+    fn get_pci_config_regions_addr(
+        &mut self,
+        segment_group_no: u16,
+        bus: u8,
+        device: u8,
+        function: u8,
+    ) -> Option<u64> {
+        if let Ok(config) = acpi::mcfg::PciConfigRegions::new(&self.rsdp) {
+            return config.physical_address(segment_group_no, bus, device, function);
+        }
+        None
+    }
+}
+
+static mut ACPI: LazyInit<Acpi> = LazyInit::new();
+
+pub(crate) fn init() {
+    unsafe {
+        let mut acpi = Acpi::new();
+        acpi.init();
+        ACPI.init_by(acpi);
+    }
+}
+
+/// Get PCI IRQ and map it to vector used in OS.
+pub fn get_pci_irq_vector(bus: u8, device: u8, function: u8) -> Option<usize> {
+    unsafe { ACPI.get_pci_irq_desc(bus, device, function) }.map(|irq_desc| irq_to_vector(irq_desc.irq as u8))
+}
+
+/// Get PCIe ECAM space physical address.
+pub fn get_ecam_address() -> Option<u64> {
+    unsafe { ACPI.get_ecam_address() }
+}

--- a/modules/axhal/src/platform/pc_x86/apic.rs
+++ b/modules/axhal/src/platform/pc_x86/apic.rs
@@ -51,11 +51,12 @@ static IO_APIC: LazyInit<SpinNoIrq<IoApic>> = LazyInit::new();
 pub fn set_enable(vector: usize, enabled: bool) {
     // should not affect LAPIC interrupts
     if vector < APIC_TIMER_VECTOR as _ {
+        let irq = vector_to_irq(vector);
         unsafe {
             if enabled {
-                IO_APIC.lock().enable_irq(vector as u8);
+                IO_APIC.lock().enable_irq(irq as u8);
             } else {
-                IO_APIC.lock().disable_irq(vector as u8);
+                IO_APIC.lock().disable_irq(irq as u8);
             }
         }
     }

--- a/modules/axhal/src/platform/pc_x86/apic.rs
+++ b/modules/axhal/src/platform/pc_x86/apic.rs
@@ -16,7 +16,7 @@ use crate::platform::pc_x86::current_cpu_id;
 use x2apic::ioapic::{IrqFlags, IrqMode};
 
 #[cfg(feature = "irq")]
-use crate::arch::{IRQ_VECTOR_START};
+use crate::arch::IRQ_VECTOR_START;
 /// map external IRQ to vector
 #[cfg(feature = "irq")]
 pub fn irq_to_vector(irq: u8) -> usize {

--- a/modules/axhal/src/platform/pc_x86/apic.rs
+++ b/modules/axhal/src/platform/pc_x86/apic.rs
@@ -11,11 +11,11 @@ use self::vectors::*;
 use crate::mem::phys_to_virt;
 
 #[cfg(feature = "irq")]
+use crate::arch::vector_to_irq;
+#[cfg(feature = "irq")]
 use crate::platform::pc_x86::current_cpu_id;
 #[cfg(feature = "irq")]
 use x2apic::ioapic::{IrqFlags, IrqMode};
-#[cfg(feature = "irq")]
-use crate::arch::{vector_to_irq};
 
 pub(super) mod vectors {
     pub const APIC_TIMER_VECTOR: u8 = 0xf0;
@@ -52,15 +52,15 @@ pub fn set_enable(vector: usize, enabled: bool) {
 
 /// Program IO_APIC in order to route IO_APIC IRQ to vector.
 #[cfg(feature = "irq")]
-fn ioapic_redirect(vector:usize){
+fn ioapic_redirect(vector: usize) {
     let irq = vector_to_irq(vector);
-    let mut table_entry = unsafe{IO_APIC.lock().table_entry(irq)};
+    let mut table_entry = unsafe { IO_APIC.lock().table_entry(irq) };
     table_entry.set_vector(vector as u8);
     table_entry.set_mode(IrqMode::Fixed);
     let irq_flag = table_entry.flags() - IrqFlags::MASKED;
     table_entry.set_flags(irq_flag);
     table_entry.set_dest(current_cpu_id() as u8);
-    unsafe{IO_APIC.lock().set_table_entry(irq, table_entry)};
+    unsafe { IO_APIC.lock().set_table_entry(irq, table_entry) };
 }
 
 /// Registers an IRQ handler for the given IRQ.

--- a/modules/axhal/src/platform/pc_x86/apic.rs
+++ b/modules/axhal/src/platform/pc_x86/apic.rs
@@ -11,11 +11,22 @@ use self::vectors::*;
 use crate::mem::phys_to_virt;
 
 #[cfg(feature = "irq")]
-use crate::arch::vector_to_irq;
-#[cfg(feature = "irq")]
 use crate::platform::pc_x86::current_cpu_id;
 #[cfg(feature = "irq")]
 use x2apic::ioapic::{IrqFlags, IrqMode};
+
+#[cfg(feature = "irq")]
+use crate::arch::{IRQ_VECTOR_START};
+/// map external IRQ to vector
+#[cfg(feature = "irq")]
+pub fn irq_to_vector(irq: u8) -> usize {
+    (irq + IRQ_VECTOR_START) as usize
+}
+/// map vector to external IRQ
+#[cfg(feature = "irq")]
+pub fn vector_to_irq(vector: usize) -> u8 {
+    vector as u8 - IRQ_VECTOR_START
+}
 
 pub(super) mod vectors {
     pub const APIC_TIMER_VECTOR: u8 = 0xf0;

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -15,7 +15,7 @@ pub mod irq {
     pub use super::apic::*;
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "axalloc")]
 pub mod acpi;
 
 pub mod console {
@@ -61,7 +61,7 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "axalloc")]
     self::acpi::init();
 }
 

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -6,6 +6,7 @@ mod uart16550;
 pub mod mem;
 pub mod misc;
 pub mod time;
+pub mod acpi;
 
 #[cfg(feature = "smp")]
 pub mod mp;
@@ -58,6 +59,7 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
+    self::acpi::init();
 }
 
 /// Initializes the platform devices for secondary CPUs.

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -6,6 +6,7 @@ mod uart16550;
 pub mod mem;
 pub mod misc;
 pub mod time;
+#[cfg(feature = "alloc")]
 pub mod acpi;
 
 #[cfg(feature = "smp")]
@@ -59,6 +60,7 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
+    #[cfg(feature = "alloc")]
     self::acpi::init();
 }
 

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -3,27 +3,19 @@ mod boot;
 mod dtables;
 mod uart16550;
 
-/// acpi module
-#[cfg(feature = "irq")]
 pub mod acpi;
-/// mem module
 pub mod mem;
-/// misc module
 pub mod misc;
-/// time module
 pub mod time;
 
-/// mp module
 #[cfg(feature = "smp")]
 pub mod mp;
 
-/// irq module
 #[cfg(feature = "irq")]
 pub mod irq {
     pub use super::apic::*;
 }
 
-/// console module
 pub mod console {
     pub use super::uart16550::*;
 }
@@ -67,7 +59,6 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
-    #[cfg(feature = "irq")]
     self::acpi::init();
 }
 

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -3,11 +3,11 @@ mod boot;
 mod dtables;
 mod uart16550;
 
+#[cfg(feature = "alloc")]
+pub mod acpi;
 pub mod mem;
 pub mod misc;
 pub mod time;
-#[cfg(feature = "alloc")]
-pub mod acpi;
 
 #[cfg(feature = "smp")]
 pub mod mp;

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -3,7 +3,6 @@ mod boot;
 mod dtables;
 mod uart16550;
 
-pub mod acpi;
 pub mod mem;
 pub mod misc;
 pub mod time;
@@ -15,6 +14,9 @@ pub mod mp;
 pub mod irq {
     pub use super::apic::*;
 }
+
+#[cfg(feature = "alloc")]
+pub mod acpi;
 
 pub mod console {
     pub use super::uart16550::*;
@@ -59,6 +61,7 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
+    #[cfg(feature = "alloc")]
     self::acpi::init();
 }
 

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -3,20 +3,27 @@ mod boot;
 mod dtables;
 mod uart16550;
 
+/// acpi module
 #[cfg(feature = "alloc")]
 pub mod acpi;
+/// mem module
 pub mod mem;
+/// misc module
 pub mod misc;
+/// time module
 pub mod time;
 
+/// mp module
 #[cfg(feature = "smp")]
 pub mod mp;
 
+/// irq module
 #[cfg(feature = "irq")]
 pub mod irq {
     pub use super::apic::*;
 }
 
+/// console module
 pub mod console {
     pub use super::uart16550::*;
 }

--- a/modules/axhal/src/platform/pc_x86/mod.rs
+++ b/modules/axhal/src/platform/pc_x86/mod.rs
@@ -4,7 +4,7 @@ mod dtables;
 mod uart16550;
 
 /// acpi module
-#[cfg(feature = "alloc")]
+#[cfg(feature = "irq")]
 pub mod acpi;
 /// mem module
 pub mod mem;
@@ -67,7 +67,7 @@ unsafe extern "C" fn rust_entry_secondary(magic: usize) {
 pub fn platform_init() {
     self::apic::init_primary();
     self::time::init_primary();
-    #[cfg(feature = "alloc")]
+    #[cfg(feature = "irq")]
     self::acpi::init();
 }
 


### PR DESCRIPTION
This PR
- obtain the routing info from PCIe device pin to IOAPIC irq pin using ACPI table.
- route IOAPIC irq to interrupt vector by programming IOAPIC.

Since the virtio framework in the main branch does not currently support interrupts, this PR provides the `get_pci_irq_vector` function for fetching x86_64 device interrupt numbers.