### PR TITLE
net: Add network Ethernet bandwidth benchmark testing tool.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arceos-bwbench"
+version = "0.1.0"
+dependencies = [
+ "axnet",
+ "libax",
+]
+
+[[package]]
 name = "arceos-display"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "apps/net/httpclient",
     "apps/net/httpserver",
     "apps/net/udpserver",
+    "apps/net/bwbench",
     "apps/task/parallel",
     "apps/task/sleep",
     "apps/task/yield",

--- a/apps/net/bwbench/Cargo.toml
+++ b/apps/net/bwbench/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "arceos-bwbench"
+version = "0.1.0"
+edition = "2021"
+authors = ["ChengXiang Qi <kuangjux@outlook.com>"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libax = {path = "../../../ulib/libax", features = ["net"]}
+axnet = {path = "../../../modules/axnet"}

--- a/apps/net/bwbench/src/main.rs
+++ b/apps/net/bwbench/src/main.rs
@@ -1,0 +1,11 @@
+#![no_std]
+#![no_main]
+
+extern crate libax;
+
+#[no_mangle]
+fn main() {
+    libax::println!("Benchmarking bandwidth...");
+    axnet::bench_transmit();
+    // axnet::bench_receive();
+}

--- a/modules/axnet/Cargo.toml
+++ b/modules/axnet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axnet"
 version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = ["Yuekai Jia <equation618@gmail.com>", "ChengXiang Qi <kuangjux@outlook.com>"]
 description = "ArceOS network module"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"

--- a/modules/axnet/src/lib.rs
+++ b/modules/axnet/src/lib.rs
@@ -35,6 +35,7 @@ cfg_if::cfg_if! {
 
 pub use self::net_impl::TcpSocket;
 pub use self::net_impl::UdpSocket;
+pub use self::net_impl::{bench_receive, bench_transmit};
 pub use self::net_impl::{poll_interfaces, resolve_socket_addr};
 pub use smoltcp::wire::{IpAddress as IpAddr, IpEndpoint as SocketAddr, Ipv4Address as Ipv4Addr};
 

--- a/modules/axnet/src/smoltcp_impl/bench.rs
+++ b/modules/axnet/src/smoltcp_impl/bench.rs
@@ -1,0 +1,74 @@
+use super::{AxNetRxToken, AxNetTxToken, STANDARD_MTU};
+use super::{DeviceWrapper, InterfaceWrapper};
+use smoltcp::phy::{Device, RxToken, TxToken};
+
+const GB: usize = 1000 * MB;
+const MB: usize = 1000 * KB;
+const KB: usize = 1000;
+
+impl DeviceWrapper {
+    pub fn bench_transmit_bandwidth(&mut self) {
+        // 10 Gb
+        const MAX_SEND_BYTES: usize = 10 * GB;
+        let mut send_bytes: usize = 0;
+        let mut past_send_bytes: usize = 0;
+        let mut past_time = InterfaceWrapper::current_time();
+
+        // Send bytes
+        while send_bytes < MAX_SEND_BYTES {
+            if let Some(tx_token) = self.transmit(InterfaceWrapper::current_time()) {
+                AxNetTxToken::consume(tx_token, STANDARD_MTU, |tx_buf| {
+                    tx_buf[0..12].fill(1);
+                    // ether type: IPv4
+                    tx_buf[12..14].copy_from_slice(&[0x08, 0x00]);
+                    tx_buf[14..STANDARD_MTU].fill(1);
+                });
+                send_bytes += STANDARD_MTU;
+            }
+
+            let current_time = InterfaceWrapper::current_time();
+            if (current_time - past_time).secs() == 1 {
+                let gb = ((send_bytes - past_send_bytes) * 8) / GB;
+                let mb = (((send_bytes - past_send_bytes) * 8) % GB) / MB;
+                let gib = (send_bytes - past_send_bytes) / GB;
+                let mib = ((send_bytes - past_send_bytes) % GB) / MB;
+                info!(
+                    "Transmit: {}.{:03}GBytes, Bandwidth: {}.{:03}Gbits/sec.",
+                    gib, mib, gb, mb
+                );
+                past_time = current_time;
+                past_send_bytes = send_bytes;
+            }
+        }
+    }
+
+    pub fn bench_receive_bandwidth(&mut self) {
+        // 10 Gb
+        const MAX_RECEIVE_BYTES: usize = 10 * GB;
+        let mut receive_bytes: usize = 0;
+        let mut past_receive_bytes: usize = 0;
+        let mut past_time = InterfaceWrapper::current_time();
+        // Receive bytes
+        while receive_bytes < MAX_RECEIVE_BYTES {
+            if let Some(rx_token) = self.receive(InterfaceWrapper::current_time()) {
+                AxNetRxToken::consume(rx_token.0, |rx_buf| {
+                    receive_bytes += rx_buf.len();
+                });
+            }
+
+            let current_time = InterfaceWrapper::current_time();
+            if (current_time - past_time).secs() == 1 {
+                let gb = ((receive_bytes - past_receive_bytes) * 8) / GB;
+                let mb = (((receive_bytes - past_receive_bytes) * 8) % GB) / MB;
+                let gib = (receive_bytes - past_receive_bytes) / GB;
+                let mib = ((receive_bytes - past_receive_bytes) % GB) / MB;
+                info!(
+                    "Receive: {}.{:03}GBytes, Bandwidth: {}.{:03}Gbits/sec.",
+                    gib, mib, gb, mb
+                );
+                past_time = current_time;
+                past_receive_bytes = receive_bytes;
+            }
+        }
+    }
+}

--- a/modules/axnet/src/smoltcp_impl/mod.rs
+++ b/modules/axnet/src/smoltcp_impl/mod.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod dns;
 mod listen_table;
 mod tcp;
@@ -28,6 +29,8 @@ const IP: IpAddress = IpAddress::v4(10, 0, 2, 15); // QEMU user networking defau
 const GATEWAY: IpAddress = IpAddress::v4(10, 0, 2, 2); // QEMU user networking gateway
 const DNS_SEVER: IpAddress = IpAddress::v4(8, 8, 8, 8);
 const IP_PREFIX: u8 = 24;
+
+const STANDARD_MTU: usize = 1500;
 
 const RANDOM_SEED: u64 = 0xA2CE_05A2_CE05_A2CE;
 
@@ -285,6 +288,16 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) -> Result<(), smolt
 /// packets to the NIC.
 pub fn poll_interfaces() {
     SOCKET_SET.poll_interfaces();
+}
+
+/// Benchmark raw socket transmit bandwidth.
+pub fn bench_transmit() {
+    ETH0.dev.lock().bench_transmit_bandwidth();
+}
+
+/// Benchmark raw socket receive bandwidth.
+pub fn bench_receive() {
+    ETH0.dev.lock().bench_receive_bandwidth();
 }
 
 pub(crate) fn init(net_dev: AxNetDevice) {

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,5 @@
 deptool/Cargo.lock
 deptool/target
 deptool/output.txt
+bwbench_client/target
+bwbench_client/Cargo.lock

--- a/tools/bwbench_client/Cargo.toml
+++ b/tools/bwbench_client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bwbench-client"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = "0.4"
+libc = "0.2.18"
+
+[workspace]

--- a/tools/bwbench_client/README.md
+++ b/tools/bwbench_client/README.md
@@ -1,0 +1,18 @@
+# Benchmark BandWidth Client
+
+Benchmark BandWidth Client is a performance testing tool for measuring the network card's ability to send Ethernet packets. It can test both the transmission throughput and the reception throughput.
+
+## Usage
+In client:
+```shell
+cargo run --release [sender|receiver] [interface]
+```
+
+By reading the source code, you can control the behavior of the benchmark by modifying constants such as `MAX_BYTES`.
+
+In arceos: 
+```
+make A=apps/net/bwbench NET=y run
+```
+
+By default, arceos `bebench` uses `bench_transmit`. You can uncomment the line and add `bench_receive`, but please note that currently only one of either `bench_transmit` or `bench_receive` is allowed to be enabled.

--- a/tools/bwbench_client/src/device.rs
+++ b/tools/bwbench_client/src/device.rs
@@ -1,0 +1,217 @@
+use std::os::unix::io::AsRawFd;
+
+const ETH_P_ALL: libc::c_short = 0x0003;
+const SIOCGIFINDEX: libc::c_ulong = 0x8933;
+const SIOCGIFMTU: libc::c_ulong = 0x8921;
+const SIOCSIFMTU: libc::c_ulong = 0x8922;
+const SIOCGIFHWADDR: libc::c_ulong = 0x8927;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+union ifreq_data {
+    ifr_mtu: libc::c_int,
+    mac_addr: libc::sockaddr,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct ifreq {
+    ifr_name: [libc::c_char; libc::IF_NAMESIZE],
+    ifr_data: ifreq_data,
+}
+
+impl ifreq {
+    #[cfg(target_os = "linux")]
+    fn ifreq_for(interface: &str) -> ifreq {
+        let mut ifreq = ifreq {
+            ifr_name: [0; libc::IF_NAMESIZE],
+            ifr_data: ifreq_data { ifr_mtu: 0 },
+        };
+        for (i, byte) in interface.as_bytes().iter().enumerate() {
+            ifreq.ifr_name[i] = *byte as libc::c_char
+        }
+        ifreq
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ioctl(&mut self, lower: libc::c_int, cmd: libc::c_ulong) -> std::io::Result<ifreq_data> {
+        unsafe {
+            if libc::ioctl(lower, cmd as _, self as *mut Self) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+        Ok(self.ifr_data)
+    }
+}
+
+pub struct NetDevice {
+    fd: libc::c_int,
+    ifreq: ifreq,
+    mac_addr: [u8; 6],
+}
+
+impl AsRawFd for NetDevice {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.fd
+    }
+}
+
+impl NetDevice {
+    pub fn new(interface: &str) -> std::io::Result<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            let lower = unsafe {
+                let lower = libc::socket(
+                    libc::AF_PACKET,
+                    libc::SOCK_RAW | libc::SOCK_NONBLOCK,
+                    ETH_P_ALL.to_be() as i32,
+                );
+                if lower == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                lower
+            };
+
+            let mut ifreq = ifreq::ifreq_for(interface);
+
+            let ifreq_mac_addr = unsafe { ifreq.ioctl(lower, SIOCGIFHWADDR)?.mac_addr };
+            let mut mac_addr = [0u8; 6];
+            for i in 0..6 {
+                mac_addr[i] = ifreq_mac_addr.sa_data[i] as u8;
+            }
+
+            println!(
+                "Device MAC: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]
+            );
+
+            let mut dev = Self {
+                fd: lower,
+                ifreq,
+                mac_addr,
+            };
+
+            dev.bind_interface()?;
+
+            let mtu = dev.interface_mtu()?;
+            println!("DEVICE MTU: {}", mtu);
+
+            Ok(dev)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Not supported",
+            ))
+        }
+    }
+
+    pub fn mac_addr(&self) -> [u8; 6] {
+        self.mac_addr
+    }
+
+    pub fn bind_interface(&mut self) -> std::io::Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            let sockaddr = libc::sockaddr_ll {
+                sll_family: libc::AF_PACKET as u16,
+                sll_protocol: ETH_P_ALL.to_be() as u16,
+                sll_ifindex: unsafe {
+                    self.ifreq.ioctl(self.fd, SIOCGIFINDEX)?.ifr_mtu as libc::c_int
+                },
+                sll_hatype: 1,
+                sll_pkttype: 0,
+                sll_halen: 6,
+                sll_addr: [0; 8],
+            };
+
+            unsafe {
+                let res = libc::bind(
+                    self.fd,
+                    &sockaddr as *const libc::sockaddr_ll as *const libc::sockaddr,
+                    std::mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+                );
+                if res == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+            }
+
+            Ok(())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Not supported",
+            ))
+        }
+    }
+
+    pub fn interface_mtu(&mut self) -> std::io::Result<usize> {
+        #[cfg(target_os = "linux")]
+        {
+            self.ifreq
+                .ioctl(self.fd, SIOCGIFMTU)
+                .map(|mtu| unsafe { mtu.ifr_mtu as usize })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Not supported",
+            ))
+        }
+    }
+
+    pub fn recv(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let len = unsafe {
+            libc::recv(
+                self.fd,
+                buffer.as_mut_ptr() as *mut libc::c_void,
+                buffer.len(),
+                0,
+            )
+        };
+
+        if len == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::WouldBlock {
+                return Err(err);
+            } else {
+                panic!("err: {:?}", err);
+            }
+        }
+        Ok(len as usize)
+    }
+
+    pub fn send(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let len = unsafe {
+            libc::send(
+                self.fd,
+                buffer.as_ptr() as *const libc::c_void,
+                buffer.len(),
+                0,
+            )
+        };
+
+        if len == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() == std::io::ErrorKind::WouldBlock {
+                return Err(err);
+            } else {
+                panic!("err: {:?}", err);
+            }
+        }
+        Ok(len as usize)
+    }
+}
+
+impl Drop for NetDevice {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.fd);
+        }
+    }
+}

--- a/tools/bwbench_client/src/main.rs
+++ b/tools/bwbench_client/src/main.rs
@@ -1,0 +1,133 @@
+//! A raw socket benchmark client.
+
+#![deny(warnings)]
+#![deny(missing_docs)]
+#![allow(dead_code, unused_variables)]
+
+use crate::device::NetDevice;
+use chrono::Local;
+use std::env;
+use std::fmt::Display;
+
+mod device;
+
+const STANDARD_MTU: usize = 1500;
+
+const MAX_BYTES: usize = 10 * GB;
+const MB: usize = 1000 * 1000;
+const GB: usize = 1000 * MB;
+
+struct EthernetMacAddress([u8; 6]);
+
+impl Display for EthernetMacAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mac = self.0;
+        write!(
+            f,
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+        )
+    }
+}
+
+enum Client {
+    Sender,
+    Receiver,
+}
+
+fn transmit_benchmark(interface: &str) {
+    println!("Sender Mode!");
+    let mut dev = NetDevice::new(interface).unwrap();
+
+    let mut tx_buf = [1u8; STANDARD_MTU];
+    // ether type: IPv4
+    tx_buf[12..14].copy_from_slice(&[0x08, 0x00]);
+
+    let mut send_bytes = 0;
+    let mut past_send_bytes = 0;
+    let mut past_time = Local::now();
+
+    loop {
+        if let Ok(len) = dev.send(&tx_buf[..]) {
+            send_bytes += len;
+            let current_time = Local::now();
+            if current_time.signed_duration_since(past_time).num_seconds() == 1 {
+                let gb = ((send_bytes - past_send_bytes) * 8) / GB;
+                let mb = (((send_bytes - past_send_bytes) * 8) % GB) / MB;
+                let gib = (send_bytes - past_send_bytes) / GB;
+                let mib = ((send_bytes - past_send_bytes) % GB) / MB;
+                println!(
+                    "Transfer: {}.{:03}GBytes, Bandwidth: {}.{:03}Gbits/sec.",
+                    gib, mib, gb, mb
+                );
+                past_send_bytes = send_bytes;
+                past_time = current_time;
+            }
+        }
+
+        if send_bytes >= MAX_BYTES {
+            break;
+        }
+    }
+}
+
+fn receive_benchmark(interface: &str) {
+    println!("Receiver Mode!");
+    let mut dev = NetDevice::new(interface).unwrap();
+
+    let mut receive_bytes = 0;
+    let mut past_receive_bytes = 0;
+    let mut past_time = Local::now();
+
+    let mut rx_buffer = [0; STANDARD_MTU];
+
+    loop {
+        if let Ok(len) = dev.recv(&mut rx_buffer) {
+            receive_bytes += len;
+        }
+
+        let current_time = Local::now();
+        if current_time.signed_duration_since(past_time).num_seconds() == 1 {
+            let gb = ((receive_bytes - past_receive_bytes) * 8) / GB;
+            let mb = (((receive_bytes - past_receive_bytes) * 8) % GB) / MB;
+            let gib = (receive_bytes - past_receive_bytes) / GB;
+            let mib = ((receive_bytes - past_receive_bytes) % GB) / MB;
+            println!(
+                "Receive: {}.{:03}GBytes, Bandwidth: {}.{:03}Gbits/sec.",
+                gib, mib, gb, mb
+            );
+            past_receive_bytes = receive_bytes;
+            past_time = current_time;
+        }
+
+        if receive_bytes >= MAX_BYTES {
+            break;
+        }
+    }
+}
+
+fn benchmark_bandwidth(client: Client, interface: &str) {
+    match client {
+        Client::Sender => transmit_benchmark(interface),
+        Client::Receiver => receive_benchmark(interface),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 3 {
+        panic!("Usage: cargo run --release [send|receive] <interface>");
+    }
+
+    let kind = args[1].as_str();
+    let client = match kind.chars().next().unwrap() {
+        's' => Client::Sender,
+        'r' => Client::Receiver,
+        _ => panic!("Unknown Mode!"),
+    };
+
+    let interface = args[2].as_str();
+
+    benchmark_bandwidth(client, interface);
+}


### PR DESCRIPTION
In order to analyze network performance bottlenecks in either the network card driver or the kernel protocol stack, this PR primarily develops an Ethernet raw packet send/receive performance analysis tool. It accomplishes the following tasks:

- Implements network send/receive bandwidth performance testing based on the smoltcp Device in `modules/axnet`, and adds the `apps/net/benchmark_bandwidth` application.
- Adds `benchmark_bandwidth_client` to work in conjunction with arceos `benchmark_bandwidth`.
- You can perform performance testing operations between different network cards and hosts by configuring constants such as `MAX_SIZE`, `SRC_MAC`, and `DST_MAC`.