### PR TITLE
Modifying network interfaces to accommodate different network devices, optimizing virtio-net performance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,8 +1414,7 @@ dependencies = [
 [[package]]
 name = "smoltcp"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2e3a36ac8fea7b94e666dfa3871063d6e0a5c9d5d4fec9a1a6b7b6760f0229"
+source = "git+https://github.com/rcore-os/smoltcp.git?rev=2ade274#2ade2747abc4d779d0836154b0413d13ce16cd5b"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/crates/driver_net/src/lib.rs
+++ b/crates/driver_net/src/lib.rs
@@ -6,18 +6,18 @@
 
 mod net_buf;
 
+use core::ptr::NonNull;
+
 #[doc(no_inline)]
 pub use driver_common::{BaseDriverOps, DevError, DevResult, DeviceType};
 
-pub use self::net_buf::{NetBuffer, NetBufferBox, NetBufferPool};
+pub use self::net_buf::{NetBuf, NetBufBox, NetBufPool};
 
 /// The ethernet address of the NIC (MAC address).
 pub struct EthernetAddress(pub [u8; 6]);
 
 /// Operations that require a network device (NIC) driver to implement.
-///
-/// `'a` indicates the lifetime of the network buffers.
-pub trait NetDriverOps<'a>: BaseDriverOps {
+pub trait NetDriverOps: BaseDriverOps {
     /// The ethernet address of the NIC.
     fn mac_address(&self) -> EthernetAddress;
 
@@ -33,36 +33,71 @@ pub trait NetDriverOps<'a>: BaseDriverOps {
     /// Size of the transmit queue.
     fn tx_queue_size(&self) -> usize;
 
-    /// Fills the receive queue with buffers.
-    ///
-    /// It should be called once when the driver is initialized.
-    fn fill_rx_buffers(&mut self, buf_pool: &'a NetBufferPool) -> DevResult;
-
-    /// Prepares a buffer for transmitting.
-    ///
-    /// e.g., fill the header of the packet.
-    fn prepare_tx_buffer(&self, tx_buf: &mut NetBuffer, packet_len: usize) -> DevResult;
-
     /// Gives back the `rx_buf` to the receive queue for later receiving.
     ///
     /// `rx_buf` should be the same as the one returned by
     /// [`NetDriverOps::receive`].
-    fn recycle_rx_buffer(&mut self, rx_buf: NetBufferBox<'a>) -> DevResult;
+    fn recycle_rx_buffer(&mut self, rx_buf: NetBufPtr) -> DevResult;
 
-    /// Transmits a packet in the buffer to the network, and blocks until the
-    /// request completed.
-    ///
-    /// `tx_buf` should be initialized by [`NetDriverOps::prepare_tx_buffer`].
-    fn transmit(&mut self, tx_buf: &NetBuffer) -> DevResult;
+    /// Poll the transmit queue and gives back the buffers for previous transmiting.
+    /// returns [`DevResult`].
+    fn recycle_tx_buffers(&mut self) -> DevResult;
 
-    /// Receives a packet from the network and store it in the [`NetBuffer`],
+    /// Transmits a packet in the buffer to the network, without blocking,
+    /// returns [`DevResult`].
+    fn transmit(&mut self, tx_buf: NetBufPtr) -> DevResult;
+
+    /// Receives a packet from the network and store it in the [`NetBuf`],
     /// returns the buffer.
     ///
     /// Before receiving, the driver should have already populated some buffers
-    /// in the receive queue by [`NetDriverOps::fill_rx_buffers`] or
-    /// [`NetDriverOps::recycle_rx_buffer`].
+    /// in the receive queue by [`NetDriverOps::recycle_rx_buffer`].
     ///
     /// If currently no incomming packets, returns an error with type
     /// [`DevError::Again`].
-    fn receive(&mut self) -> DevResult<NetBufferBox<'a>>;
+    fn receive(&mut self) -> DevResult<NetBufPtr>;
+
+    /// Allocate a memory buffer of a specified size for network transmission,
+    /// returns [`DevResult`]
+    fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr>;
+}
+
+/// A raw buffer struct for network device.
+pub struct NetBufPtr {
+    // The raw pointer of the original object.
+    raw_ptr: NonNull<u8>,
+    // The pointer to the net buffer.
+    buf_ptr: NonNull<u8>,
+    len: usize,
+}
+
+impl NetBufPtr {
+    /// Create a new [`NetBufPtr`].
+    pub fn new(raw_ptr: NonNull<u8>, buf_ptr: NonNull<u8>, len: usize) -> Self {
+        Self {
+            raw_ptr,
+            buf_ptr,
+            len,
+        }
+    }
+
+    /// Return raw pointer of the original object.
+    pub fn raw_ptr<T>(&self) -> *mut T {
+        self.raw_ptr.as_ptr() as *mut T
+    }
+
+    /// Return [`NetBufPtr`] buffer len.
+    pub fn packet_len(&self) -> usize {
+        self.len
+    }
+
+    /// Return [`NetBufPtr`] buffer as &[u8].
+    pub fn packet(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf_ptr.as_ptr() as *const u8, self.len) }
+    }
+
+    /// Return [`NetBufPtr`] buffer as &mut [u8].
+    pub fn packet_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.buf_ptr.as_ptr(), self.len) }
+    }
 }

--- a/crates/driver_virtio/src/net.rs
+++ b/crates/driver_virtio/src/net.rs
@@ -1,31 +1,78 @@
 use crate::as_dev_err;
+use alloc::{sync::Arc, vec::Vec};
 use driver_common::{BaseDriverOps, DevError, DevResult, DeviceType};
-use driver_net::{EthernetAddress, NetBuffer, NetBufferBox, NetBufferPool, NetDriverOps};
+use driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
 use virtio_drivers::{device::net::VirtIONetRaw as InnerDev, transport::Transport, Hal};
+
+extern crate alloc;
+
+const NET_BUF_LEN: usize = 1526;
 
 /// The VirtIO network device driver.
 ///
 /// `QS` is the VirtIO queue size.
-pub struct VirtIoNetDev<'a, H: Hal, T: Transport, const QS: usize> {
-    rx_buffers: [Option<NetBufferBox<'a>>; QS],
+pub struct VirtIoNetDev<H: Hal, T: Transport, const QS: usize> {
+    rx_buffers: [Option<NetBufBox>; QS],
+    tx_buffers: [Option<NetBufBox>; QS],
+    free_tx_bufs: Vec<NetBufBox>,
+    buf_pool: Arc<NetBufPool>,
     inner: InnerDev<H, T, QS>,
 }
 
-unsafe impl<H: Hal, T: Transport, const QS: usize> Send for VirtIoNetDev<'_, H, T, QS> {}
-unsafe impl<H: Hal, T: Transport, const QS: usize> Sync for VirtIoNetDev<'_, H, T, QS> {}
+unsafe impl<H: Hal, T: Transport, const QS: usize> Send for VirtIoNetDev<H, T, QS> {}
+unsafe impl<H: Hal, T: Transport, const QS: usize> Sync for VirtIoNetDev<H, T, QS> {}
 
-impl<'a, H: Hal, T: Transport, const QS: usize> VirtIoNetDev<'a, H, T, QS> {
+impl<H: Hal, T: Transport, const QS: usize> VirtIoNetDev<H, T, QS> {
     /// Creates a new driver instance and initializes the device, or returns
     /// an error if any step fails.
     pub fn try_new(transport: T) -> DevResult<Self> {
-        const NONE_BUF: Option<NetBufferBox> = None;
+        // 0. Create a new driver instance.
+        const NONE_BUF: Option<NetBufBox> = None;
         let inner = InnerDev::new(transport).map_err(as_dev_err)?;
         let rx_buffers = [NONE_BUF; QS];
-        Ok(Self { rx_buffers, inner })
+        let tx_buffers = [NONE_BUF; QS];
+        let buf_pool = NetBufPool::new(2 * QS, NET_BUF_LEN)?;
+        let free_tx_bufs = Vec::with_capacity(QS);
+
+        let mut dev = Self {
+            rx_buffers,
+            inner,
+            tx_buffers,
+            free_tx_bufs,
+            buf_pool,
+        };
+
+        // 1. Fill all rx buffers.
+        for (i, rx_buf_place) in dev.rx_buffers.iter_mut().enumerate() {
+            let mut rx_buf = dev.buf_pool.alloc_boxed().ok_or(DevError::NoMemory)?;
+            // Safe because the buffer lives as long as the queue.
+            let token = unsafe {
+                dev.inner
+                    .receive_begin(rx_buf.raw_buf_mut())
+                    .map_err(as_dev_err)?
+            };
+            assert_eq!(token, i as u16);
+            *rx_buf_place = Some(rx_buf);
+        }
+
+        // 2. Allocate all tx buffers.
+        for _ in 0..QS {
+            let mut tx_buf = dev.buf_pool.alloc_boxed().ok_or(DevError::NoMemory)?;
+            // Fill header
+            let hdr_len = dev
+                .inner
+                .fill_buffer_header(tx_buf.raw_buf_mut())
+                .or(Err(DevError::InvalidParam))?;
+            tx_buf.set_header_len(hdr_len);
+            dev.free_tx_bufs.push(tx_buf);
+        }
+
+        // 3. Return the driver instance.
+        Ok(dev)
     }
 }
 
-impl<H: Hal, T: Transport, const QS: usize> const BaseDriverOps for VirtIoNetDev<'_, H, T, QS> {
+impl<H: Hal, T: Transport, const QS: usize> const BaseDriverOps for VirtIoNetDev<H, T, QS> {
     fn device_name(&self) -> &str {
         "virtio-net"
     }
@@ -35,7 +82,7 @@ impl<H: Hal, T: Transport, const QS: usize> const BaseDriverOps for VirtIoNetDev
     }
 }
 
-impl<'a, H: Hal, T: Transport, const QS: usize> NetDriverOps<'a> for VirtIoNetDev<'a, H, T, QS> {
+impl<H: Hal, T: Transport, const QS: usize> NetDriverOps for VirtIoNetDev<H, T, QS> {
     #[inline]
     fn mac_address(&self) -> EthernetAddress {
         EthernetAddress(self.inner.mac_address())
@@ -43,7 +90,7 @@ impl<'a, H: Hal, T: Transport, const QS: usize> NetDriverOps<'a> for VirtIoNetDe
 
     #[inline]
     fn can_transmit(&self) -> bool {
-        self.inner.can_transmit()
+        !self.free_tx_bufs.is_empty() && self.inner.can_transmit()
     }
 
     #[inline]
@@ -61,35 +108,8 @@ impl<'a, H: Hal, T: Transport, const QS: usize> NetDriverOps<'a> for VirtIoNetDe
         QS
     }
 
-    fn fill_rx_buffers(&mut self, buf_pool: &'a NetBufferPool) -> DevResult {
-        for (i, rx_buf_place) in self.rx_buffers.iter_mut().enumerate() {
-            let mut rx_buf = buf_pool.alloc_boxed().ok_or(DevError::NoMemory)?;
-            // Safe because the buffer lives as long as the queue.
-            let token = unsafe {
-                self.inner
-                    .receive_begin(rx_buf.raw_buf_mut())
-                    .map_err(as_dev_err)?
-            };
-            assert_eq!(token, i as u16);
-            *rx_buf_place = Some(rx_buf);
-        }
-        Ok(())
-    }
-
-    fn prepare_tx_buffer(&self, tx_buf: &mut NetBuffer, pkt_len: usize) -> DevResult {
-        let hdr_len = self
-            .inner
-            .fill_buffer_header(tx_buf.raw_buf_mut())
-            .or(Err(DevError::InvalidParam))?;
-        if hdr_len + pkt_len > tx_buf.capacity() {
-            return Err(DevError::InvalidParam);
-        }
-        tx_buf.set_header_len(hdr_len);
-        tx_buf.set_packet_len(pkt_len);
-        Ok(())
-    }
-
-    fn recycle_rx_buffer(&mut self, mut rx_buf: NetBufferBox<'a>) -> DevResult {
+    fn recycle_rx_buffer(&mut self, rx_buf: NetBufPtr) -> DevResult {
+        let mut rx_buf = unsafe { NetBuf::from_buf_ptr(rx_buf) };
         // Safe because we take the ownership of `rx_buf` back to `rx_buffers`,
         // it lives as long as the queue.
         let new_token = unsafe {
@@ -106,14 +126,36 @@ impl<'a, H: Hal, T: Transport, const QS: usize> NetDriverOps<'a> for VirtIoNetDe
         Ok(())
     }
 
-    fn transmit(&mut self, tx_buf: &NetBuffer) -> DevResult {
-        self.inner
-            .transmit_wait(tx_buf.packet_with_header())
-            .map_err(as_dev_err)?;
+    fn recycle_tx_buffers(&mut self) -> DevResult {
+        while let Some(token) = self.inner.poll_transmit() {
+            let tx_buf = self.tx_buffers[token as usize]
+                .take()
+                .ok_or(DevError::BadState)?;
+            unsafe {
+                self.inner
+                    .transmit_complete(token, tx_buf.packet_with_header())
+                    .map_err(as_dev_err)?;
+            }
+            // Recycle the buffer.
+            self.free_tx_bufs.push(tx_buf);
+        }
         Ok(())
     }
 
-    fn receive(&mut self) -> DevResult<NetBufferBox<'a>> {
+    fn transmit(&mut self, tx_buf: NetBufPtr) -> DevResult {
+        // 0. prepare tx buffer.
+        let tx_buf = unsafe { NetBuf::from_buf_ptr(tx_buf) };
+        // 1. transmit packet.
+        let token = unsafe {
+            self.inner
+                .transmit_begin(tx_buf.packet_with_header())
+                .map_err(as_dev_err)?
+        };
+        self.tx_buffers[token as usize] = Some(tx_buf);
+        Ok(())
+    }
+
+    fn receive(&mut self) -> DevResult<NetBufPtr> {
         if let Some(token) = self.inner.poll_receive() {
             let mut rx_buf = self.rx_buffers[token as usize]
                 .take()
@@ -126,9 +168,26 @@ impl<'a, H: Hal, T: Transport, const QS: usize> NetDriverOps<'a> for VirtIoNetDe
             };
             rx_buf.set_header_len(hdr_len);
             rx_buf.set_packet_len(pkt_len);
-            Ok(rx_buf)
+
+            Ok(rx_buf.into_buf_ptr())
         } else {
             Err(DevError::Again)
         }
+    }
+
+    fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr> {
+        // 0. Allocate a buffer from the queue.
+        let mut net_buf = self.free_tx_bufs.pop().ok_or(DevError::NoMemory)?;
+        let pkt_len = size;
+
+        // 1. Check if the buffer is large enough.
+        let hdr_len = net_buf.header_len();
+        if hdr_len + pkt_len > net_buf.capacity() {
+            return Err(DevError::InvalidParam);
+        }
+        net_buf.set_packet_len(pkt_len);
+
+        // 2. Return the buffer.
+        Ok(net_buf.into_buf_ptr())
     }
 }

--- a/modules/axdriver/src/dummy.rs
+++ b/modules/axdriver/src/dummy.rs
@@ -8,7 +8,7 @@ use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(net_dev = "dummy")] {
-        use driver_net::{EthernetAddress, NetBuffer, NetBufferBox, NetBufferPool};
+        use driver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr};
 
         pub struct DummyNetDev;
         pub struct DummyNetDrvier;
@@ -19,17 +19,17 @@ cfg_if! {
             fn device_name(&self) -> &str { "dummy-net" }
         }
 
-        impl<'a> NetDriverOps<'a> for DummyNetDev {
+        impl NetDriverOps for DummyNetDev {
             fn mac_address(&self) -> EthernetAddress { unreachable!() }
             fn can_transmit(&self) -> bool { false }
             fn can_receive(&self) -> bool { false }
             fn rx_queue_size(&self) -> usize { 0 }
             fn tx_queue_size(&self) -> usize { 0 }
-            fn fill_rx_buffers(&mut self, _: &NetBufferPool) -> DevResult { Err(DevError::Unsupported) }
-            fn prepare_tx_buffer(&self, _: &mut NetBuffer, _: usize) -> DevResult { Err(DevError::Unsupported) }
-            fn recycle_rx_buffer(&mut self, _: NetBufferBox<'a>) -> DevResult { Err(DevError::Unsupported) }
-            fn transmit(&mut self, _: &NetBuffer) -> DevResult { Err(DevError::Unsupported) }
-            fn receive(&mut self) -> DevResult<NetBufferBox<'a>> { Err(DevError::Unsupported) }
+            fn recycle_rx_buffer(&mut self, _: NetBufPtr) -> DevResult { Err(DevError::Unsupported) }
+            fn recycle_tx_buffers(&mut self) -> DevResult { Err(DevError::Unsupported) }
+            fn transmit(&mut self, _: NetBufPtr) -> DevResult { Err(DevError::Unsupported) }
+            fn receive(&mut self) -> DevResult<NetBufPtr> { Err(DevError::Unsupported) }
+            fn alloc_tx_buffer(&mut self, _: usize) -> DevResult<NetBufPtr> { Err(DevError::Unsupported) }
         }
     }
 }

--- a/modules/axdriver/src/structs/dyn.rs
+++ b/modules/axdriver/src/structs/dyn.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 
 /// The unified type of the NIC devices.
 #[cfg(feature = "net")]
-pub type AxNetDevice = Box<dyn NetDriverOps<'static>>;
+pub type AxNetDevice = Box<dyn NetDriverOps>;
 /// The unified type of the block storage devices.
 #[cfg(feature = "block")]
 pub type AxBlockDevice = Box<dyn BlockDriverOps>;
@@ -16,7 +16,7 @@ pub type AxDisplayDevice = Box<dyn DisplayDriverOps>;
 impl super::AxDeviceEnum {
     /// Constructs a network device.
     #[cfg(feature = "net")]
-    pub fn from_net(dev: impl NetDriverOps<'static> + 'static) -> Self {
+    pub fn from_net(dev: impl NetDriverOps + 'static) -> Self {
         Self::Net(Box::new(dev))
     }
 

--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -34,7 +34,7 @@ cfg_if! {
 
         impl VirtIoDevMeta for VirtIoNet {
             const DEVICE_TYPE: DeviceType = DeviceType::Net;
-            type Device = driver_virtio::VirtIoNetDev<'static, VirtIoHalImpl, VirtIoTransport, 64>;
+            type Device = driver_virtio::VirtIoNetDev<VirtIoHalImpl, VirtIoTransport, 64>;
 
             fn try_new(transport: VirtIoTransport) -> DevResult<AxDeviceEnum> {
                 Ok(AxDeviceEnum::from_net(Self::Device::try_new(transport)?))

--- a/modules/axnet/Cargo.toml
+++ b/modules/axnet/Cargo.toml
@@ -26,7 +26,8 @@ axdriver = { path = "../axdriver", features = ["net"] }
 axio = { path = "../../crates/axio" }
 
 [dependencies.smoltcp]
-version = "0.10"
+git = "https://github.com/rcore-os/smoltcp.git"
+rev = "2ade274"
 default-features = false
 features = [
   "alloc", "log",   # no std


### PR DESCRIPTION
This is a relatively large PR that does the following things:
- Redesigned the network abstraction interface to accommodate different types of network devices.
- Set virtio-net transmit to non-blocking for improved performance.
- Recycle `tx_buffer` and reuse it during the next allocation to reduce dynamic memory allocation.
- Replace `&` with `Arc` in `NetBuffer` to hold references to `NetBufferPool`, eliminating the dependency on lifetimes.
- Modify `smoltcp` to remove the usage of `DeviceWrapper` `rx_buf_queue` for improved performance.