### PR TITLE
net: Add support for Intel 82599 (ixgbe) NIC & performed performance optimization.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator"
 version = "0.1.0"
 dependencies = [
@@ -168,7 +177,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -425,7 +434,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.22",
+ "syn 2.0.27",
  "which",
 ]
 
@@ -590,12 +599,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "crate_interface"
 version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -624,7 +639,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -659,6 +674,8 @@ name = "driver_net"
 version = "0.1.0"
 dependencies = [
  "driver_common",
+ "ixgbe-driver",
+ "log",
  "spin 0.9.8",
 ]
 
@@ -721,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -748,12 +765,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fatfs"
@@ -851,12 +865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,30 +908,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "ixgbe-driver"
+version = "0.1.0"
+source = "git+https://github.com/KuangjuX/ixgbe-driver.git?rev=8e5eb74#8e5eb741299d7d95c373ec745e39a1473fe84563"
+dependencies = [
+ "bit_field",
+ "core_detect",
+ "log",
+ "smoltcp",
+ "volatile 0.3.0",
+]
 
 [[package]]
 name = "js-sys"
@@ -1009,9 +1009,9 @@ version = "0.1.0"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "peeking_take_while"
@@ -1151,7 +1151,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1162,12 +1162,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1196,18 +1196,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -1275,18 +1275,32 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "riscv"
@@ -1316,13 +1330,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -1330,15 +1343,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sbi-rt"
@@ -1367,41 +1380,41 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "3b88756493a5bd5e5395d53baa70b194b05764ab85b59e43e4b8f4e1192fa9b1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1489,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1500,11 +1513,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall",
@@ -1529,22 +1541,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1585,9 +1597,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -1600,14 +1612,14 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "version_check"
@@ -1630,6 +1642,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "volatile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
 
 [[package]]
 name = "volatile"
@@ -1670,7 +1688,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
  "wasm-bindgen-shared",
 ]
 
@@ -1692,7 +1710,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.27",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1765,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1822,9 +1840,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
 ]
@@ -1862,7 +1880,7 @@ dependencies = [
  "bit_field",
  "bitflags 1.3.2",
  "rustversion",
- "volatile",
+ "volatile 0.4.6",
 ]
 
 [[package]]

--- a/crates/driver_net/Cargo.toml
+++ b/crates/driver_net/Cargo.toml
@@ -2,13 +2,19 @@
 name = "driver_net"
 version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = ["Yuekai Jia <equation618@gmail.com>", "ChengXiang Qi <kuangjux@outlook.com>"]
 description = "Common traits and types for network device (NIC) drivers"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"
 repository = "https://github.com/rcore-os/arceos/tree/main/crates/driver_net"
 documentation = "https://rcore-os.github.io/arceos/driver_net/index.html"
 
+[features]
+default = []
+ixgbe = ["dep:ixgbe-driver"]
+
 [dependencies]
 spin = "0.9"
+log = "0.4"
 driver_common = { path = "../driver_common" }
+ixgbe-driver = {git = "https://github.com/KuangjuX/ixgbe-driver.git", rev = "8e5eb74", optional = true}

--- a/crates/driver_net/src/ixgbe.rs
+++ b/crates/driver_net/src/ixgbe.rs
@@ -1,0 +1,160 @@
+use core::convert::From;
+use core::{mem::ManuallyDrop, ptr::NonNull};
+
+use alloc::{collections::VecDeque, sync::Arc};
+use driver_common::{BaseDriverOps, DevError, DevResult, DeviceType};
+use ixgbe_driver::{IxgbeDevice, IxgbeError, IxgbeNetBuf, MemPool, NicDevice};
+pub use ixgbe_driver::{IxgbeHal, PhysAddr, INTEL_82599, INTEL_VEND};
+
+use crate::{EthernetAddress, NetBufPtr, NetDriverOps};
+
+extern crate alloc;
+
+const RECV_BATCH_SIZE: usize = 64;
+const RX_BUFFER_SIZE: usize = 1024;
+const MEM_POOL: usize = 4096;
+const MEM_POOL_ENTRY_SIZE: usize = 2048;
+
+/// The ixgbe NIC device driver.
+///
+/// `QS` is the ixgbe queue size, `QN` is the ixgbe queue num.
+pub struct IxgbeNic<H: IxgbeHal, const QS: usize, const QN: u16> {
+    inner: IxgbeDevice<H, QS>,
+    mem_pool: Arc<MemPool>,
+    rx_buffer_queue: VecDeque<NetBufPtr>,
+}
+
+unsafe impl<H: IxgbeHal, const QS: usize, const QN: u16> Sync for IxgbeNic<H, QS, QN> {}
+unsafe impl<H: IxgbeHal, const QS: usize, const QN: u16> Send for IxgbeNic<H, QS, QN> {}
+
+impl<H: IxgbeHal, const QS: usize, const QN: u16> IxgbeNic<H, QS, QN> {
+    /// Creates a net ixgbe NIC instance and initialize, or returns a error if
+    /// any step fails.
+    pub fn init(base: usize, len: usize) -> DevResult<Self> {
+        let mem_pool = MemPool::allocate::<H>(MEM_POOL, MEM_POOL_ENTRY_SIZE)
+            .map_err(|_| DevError::NoMemory)?;
+        let inner = IxgbeDevice::<H, QS>::init(base, len, QN, QN, &mem_pool).map_err(|err| {
+            log::error!("Failed to initialize ixgbe device: {:?}", err);
+            DevError::BadState
+        })?;
+
+        let rx_buffer_queue = VecDeque::with_capacity(RX_BUFFER_SIZE);
+        Ok(Self {
+            inner,
+            mem_pool,
+            rx_buffer_queue,
+        })
+    }
+}
+
+impl<H: IxgbeHal, const QS: usize, const QN: u16> BaseDriverOps for IxgbeNic<H, QS, QN> {
+    fn device_name(&self) -> &str {
+        self.inner.get_driver_name()
+    }
+
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Net
+    }
+}
+
+impl<H: IxgbeHal, const QS: usize, const QN: u16> NetDriverOps for IxgbeNic<H, QS, QN> {
+    fn mac_address(&self) -> EthernetAddress {
+        EthernetAddress(self.inner.get_mac_addr())
+    }
+
+    fn rx_queue_size(&self) -> usize {
+        QS
+    }
+
+    fn tx_queue_size(&self) -> usize {
+        QS
+    }
+
+    fn can_receive(&self) -> bool {
+        !self.rx_buffer_queue.is_empty() || self.inner.can_receive(0).unwrap()
+    }
+
+    fn can_transmit(&self) -> bool {
+        // Default implementation is return true forever.
+        self.inner.can_send(0).unwrap()
+    }
+
+    fn recycle_rx_buffer(&mut self, rx_buf: NetBufPtr) -> DevResult {
+        let rx_buf = ixgbe_ptr_to_buf(rx_buf, &self.mem_pool)?;
+        drop(rx_buf);
+        Ok(())
+    }
+
+    fn recycle_tx_buffers(&mut self) -> DevResult {
+        self.inner
+            .recycle_tx_buffers(0)
+            .map_err(|_| DevError::BadState)?;
+        Ok(())
+    }
+
+    fn receive(&mut self) -> DevResult<NetBufPtr> {
+        if !self.can_receive() {
+            return Err(DevError::Again);
+        }
+        if !self.rx_buffer_queue.is_empty() {
+            // RX buffer have received packets.
+            Ok(self.rx_buffer_queue.pop_front().unwrap())
+        } else {
+            // RX queue is empty, receive from ixgbe NIC.
+            match self.inner.receive_packets(0, RECV_BATCH_SIZE, |rx_buf| {
+                let rx_buf = NetBufPtr::from(rx_buf);
+                self.rx_buffer_queue.push_back(rx_buf);
+            }) {
+                Ok(recv_nums) => {
+                    if recv_nums == 0 {
+                        // No packet is received, it is impossible things.
+                        panic!("Error: No receive packets.")
+                    } else {
+                        Ok(self.rx_buffer_queue.pop_front().unwrap())
+                    }
+                }
+                Err(e) => match e {
+                    IxgbeError::NotReady => Err(DevError::Again),
+                    _ => Err(DevError::BadState),
+                },
+            }
+        }
+    }
+
+    fn transmit(&mut self, tx_buf: NetBufPtr) -> DevResult {
+        let tx_buf = ixgbe_ptr_to_buf(tx_buf, &self.mem_pool)?;
+        match self.inner.send(0, tx_buf) {
+            Ok(_) => Ok(()),
+            Err(err) => match err {
+                IxgbeError::QueueFull => Err(DevError::Again),
+                _ => panic!("Unexpected err: {:?}", err),
+            },
+        }
+    }
+
+    fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr> {
+        let tx_buf = IxgbeNetBuf::alloc(&self.mem_pool, size).map_err(|_| DevError::NoMemory)?;
+        Ok(NetBufPtr::from(tx_buf))
+    }
+}
+
+impl From<IxgbeNetBuf> for NetBufPtr {
+    fn from(buf: IxgbeNetBuf) -> Self {
+        // Use `ManuallyDrop` to avoid drop `tx_buf`.
+        let mut buf = ManuallyDrop::new(buf);
+        // In ixgbe, `raw_ptr` is the pool entry, `buf_ptr` is the packet ptr, `len` is packet len
+        // to avoid too many dynamic memory allocation.
+        let buf_ptr = buf.packet_mut().as_mut_ptr();
+        Self::new(
+            NonNull::new(buf.pool_entry() as *mut u8).unwrap(),
+            NonNull::new(buf_ptr).unwrap(),
+            buf.packet_len(),
+        )
+    }
+}
+
+// Converts a `NetBufPtr` to `IxgbeNetBuf`.
+fn ixgbe_ptr_to_buf(ptr: NetBufPtr, pool: &Arc<MemPool>) -> DevResult<IxgbeNetBuf> {
+    IxgbeNetBuf::construct(ptr.raw_ptr.as_ptr() as usize, pool, ptr.len)
+        .map_err(|_| DevError::BadState)
+}

--- a/crates/driver_net/src/lib.rs
+++ b/crates/driver_net/src/lib.rs
@@ -3,7 +3,11 @@
 #![no_std]
 #![feature(const_mut_refs)]
 #![feature(const_slice_from_raw_parts_mut)]
+#![feature(box_into_inner)]
 
+#[cfg(feature = "ixgbe")]
+/// ixgbe NIC device driver.
+pub mod ixgbe;
 mod net_buf;
 
 use core::ptr::NonNull;

--- a/crates/driver_virtio/Cargo.toml
+++ b/crates/driver_virtio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "driver_virtio"
 version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = ["Yuekai Jia <equation618@gmail.com>", "ChengXiang Qi <kuangjux@outlook.com>"]
 description = "Wrappers of some devices in the `virtio-drivers` crate, that implement traits in the `driver_common` series crates"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"

--- a/doc/ixgbe.md
+++ b/doc/ixgbe.md
@@ -1,0 +1,22 @@
+# How to run arceos with ixgbe NIC?
+
+First, you need to enable a new network feature and comment out the existing feature in `modules/axruntime/Cargo.toml`:
+
+```toml
+# net = ["alloc", "paging", "axdriver/virtio-net", "dep:axnet"]
+net = ["alloc", "paging", "axdriver/ixgbe", "dep:axnet"] # Ixgbe
+```
+
+Additionally, you also need to specify the platform that owns this network card. For example, we defined a toml file named x86_64-pc-oslab under the platforms directory to describe the platform characteristics.
+
+You can use the following command to compile an 'httpserver' app application:
+
+```shell
+make A=apps/net/httpserver ARCH=x86_64 PLATFORM=x86_64-pc-oslab NET=y
+```
+
+You can also use the following command to start the iperf application:
+
+```shell
+make A=apps/c/iperf ARCH=x86_64 PLATFORM=x86_64-pc-oslab NET=y BLK=y
+```

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "axdriver"
 version = "0.1.0"
 edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>"]
+authors = ["Yuekai Jia <equation618@gmail.com>", "ChengXiang Qi <kuangjux@outlook.com>"]
 description = "ArceOS device drivers"
 license = "GPL-3.0-or-later OR Apache-2.0"
 homepage = "https://github.com/rcore-os/arceos"
@@ -25,6 +25,7 @@ virtio-blk = ["block", "virtio", "driver_virtio/block"]
 virtio-net = ["net", "virtio", "driver_virtio/net"]
 virtio-gpu = ["display", "virtio", "driver_virtio/gpu"]
 ramdisk = ["block", "driver_block/ramdisk"]
+ixgbe = ["net", "driver_net/ixgbe", "dep:axalloc", "dep:axhal"]
 # more devices example: e1000 = ["net", "driver_net/e1000"]
 
 default = ["bus-mmio"]

--- a/modules/axdriver/build.rs
+++ b/modules/axdriver/build.rs
@@ -1,4 +1,4 @@
-const NET_DEV_FEATURES: &[&str] = &["virtio-net"];
+const NET_DEV_FEATURES: &[&str] = &["ixgbe", "virtio-net"];
 const BLOCK_DEV_FEATURES: &[&str] = &["ramdisk", "virtio-blk"];
 const DISPLAY_DEV_FEATURES: &[&str] = &["virtio-gpu"];
 

--- a/modules/axdriver/src/drivers.rs
+++ b/modules/axdriver/src/drivers.rs
@@ -66,3 +66,51 @@ cfg_if::cfg_if! {
         }
     }
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(net_dev = "ixgbe")] {
+        use crate::ixgbe::IxgbeHalImpl;
+        use axhal::mem::phys_to_virt;
+        pub struct IxgbeDriver;
+        register_net_driver!(IxgbeDriver, driver_net::ixgbe::IxgbeNic<IxgbeHalImpl, 1024, 1>);
+        impl DriverProbe for IxgbeDriver {
+            fn probe_pci(
+                    root: &mut driver_pci::PciRoot,
+                    bdf: driver_pci::DeviceFunction,
+                    dev_info: &driver_pci::DeviceFunctionInfo,
+                ) -> Option<crate::AxDeviceEnum> {
+                    use crate::ixgbe::IxgbeHalImpl;
+                    use driver_net::ixgbe::{INTEL_82599, INTEL_VEND, IxgbeNic};
+                    if dev_info.vendor_id == INTEL_VEND && dev_info.device_id == INTEL_82599 {
+                        // Intel 10Gb Network
+                        info!("ixgbe PCI device found at {:?}", bdf);
+
+                        // Initialize the device
+                        // These can be changed according to the requirments specified in the ixgbe init function.
+                        const QN: u16 = 1;
+                        const QS: usize = 1024;
+                        let bar_info = root.bar_info(bdf, 0).unwrap();
+                        match bar_info {
+                            driver_pci::BarInfo::Memory {
+                                address,
+                                size,
+                                ..
+                            } => {
+                                let ixgbe_nic = IxgbeNic::<IxgbeHalImpl, QS, QN>::init(
+                                    phys_to_virt((address as usize).into()).into(),
+                                    size as usize
+                                )
+                                .expect("failed to initialize ixgbe device");
+                                return Some(AxDeviceEnum::from_net(ixgbe_nic));
+                            }
+                            driver_pci::BarInfo::IO { .. } => {
+                                error!("ixgbe: BAR0 is of I/O type");
+                                return None;
+                            }
+                        }
+                    }
+                    None
+            }
+        }
+    }
+}

--- a/modules/axdriver/src/ixgbe.rs
+++ b/modules/axdriver/src/ixgbe.rs
@@ -1,0 +1,37 @@
+use axalloc::global_allocator;
+use axhal::mem::{phys_to_virt, virt_to_phys};
+use core::ptr::NonNull;
+use driver_net::ixgbe::{IxgbeHal, PhysAddr as IxgbePhysAddr};
+
+pub struct IxgbeHalImpl;
+
+unsafe impl IxgbeHal for IxgbeHalImpl {
+    fn dma_alloc(size: usize) -> (IxgbePhysAddr, NonNull<u8>) {
+        let vaddr = if let Ok(vaddr) = global_allocator().alloc(size, 2) {
+            vaddr
+        } else {
+            return (0, NonNull::dangling());
+        };
+        let paddr = virt_to_phys(vaddr.into());
+        let ptr = NonNull::new(vaddr as _).unwrap();
+        (paddr.as_usize(), ptr)
+    }
+
+    unsafe fn dma_dealloc(_paddr: IxgbePhysAddr, vaddr: NonNull<u8>, size: usize) -> i32 {
+        global_allocator().dealloc(vaddr.as_ptr() as usize, size, 2);
+        0
+    }
+
+    unsafe fn mmio_phys_to_virt(paddr: IxgbePhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(phys_to_virt(paddr.into()).as_mut_ptr()).unwrap()
+    }
+
+    unsafe fn mmio_virt_to_phys(vaddr: NonNull<u8>, _size: usize) -> IxgbePhysAddr {
+        virt_to_phys((vaddr.as_ptr() as usize).into()).into()
+    }
+
+    fn wait_until(duration: core::time::Duration) -> Result<(), &'static str> {
+        axhal::time::busy_wait_until(duration);
+        Ok(())
+    }
+}

--- a/modules/axdriver/src/lib.rs
+++ b/modules/axdriver/src/lib.rs
@@ -75,6 +75,9 @@ mod structs;
 #[cfg(feature = "virtio")]
 mod virtio;
 
+#[cfg(feature = "ixgbe")]
+mod ixgbe;
+
 pub mod prelude;
 
 #[allow(unused_imports)]

--- a/modules/axdriver/src/macros.rs
+++ b/modules/axdriver/src/macros.rs
@@ -54,5 +54,10 @@ macro_rules! for_each_drivers {
             type $drv_type = crate::drivers::RamDiskDriver;
             $code
         }
+        #[cfg(net_dev = "ixgbe")]
+        {
+            type $drv_type = crate::drivers::IxgbeDriver;
+            $code
+        }
     }};
 }

--- a/platforms/x86_64-pc-oslab.toml
+++ b/platforms/x86_64-pc-oslab.toml
@@ -1,0 +1,37 @@
+# Architecture identifier.
+arch = "x86_64"
+# Platform identifier.
+platform = "x86_64-pc-oslab"
+# Platform family.
+family = "x86-pc"
+
+# Base address of the whole physical memory.
+phys-memory-base = "0"
+# Size of the whole physical memory.
+phys-memory-size = "0x800_0000"     # 128M
+# Base physical address of the kernel image.
+kernel-base-paddr = "0x20_0000"
+# Base virtual address of the kernel image.
+kernel-base-vaddr = "0xffff_ff80_0020_0000"
+# Linear mapping offset, for quick conversions between physical and virtual
+# addresses.
+phys-virt-offset = "0xffff_ff80_0000_0000"
+# MMIO regions with format (`base_paddr`, `size`).
+mmio-regions = [
+    ["0xfec0_0000", "0x1000"],      # IO APIC
+    ["0xfed0_0000", "0x1000"],      # HPET
+    ["0xfee0_0000", "0x1000"],      # Local APIC
+    ["0xf000_0000", "0x0800_0000"], # PCI config space
+    ["0xfcd8_0000", "0x0008_0000"], # Ixgbe BAR0
+]
+# VirtIO MMIO regions with format (`base_paddr`, `size`).
+virtio-mmio-regions = []
+# Base physical address of the PCIe ECAM space (should read from ACPI 'MCFG' table).
+pci-ecam-base = "0xf000_0000"
+# End PCI bus number.
+pci-bus-end = "0x7f"
+# PCI device memory ranges (not used on x86).
+pci-ranges = []
+
+# Timer interrupt frequencyin Hz.
+timer-frequency = "4_000_000_000"   # 4.0GHz

--- a/tools/bwbench_client/Cargo.toml
+++ b/tools/bwbench_client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bwbench-client"
 version = "0.1.0"
 edition = "2021"
+authors = ["ChengXiang Qi <kuangjux@outlook.com>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This is a relatively large PR that mainly does the following things:
- Referencing [ixy.rs](https://github.com/ixy-languages/ixy.rs), implemented the Intel 82599 (ixgbe) driver and optimized its performance to a certain extent.
- Completed the detection and initialization of ixgbe in `axdriver`.
- Added a new platform `x86-pc-oslab` for adapting to physical machines and conducting real network card development and testing.
- Based on #99, re-implemented the ixgbe driver and protocol stack adaptation for the network interface.
- Currently, the performance tested using ab (Apache HTTP server benchmarking tool) can reach 25000+ requests/second. TCP packet receiving performance tested with `iperf` can reach 3.5G, while packet sending performance can reach 4.0G. UDP packet receiving performance tested can reach 3.4G (not accurately measured), and packet sending performance reaches 9+G. Using `bw_client` for testing, the packet receiving performance reaches at least 6G (not accurately measured, as the client did not fully send), and packet sending can fully saturate at 10G.
![WechatIMG1507](https://github.com/rcore-os/arceos/assets/56680481/f2b76437-eb7e-429d-a6ec-47f0cac0d5d1)
![WechatIMG1506 1](https://github.com/rcore-os/arceos/assets/56680481/c56b0944-ebfe-442c-a3a6-a0fa9dfbf271)
- Still, there are some related tasks that need to be done, such as supporting network card interrupts and enabling multiple queues and RSS in multi-core. These will be submitted in subsequent PRs.