### PR TITLE
Add arceos_api between ulib and modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,6 @@ dependencies = [
 name = "arceos-shell"
 version = "0.1.0"
 dependencies = [
- "axfeat",
  "axfs_ramfs",
  "axfs_vfs",
  "axstd",
@@ -466,7 +465,6 @@ dependencies = [
  "arceos_api",
  "axerrno",
  "axfeat",
- "axfs",
  "axio",
  "spinlock",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,6 @@ dependencies = [
  "axfeat",
  "axfs",
  "axio",
- "axsync",
  "spinlock",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "arceos_api"
+version = "0.1.0"
+dependencies = [
+ "axalloc",
+ "axconfig",
+ "axdisplay",
+ "axerrno",
+ "axfeat",
+ "axfs",
+ "axhal",
+ "axio",
+ "axlog",
+ "axnet",
+ "axruntime",
+ "axtask",
+]
+
+[[package]]
 name = "arm_gic"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,19 +463,12 @@ dependencies = [
 name = "axstd"
 version = "0.1.0"
 dependencies = [
- "axalloc",
- "axconfig",
- "axdisplay",
+ "arceos_api",
  "axerrno",
  "axfeat",
  "axfs",
- "axhal",
  "axio",
- "axlog",
- "axnet",
- "axruntime",
  "axsync",
- "axtask",
  "spinlock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "modules/axtask",
 
     "api/axfeat",
+    "api/arceos_api",
 
     "ulib/axstd",
     "ulib/axlibc",

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "arceos_api"
+version = "0.1.0"
+edition = "2021"
+authors = ["Yuekai Jia <equation618@gmail.com>"]
+description = "Public APIs and types for ArceOS modules"
+license = "GPL-3.0-or-later OR Apache-2.0"
+homepage = "https://github.com/rcore-os/arceos"
+repository = "https://github.com/rcore-os/arceos/tree/main/api/arceos_api"
+documentation = "https://rcore-os.github.io/arceos/arceos_api/index.html"
+
+[features]
+default = []
+
+irq = ["axfeat/irq"]
+alloc = ["dep:axalloc", "axfeat/alloc"]
+multitask = ["axtask/multitask", "axfeat/multitask"]
+fs = ["dep:axfs", "axfeat/fs"]
+net = ["dep:axnet", "axfeat/net"]
+display = ["dep:axdisplay", "axfeat/display"]
+
+myfs = ["axfeat/myfs"]
+
+# Use dummy functions if the feature is not enabled
+dummy-if-not-enabled = []
+
+[dependencies]
+axfeat = { path = "../axfeat" }
+axruntime = { path = "../../modules/axruntime" }
+axconfig = { path = "../../modules/axconfig" }
+axlog = { path = "../../modules/axlog" }
+axio = { path = "../../crates/axio" }
+axerrno = { path = "../../crates/axerrno" }
+axhal = { path = "../../modules/axhal" }
+axalloc = { path = "../../modules/axalloc", optional = true }
+axtask = { path = "../../modules/axtask", optional = true }
+axfs = { path = "../../modules/axfs", optional = true }
+axnet = { path = "../../modules/axnet", optional = true }
+axdisplay = { path = "../../modules/axdisplay", optional = true }

--- a/api/arceos_api/src/imp/display.rs
+++ b/api/arceos_api/src/imp/display.rs
@@ -1,0 +1,11 @@
+pub use axdisplay::DisplayInfo as AxDisplayInfo;
+
+/// Gets the framebuffer information.
+pub fn ax_framebuffer_info() -> AxDisplayInfo {
+    axdisplay::framebuffer_info()
+}
+
+/// Flushes the framebuffer, i.e. show on the screen.
+pub fn ax_framebuffer_flush() {
+    axdisplay::framebuffer_flush()
+}

--- a/api/arceos_api/src/imp/fs.rs
+++ b/api/arceos_api/src/imp/fs.rs
@@ -1,0 +1,87 @@
+use alloc::string::String;
+use axerrno::AxResult;
+use axfs::fops::{Directory, File};
+
+pub use axfs::fops::DirEntry as AxDirEntry;
+pub use axfs::fops::FileAttr as AxFileAttr;
+pub use axfs::fops::FilePerm as AxFilePerm;
+pub use axfs::fops::FileType as AxFileType;
+pub use axfs::fops::OpenOptions as AxOpenOptions;
+pub use axio::SeekFrom as AxSeekFrom;
+
+#[cfg(feature = "myfs")]
+pub use axfs::fops::{Disk as AxDisk, MyFileSystemIf};
+
+/// A handle to an opened file.
+pub struct AxFileHandle(File);
+
+/// A handle to an opened directory.
+pub struct AxDirHandle(Directory);
+
+pub fn ax_open_file(path: &str, opts: &AxOpenOptions) -> AxResult<AxFileHandle> {
+    Ok(AxFileHandle(File::open(path, opts)?))
+}
+
+pub fn ax_open_dir(path: &str, opts: &AxOpenOptions) -> AxResult<AxDirHandle> {
+    Ok(AxDirHandle(Directory::open_dir(path, opts)?))
+}
+
+pub fn ax_read_file(file: &mut AxFileHandle, buf: &mut [u8]) -> AxResult<usize> {
+    file.0.read(buf)
+}
+
+pub fn ax_read_file_at(file: &AxFileHandle, offset: u64, buf: &mut [u8]) -> AxResult<usize> {
+    file.0.read_at(offset, buf)
+}
+
+pub fn ax_write_file(file: &mut AxFileHandle, buf: &[u8]) -> AxResult<usize> {
+    file.0.write(buf)
+}
+
+pub fn ax_write_file_at(file: &AxFileHandle, offset: u64, buf: &[u8]) -> AxResult<usize> {
+    file.0.write_at(offset, buf)
+}
+
+pub fn ax_truncate_file(file: &AxFileHandle, size: u64) -> AxResult {
+    file.0.truncate(size)
+}
+
+pub fn ax_flush_file(file: &AxFileHandle) -> AxResult {
+    file.0.flush()
+}
+
+pub fn ax_seek_file(file: &mut AxFileHandle, pos: AxSeekFrom) -> AxResult<u64> {
+    file.0.seek(pos)
+}
+
+pub fn ax_file_attr(file: &AxFileHandle) -> AxResult<AxFileAttr> {
+    file.0.get_attr()
+}
+
+pub fn ax_read_dir(dir: &mut AxDirHandle, dirents: &mut [AxDirEntry]) -> AxResult<usize> {
+    dir.0.read_dir(dirents)
+}
+
+pub fn ax_create_dir(path: &str) -> AxResult {
+    axfs::api::create_dir(path)
+}
+
+pub fn ax_remove_dir(path: &str) -> AxResult {
+    axfs::api::remove_dir(path)
+}
+
+pub fn ax_remove_file(path: &str) -> AxResult {
+    axfs::api::remove_file(path)
+}
+
+pub fn ax_rename(old: &str, new: &str) -> AxResult {
+    axfs::api::rename(old, new)
+}
+
+pub fn ax_current_dir() -> AxResult<String> {
+    axfs::api::current_dir()
+}
+
+pub fn ax_set_current_dir(path: &str) -> AxResult {
+    axfs::api::set_current_dir(path)
+}

--- a/api/arceos_api/src/imp/mem.rs
+++ b/api/arceos_api/src/imp/mem.rs
@@ -1,0 +1,16 @@
+cfg_alloc! {
+    use core::alloc::Layout;
+    use core::ptr::NonNull;
+
+    pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
+        if let Ok(vaddr) = axalloc::global_allocator().alloc(layout) {
+            Some(unsafe { NonNull::new_unchecked(vaddr.get() as _) })
+        } else {
+            None
+        }
+    }
+
+    pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
+        axalloc::global_allocator().dealloc(ptr.addr(), layout)
+    }
+}

--- a/api/arceos_api/src/imp/mod.rs
+++ b/api/arceos_api/src/imp/mod.rs
@@ -1,0 +1,42 @@
+mod mem;
+mod task;
+
+cfg_fs! {
+    mod fs;
+    pub use fs::*;
+}
+
+cfg_net! {
+    mod net;
+    pub use net::*;
+}
+
+cfg_display! {
+    mod display;
+    pub use display::*;
+}
+
+mod stdio {
+    use core::fmt;
+
+    pub fn ax_console_read_byte() -> Option<u8> {
+        axhal::console::getchar().map(|c| if c == b'\r' { b'\n' } else { c })
+    }
+
+    pub fn ax_console_write_bytes(buf: &[u8]) -> crate::AxResult<usize> {
+        axhal::console::write_bytes(buf);
+        Ok(buf.len())
+    }
+
+    pub fn ax_console_write_fmt(args: fmt::Arguments) -> fmt::Result {
+        axlog::print_fmt(args)
+    }
+}
+
+pub use self::mem::*;
+pub use self::stdio::*;
+pub use self::task::*;
+
+pub use axhal::misc::terminate as ax_terminate;
+pub use axhal::time::{current_time as ax_current_time, TimeValue as AxTimeValue};
+pub use axio::PollState as AxPollState;

--- a/api/arceos_api/src/imp/net.rs
+++ b/api/arceos_api/src/imp/net.rs
@@ -1,0 +1,131 @@
+use crate::io::AxPollState;
+use axerrno::AxResult;
+use axnet::{UdpSocket, TcpSocket};
+use core::net::{IpAddr, SocketAddr};
+
+/// A handle to a TCP socket.
+pub struct AxTcpSocketHandle(TcpSocket);
+
+/// A handle to a UDP socket.
+pub struct AxUdpSocketHandle(UdpSocket);
+
+////////////////////////////////////////////////////////////////////////////////
+// TCP socket
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn ax_tcp_socket() -> AxTcpSocketHandle {
+    AxTcpSocketHandle(TcpSocket::new())
+}
+
+pub fn ax_tcp_socket_addr(socket: &AxTcpSocketHandle) -> AxResult<SocketAddr> {
+    socket.0.local_addr()
+}
+
+pub fn ax_tcp_peer_addr(socket: &AxTcpSocketHandle) -> AxResult<SocketAddr> {
+    socket.0.peer_addr()
+}
+
+pub fn ax_tcp_set_nonblocking(socket: &AxTcpSocketHandle, nonblocking: bool) -> AxResult {
+    socket.0.set_nonblocking(nonblocking);
+    Ok(())
+}
+
+pub fn ax_tcp_connect(socket: &AxTcpSocketHandle, addr: SocketAddr) -> AxResult {
+    socket.0.connect(addr)
+}
+
+pub fn ax_tcp_bind(socket: &AxTcpSocketHandle, addr: SocketAddr) -> AxResult {
+    socket.0.bind(addr)
+}
+
+pub fn ax_tcp_listen(socket: &AxTcpSocketHandle, _backlog: usize) -> AxResult {
+    socket.0.listen()
+}
+
+pub fn ax_tcp_accept(socket: &AxTcpSocketHandle) -> AxResult<(AxTcpSocketHandle, SocketAddr)> {
+    let new_sock = socket.0.accept()?;
+    let addr = new_sock.peer_addr()?;
+    Ok((AxTcpSocketHandle(new_sock), addr))
+}
+
+pub fn ax_tcp_send(socket: &AxTcpSocketHandle, buf: &[u8]) -> AxResult<usize> {
+    socket.0.send(buf)
+}
+
+pub fn ax_tcp_recv(socket: &AxTcpSocketHandle, buf: &mut [u8]) -> AxResult<usize> {
+    socket.0.recv(buf)
+}
+
+pub fn ax_tcp_poll(socket: &AxTcpSocketHandle) -> AxResult<AxPollState> {
+    socket.0.poll()
+}
+
+pub fn ax_tcp_shutdown(socket: &AxTcpSocketHandle) -> AxResult {
+    socket.0.shutdown()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// UDP socket
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn ax_udp_socket() -> AxUdpSocketHandle {
+    AxUdpSocketHandle(UdpSocket::new())
+}
+
+pub fn ax_udp_socket_addr(socket: &AxUdpSocketHandle) -> AxResult<SocketAddr> {
+    socket.0.local_addr()
+}
+
+pub fn ax_udp_peer_addr(socket: &AxUdpSocketHandle) -> AxResult<SocketAddr> {
+    socket.0.peer_addr()
+}
+
+pub fn ax_udp_set_nonblocking(socket: &AxUdpSocketHandle, nonblocking: bool) -> AxResult {
+    socket.0.set_nonblocking(nonblocking);
+    Ok(())
+}
+
+pub fn ax_udp_bind(socket: &AxUdpSocketHandle, addr: SocketAddr) -> AxResult {
+    socket.0.bind(addr)
+}
+
+pub fn ax_udp_recv_from(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<(usize, SocketAddr)> {
+    socket.0.recv_from(buf)
+}
+
+pub fn ax_udp_peek_from(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<(usize, SocketAddr)> {
+    socket.0.peek_from(buf)
+}
+
+pub fn ax_udp_send_to(socket: &AxUdpSocketHandle, buf: &[u8], addr: SocketAddr) -> AxResult<usize> {
+    socket.0.send_to(buf, addr)
+}
+
+pub fn ax_udp_connect(socket: &AxUdpSocketHandle, addr: SocketAddr) -> AxResult {
+    socket.0.connect(addr)
+}
+
+pub fn ax_udp_send(socket: &AxUdpSocketHandle, buf: &[u8]) -> AxResult<usize> {
+    socket.0.send(buf)
+}
+
+pub fn ax_udp_recv(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<usize> {
+    socket.0.recv(buf)
+}
+
+pub fn ax_udp_poll(socket: &AxUdpSocketHandle) -> AxResult<AxPollState> {
+    socket.0.poll()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Miscellaneous
+////////////////////////////////////////////////////////////////////////////////
+
+pub fn ax_dns_query(domain_name: &str) -> AxResult<alloc::vec::Vec<IpAddr>> {
+    axnet::dns_query(domain_name)
+}
+
+pub fn ax_poll_interfaces() -> AxResult {
+    axnet::poll_interfaces();
+    Ok(())
+}

--- a/api/arceos_api/src/imp/task.rs
+++ b/api/arceos_api/src/imp/task.rs
@@ -1,0 +1,111 @@
+pub fn ax_sleep_until(deadline: crate::time::AxTimeValue) {
+    #[cfg(feature = "multitask")]
+    axtask::sleep_until(deadline);
+    #[cfg(not(feature = "multitask"))]
+    axhal::time::busy_wait_until(deadline);
+}
+
+pub fn ax_yield_now() {
+    #[cfg(feature = "multitask")]
+    axtask::yield_now();
+    #[cfg(not(feature = "multitask"))]
+    if cfg!(feature = "irq") {
+        axhal::arch::wait_for_irqs();
+    } else {
+        core::hint::spin_loop();
+    }
+}
+
+pub fn ax_exit(_exit_code: i32) -> ! {
+    #[cfg(feature = "multitask")]
+    axtask::exit(_exit_code);
+    #[cfg(not(feature = "multitask"))]
+    axhal::misc::terminate();
+}
+
+cfg_task! {
+    use core::time::Duration;
+
+    /// A handle to a task.
+    pub struct AxTaskHandle {
+        inner: axtask::AxTaskRef,
+        id: u64,
+    }
+
+    impl AxTaskHandle {
+        /// Returns the task ID.
+        pub fn id(&self) -> u64 {
+            self.id
+        }
+    }
+
+    /// A handle to a wait queue.
+    ///
+    /// A wait queue is used to store sleeping tasks waiting for a certain event
+    /// to happen.
+    pub struct AxWaitQueueHandle(axtask::WaitQueue);
+
+    impl AxWaitQueueHandle {
+        /// Creates a new empty wait queue.
+        pub const fn new() -> Self {
+            Self(axtask::WaitQueue::new())
+        }
+    }
+
+    pub fn ax_current_task_id() -> u64 {
+        axtask::current().id().as_u64()
+    }
+
+    pub fn ax_spawn<F>(f: F, name: alloc::string::String, stack_size: usize) -> AxTaskHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let inner = axtask::spawn_raw(f, name, stack_size);
+        AxTaskHandle {
+            id: inner.id().as_u64(),
+            inner,
+        }
+    }
+
+    pub fn ax_wait_for_exit(task: AxTaskHandle) -> Option<i32> {
+        task.inner.join()
+    }
+
+    pub fn ax_set_current_priority(prio: isize) -> crate::AxResult {
+        if axtask::set_priority(prio) {
+            Ok(())
+        } else {
+            axerrno::ax_err!(
+                BadState,
+                "ax_set_current_priority: failed to set task priority"
+            )
+        }
+    }
+
+    pub fn ax_wait_queue_wait(
+        wq: &AxWaitQueueHandle,
+        until_condition: impl Fn() -> bool,
+        timeout: Option<Duration>,
+    ) -> bool {
+        #[cfg(feature = "irq")]
+        if let Some(dur) = timeout {
+            return wq.0.wait_timeout_until(dur, until_condition);
+        }
+
+        if timeout.is_some() {
+            axlog::warn!("ax_wait_queue_wait: the `timeout` argument is ignored without the `irq` feature");
+        }
+        wq.0.wait_until(until_condition);
+        false
+    }
+
+    pub fn ax_wait_queue_wake(wq: &AxWaitQueueHandle, count: u32) {
+        if count == u32::MAX {
+            wq.0.notify_all(true);
+        } else {
+            for _ in 0..count {
+                wq.0.notify_one(true);
+            }
+        }
+    }
+}

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -1,0 +1,341 @@
+//! Public APIs and types for [ArceOS] modules
+//!
+//! [ArceOS]: https://github.com/rcore-os/arceos
+
+#![no_std]
+#![feature(ip_in_core)]
+#![feature(strict_provenance)]
+#![feature(doc_auto_cfg)]
+#![feature(doc_cfg)]
+#![allow(unused_imports)]
+
+#[cfg(any(
+    feature = "alloc",
+    feature = "fs",
+    feature = "net",
+    feature = "multitask",
+    feature = "dummy-if-not-enabled"
+))]
+extern crate alloc;
+extern crate axruntime;
+
+#[macro_use]
+mod macros;
+mod imp;
+
+pub use axerrno::{AxError, AxResult};
+
+/// Platform-specific constants and parameters.
+pub mod config {
+    pub use axconfig::*;
+}
+
+/// System operations.
+pub mod sys {
+    define_api! {
+        /// Shutdown the whole system and all CPUs.
+        pub fn ax_terminate() -> !;
+    }
+}
+
+/// Time-related operations.
+pub mod time {
+    define_api_type! {
+        pub type AxTimeValue;
+    }
+
+    define_api! {
+        /// Returns the current clock time.
+        pub fn ax_current_time() -> AxTimeValue;
+    }
+}
+
+/// Memory management.
+pub mod mem {
+    use core::{alloc::Layout, ptr::NonNull};
+
+    define_api! {
+        @cfg "alloc";
+        /// Allocate a continuous memory blocks with the given `layout` in
+        /// the global allocator.
+        ///
+        /// Returns [`None`] if the allocation fails.
+        pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>>;
+        /// Deallocate the memory block at the given `ptr` pointer with the given
+        /// `layout`, which should be allocated by [`ax_alloc`].
+        pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout);
+    }
+}
+
+/// Standard input and output.
+pub mod stdio {
+    use core::fmt;
+    define_api! {
+        /// Reads a byte from the console, or returns [`None`] if no input is available.
+        pub fn ax_console_read_byte() -> Option<u8>;
+        /// Writes a slice of bytes to the console, returns the number of bytes written.
+        pub fn ax_console_write_bytes(buf: &[u8]) -> crate::AxResult<usize>;
+        /// Writes a formatted string to the console.
+        pub fn ax_console_write_fmt(args: fmt::Arguments) -> fmt::Result;
+    }
+}
+
+/// Multi-threading management.
+pub mod task {
+    define_api_type! {
+        @cfg "multitask";
+        pub type AxTaskHandle;
+        pub type AxWaitQueueHandle;
+    }
+
+    define_api! {
+        /// Current task is going to sleep, it will be woken up at the given deadline.
+        ///
+        /// If the feature `multitask` is not enabled, it uses busy-wait instead
+        pub fn ax_sleep_until(deadline: crate::time::AxTimeValue);
+
+        /// Current task gives up the CPU time voluntarily, and switches to another
+        /// ready task.
+        ///
+        /// If the feature `multitask` is not enabled, it does nothing.
+        pub fn ax_yield_now();
+
+        /// Exits the current task with the given exit code.
+        pub fn ax_exit(exit_code: i32) -> !;
+    }
+
+    define_api! {
+        @cfg "multitask";
+
+        /// Returns the current task's ID.
+        pub fn ax_current_task_id() -> u64;
+        /// Spawns a new task with the given entry point and other arguments.
+        pub fn ax_spawn(
+            f: impl FnOnce() + Send + 'static,
+            name: alloc::string::String,
+            stack_size: usize
+        ) -> AxTaskHandle;
+        /// Waits for the given task to exit, and returns its exit code (the
+        /// argument of [`ax_exit`]).
+        pub fn ax_wait_for_exit(task: AxTaskHandle) -> Option<i32>;
+        /// Sets the priority of the current task.
+        pub fn ax_set_current_priority(prio: isize) -> crate::AxResult;
+
+        /// Blocks the current task and put it into the wait queue, until the
+        /// given condition becomes true, or the the given duration has elapsed
+        /// (if specified).
+        pub fn ax_wait_queue_wait(
+            wq: &AxWaitQueueHandle,
+            until_condition: impl Fn() -> bool,
+            timeout: Option<core::time::Duration>,
+        ) -> bool;
+        /// Wakes up one or more tasks in the wait queue.
+        ///
+        /// The maximum number of tasks to wake up is specified by `count`. If
+        /// `count` is `u32::MAX`, it will wake up all tasks in the wait queue.
+        pub fn ax_wait_queue_wake(wq: &AxWaitQueueHandle, count: u32);
+    }
+}
+
+/// Filesystem manipulation operations.
+pub mod fs {
+    use crate::AxResult;
+
+    define_api_type! {
+        @cfg "fs";
+        pub type AxFileHandle;
+        pub type AxDirHandle;
+        pub type AxOpenOptions;
+        pub type AxFileAttr;
+        pub type AxFileType;
+        pub type AxFilePerm;
+        pub type AxDirEntry;
+        pub type AxSeekFrom;
+        #[cfg(feature = "myfs")]
+        pub type AxDisk;
+        #[cfg(feature = "myfs")]
+        pub type MyFileSystemIf;
+    }
+
+    define_api! {
+        @cfg "fs";
+
+        /// Opens a file at the path relative to the current directory with the
+        /// options specified by `opts`.
+        pub fn ax_open_file(path: &str, opts: &AxOpenOptions) -> AxResult<AxFileHandle>;
+        /// Opens a directory at the path relative to the current directory with
+        /// the options specified by `opts`.
+        pub fn ax_open_dir(path: &str, opts: &AxOpenOptions) -> AxResult<AxDirHandle>;
+
+        /// Reads the file at the current position, returns the number of bytes read.
+        ///
+        /// After the read, the cursor will be advanced by the number of bytes read.
+        pub fn ax_read_file(file: &mut AxFileHandle, buf: &mut [u8]) -> AxResult<usize>;
+        /// Reads the file at the given position, returns the number of bytes read.
+        ///
+        /// It does not update the file cursor.
+        pub fn ax_read_file_at(file: &AxFileHandle, offset: u64, buf: &mut [u8]) -> AxResult<usize>;
+        /// Writes the file at the current position, returns the number of bytes
+        /// written.
+        ///
+        /// After the write, the cursor will be advanced by the number of bytes
+        /// written.
+        pub fn ax_write_file(file: &mut AxFileHandle, buf: &[u8]) -> AxResult<usize>;
+        /// Writes the file at the given position, returns the number of bytes
+        /// written.
+        ///
+        /// It does not update the file cursor.
+        pub fn ax_write_file_at(file: &AxFileHandle, offset: u64, buf: &[u8]) -> AxResult<usize>;
+        /// Truncates the file to the specified size.
+        pub fn ax_truncate_file(file: &AxFileHandle, size: u64) -> AxResult;
+        /// Flushes the file, writes all buffered data to the underlying device.
+        pub fn ax_flush_file(file: &AxFileHandle) -> AxResult;
+        /// Sets the cursor of the file to the specified offset. Returns the new
+        /// position after the seek.
+        pub fn ax_seek_file(file: &mut AxFileHandle, pos: AxSeekFrom) -> AxResult<u64>;
+        /// Returns attributes of the file.
+        pub fn ax_file_attr(file: &AxFileHandle) -> AxResult<AxFileAttr>;
+
+        /// Reads directory entries starts from the current position into the
+        /// given buffer, returns the number of entries read.
+        ///
+        /// After the read, the cursor of the directory will be advanced by the
+        /// number of entries read.
+        pub fn ax_read_dir(dir: &mut AxDirHandle, dirents: &mut [AxDirEntry]) -> AxResult<usize>;
+        /// Creates a new, empty directory at the provided path.
+        pub fn ax_create_dir(path: &str) -> AxResult;
+        /// Removes an empty directory.
+        ///
+        /// If the directory is not empty, it will return an error.
+        pub fn ax_remove_dir(path: &str) -> AxResult;
+        /// Removes a file from the filesystem.
+        pub fn ax_remove_file(path: &str) -> AxResult;
+        /// Rename a file or directory to a new name.
+        ///
+        /// It will delete the original file if `old` already exists.
+        pub fn ax_rename(old: &str, new: &str) -> AxResult;
+
+        /// Returns the current working directory.
+        pub fn ax_current_dir() -> AxResult<alloc::string::String>;
+        /// Changes the current working directory to the specified path.
+        pub fn ax_set_current_dir(path: &str) -> AxResult;
+    }
+}
+
+/// Networking primitives for TCP/UDP communication.
+pub mod net {
+    use crate::{io::AxPollState, AxResult};
+    use core::net::{IpAddr, SocketAddr};
+
+    define_api_type! {
+        @cfg "net";
+        pub type AxTcpSocketHandle;
+        pub type AxUdpSocketHandle;
+    }
+
+    define_api! {
+        @cfg "net";
+
+        // TCP socket
+
+        /// Creates a new TCP socket.
+        pub fn ax_tcp_socket() -> AxTcpSocketHandle;
+        /// Returns the local address and port of the TCP socket.
+        pub fn ax_tcp_socket_addr(socket: &AxTcpSocketHandle) -> AxResult<SocketAddr>;
+        /// Returns the remote address and port of the TCP socket.
+        pub fn ax_tcp_peer_addr(socket: &AxTcpSocketHandle) -> AxResult<SocketAddr>;
+        /// Moves this TCP socket into or out of nonblocking mode.
+        pub fn ax_tcp_set_nonblocking(socket: &AxTcpSocketHandle, nonblocking: bool) -> AxResult;
+
+        /// Connects the TCP socket to the given address and port.
+        pub fn ax_tcp_connect(handle: &AxTcpSocketHandle, addr: SocketAddr) -> AxResult;
+        /// Binds the TCP socket to the given address and port.
+        pub fn ax_tcp_bind(socket: &AxTcpSocketHandle, addr: SocketAddr) -> AxResult;
+        /// Starts listening on the bound address and port.
+        pub fn ax_tcp_listen(socket: &AxTcpSocketHandle, _backlog: usize) -> AxResult;
+        /// Accepts a new connection on the TCP socket.
+        ///
+        /// This function will block the calling thread until a new TCP connection
+        /// is established. When established, a new TCP socket is returned.
+        pub fn ax_tcp_accept(socket: &AxTcpSocketHandle) -> AxResult<(AxTcpSocketHandle, SocketAddr)>;
+
+        /// Transmits data in the given buffer on the TCP socket.
+        pub fn ax_tcp_send(socket: &AxTcpSocketHandle, buf: &[u8]) -> AxResult<usize>;
+        /// Receives data on the TCP socket, and stores it in the given buffer.
+        /// On success, returns the number of bytes read.
+        pub fn ax_tcp_recv(socket: &AxTcpSocketHandle, buf: &mut [u8]) -> AxResult<usize>;
+        /// Returns whether the TCP socket is readable or writable.
+        pub fn ax_tcp_poll(socket: &AxTcpSocketHandle) -> AxResult<AxPollState>;
+        /// Closes the connection on the TCP socket.
+        pub fn ax_tcp_shutdown(socket: &AxTcpSocketHandle) -> AxResult;
+
+        // UDP socket
+
+        /// Creates a new UDP socket.
+        pub fn ax_udp_socket() -> AxUdpSocketHandle;
+        /// Returns the local address and port of the UDP socket.
+        pub fn ax_udp_socket_addr(socket: &AxUdpSocketHandle) -> AxResult<SocketAddr>;
+        /// Returns the remote address and port of the UDP socket.
+        pub fn ax_udp_peer_addr(socket: &AxUdpSocketHandle) -> AxResult<SocketAddr>;
+        /// Moves this UDP socket into or out of nonblocking mode.
+        pub fn ax_udp_set_nonblocking(socket: &AxUdpSocketHandle, nonblocking: bool) -> AxResult;
+
+        /// Binds the UDP socket to the given address and port.
+        pub fn ax_udp_bind(socket: &AxUdpSocketHandle, addr: SocketAddr) -> AxResult;
+        /// Receives a single datagram message on the UDP socket.
+        pub fn ax_udp_recv_from(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<(usize, SocketAddr)>;
+        /// Receives a single datagram message on the UDP socket, without
+        /// removing it from the queue.
+        pub fn ax_udp_peek_from(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<(usize, SocketAddr)>;
+        /// Sends data on the UDP socket to the given address. On success,
+        /// returns the number of bytes written.
+        pub fn ax_udp_send_to(socket: &AxUdpSocketHandle, buf: &[u8], addr: SocketAddr) -> AxResult<usize>;
+
+        /// Connects this UDP socket to a remote address, allowing the `send` and
+        /// `recv` to be used to send data and also applies filters to only receive
+        /// data from the specified address.
+        pub fn ax_udp_connect(socket: &AxUdpSocketHandle, addr: SocketAddr) -> AxResult;
+        /// Sends data on the UDP socket to the remote address to which it is
+        /// connected.
+        pub fn ax_udp_send(socket: &AxUdpSocketHandle, buf: &[u8]) -> AxResult<usize>;
+        /// Receives a single datagram message on the UDP socket from the remote
+        /// address to which it is connected. On success, returns the number of
+        /// bytes read.
+        pub fn ax_udp_recv(socket: &AxUdpSocketHandle, buf: &mut [u8]) -> AxResult<usize>;
+        /// Returns whether the UDP socket is readable or writable.
+        pub fn ax_udp_poll(socket: &AxUdpSocketHandle) -> AxResult<AxPollState>;
+
+        // Miscellaneous
+
+        /// Resolves the host name to a list of IP addresses.
+        pub fn ax_dns_query(domain_name: &str) -> AxResult<alloc::vec::Vec<IpAddr>>;
+        /// Poll the network stack.
+        ///
+        /// It may receive packets from the NIC and process them, and transmit queued
+        /// packets to the NIC.
+        pub fn ax_poll_interfaces() -> AxResult;
+    }
+}
+
+/// Graphics manipulation operations.
+pub mod display {
+    define_api_type! {
+        @cfg "display";
+        pub type AxDisplayInfo;
+    }
+
+    define_api! {
+        @cfg "display";
+        /// Gets the framebuffer information.
+        pub fn ax_framebuffer_info() -> AxDisplayInfo;
+        /// Flushes the framebuffer, i.e. show on the screen.
+        pub fn ax_framebuffer_flush();
+    }
+}
+
+/// Input/output operations.
+pub mod io {
+    define_api_type! {
+        pub type AxPollState;
+    }
+}

--- a/api/arceos_api/src/macros.rs
+++ b/api/arceos_api/src/macros.rs
@@ -1,0 +1,79 @@
+#![allow(unused_macros)]
+
+macro_rules! define_api_type {
+    ($( $(#[$attr:meta])* $vis:vis type $name:ident; )+) => {
+        $(
+            $vis use $crate::imp::$name;
+        )+
+    };
+    ( @cfg $feature:literal; $( $(#[$attr:meta])* $vis:vis type $name:ident; )+ ) => {
+        $(
+            #[cfg(feature = $feature)]
+            $(#[$attr])*
+            $vis use $crate::imp::$name;
+
+            #[cfg(all(feature = "dummy-if-not-enabled", not(feature = $feature)))]
+            $(#[$attr])*
+            $vis struct $name;
+        )+
+    };
+}
+
+macro_rules! define_api {
+    ($( $(#[$attr:meta])* $vis:vis fn $name:ident( $($arg:ident : $type:ty),* $(,)? ) $( -> $ret:ty )? ; )+) => {
+        $(
+            $(#[$attr])*
+            $vis fn $name( $($arg : $type),* ) $( -> $ret )? {
+                $crate::imp::$name( $($arg),* )
+            }
+        )+
+    };
+    (
+        @cfg $feature:literal;
+        $( $(#[$attr:meta])* $vis:vis fn $name:ident( $($arg:ident : $type:ty),* $(,)? ) $( -> $ret:ty )? ; )+
+    ) => {
+        $(
+            #[cfg(feature = $feature)]
+            $(#[$attr])*
+            $vis fn $name( $($arg : $type),* ) $( -> $ret )? {
+                $crate::imp::$name( $($arg),* )
+            }
+
+            #[allow(unused_variables)]
+            #[cfg(all(feature = "dummy-if-not-enabled", not(feature = $feature)))]
+            $(#[$attr])*
+            $vis fn $name( $($arg : $type),* ) $( -> $ret )? {
+                unimplemented!(stringify!($name))
+            }
+        )+
+    };
+}
+
+macro_rules! _cfg_common {
+    ( $feature:literal $($item:item)*  ) => {
+        $(
+            #[cfg(feature = $feature)]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_alloc {
+    ($($item:item)*) => { _cfg_common!{ "alloc" $($item)* } }
+}
+
+macro_rules! cfg_fs {
+    ($($item:item)*) => { _cfg_common!{ "fs" $($item)* } }
+}
+
+macro_rules! cfg_net {
+    ($($item:item)*) => { _cfg_common!{ "net" $($item)* } }
+}
+
+macro_rules! cfg_display {
+    ($($item:item)*) => { _cfg_common!{ "display" $($item)* } }
+}
+
+macro_rules! cfg_task {
+    ($($item:item)*) => { _cfg_common!{ "multitask" $($item)* } }
+}

--- a/apps/display/src/display.rs
+++ b/apps/display/src/display.rs
@@ -2,7 +2,7 @@ use embedded_graphics::pixelcolor::Rgb888;
 use embedded_graphics::prelude::{RgbColor, Size};
 use embedded_graphics::{draw_target::DrawTarget, prelude::OriginDimensions};
 
-pub use axstd::os::arceos::axdisplay::{framebuffer_flush, framebuffer_info, DisplayInfo};
+use axstd::os::arceos::api::display as api;
 
 pub struct Display {
     size: Size,
@@ -11,11 +11,15 @@ pub struct Display {
 
 impl Display {
     pub fn new() -> Self {
-        let info = framebuffer_info();
+        let info = api::ax_framebuffer_info();
         let fb =
             unsafe { core::slice::from_raw_parts_mut(info.fb_base_vaddr as *mut u8, info.fb_size) };
         let size = Size::new(info.width, info.height);
         Self { size, fb }
+    }
+
+    pub fn flush(&self) {
+        api::ax_framebuffer_flush();
     }
 }
 

--- a/apps/display/src/main.rs
+++ b/apps/display/src/main.rs
@@ -5,8 +5,8 @@
 extern crate axstd as std;
 
 mod display;
-use display::*;
 
+use self::display::Display;
 use embedded_graphics::{
     mono_font::{ascii::FONT_10X20, MonoTextStyle},
     pixelcolor::Rgb888,
@@ -67,15 +67,14 @@ impl DrawingBoard {
     }
 }
 
-fn test_gpu() -> i32 {
+fn test_gpu() {
     let mut board = DrawingBoard::new();
     board.disp.clear(Rgb888::BLACK).unwrap();
     for _ in 0..5 {
         board.latest_pos.x += RECT_SIZE as i32 + 20;
         board.paint();
-        framebuffer_flush();
+        board.disp.flush();
     }
-    0
 }
 
 #[cfg_attr(feature = "axstd", no_mangle)]

--- a/apps/fs/shell/Cargo.toml
+++ b/apps/fs/shell/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Yuekai Jia <equation618@gmail.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-use-ramfs = ["axfeat/myfs", "dep:axfs_vfs", "dep:axfs_ramfs", "dep:crate_interface"]
+use-ramfs = ["axstd/myfs", "dep:axfs_vfs", "dep:axfs_ramfs", "dep:crate_interface"]
 default = []
 
 [dependencies]
@@ -15,4 +15,3 @@ axfs_vfs = { path = "../../../crates/axfs_vfs", optional = true }
 axfs_ramfs = { path = "../../../crates/axfs_ramfs", optional = true }
 crate_interface = { path = "../../../crates/crate_interface", optional = true }
 axstd = { path = "../../../ulib/axstd", features = ["alloc", "fs"], optional = true }
-axfeat = { path = "../../../api/axfeat", optional = true }

--- a/apps/fs/shell/src/ramfs.rs
+++ b/apps/fs/shell/src/ramfs.rs
@@ -3,13 +3,13 @@ extern crate alloc;
 use alloc::sync::Arc;
 use axfs_ramfs::RamFileSystem;
 use axfs_vfs::VfsOps;
-use std::os::arceos::axfs::fops::{Disk, MyFileSystemIf};
+use std::os::arceos::api::fs::{AxDisk, MyFileSystemIf};
 
 struct MyFileSystemIfImpl;
 
 #[crate_interface::impl_interface]
 impl MyFileSystemIf for MyFileSystemIfImpl {
-    fn new_myfs(_disk: Disk) -> Arc<dyn VfsOps> {
+    fn new_myfs(_disk: AxDisk) -> Arc<dyn VfsOps> {
         Arc::new(RamFileSystem::new())
     }
 }

--- a/apps/task/priority/src/main.rs
+++ b/apps/task/priority/src/main.rs
@@ -10,7 +10,7 @@ use std::{thread, time};
 use std::{vec, vec::Vec};
 
 #[cfg(any(feature = "axstd", target_os = "arceos"))]
-use std::os::arceos::axtask;
+use std::os::arceos::api::task::ax_set_current_priority;
 
 struct TaskParam {
     data_len: usize,
@@ -62,7 +62,7 @@ fn load(n: &u64) -> u64 {
 #[cfg_attr(feature = "axstd", no_mangle)]
 fn main() {
     #[cfg(feature = "axstd")]
-    axtask::set_priority(-20);
+    ax_set_current_priority(-20).ok();
 
     let data = (0..PAYLOAD_KIND)
         .map(|i| Arc::new(vec![TASK_PARAMS[i].value; TASK_PARAMS[i].data_len]))
@@ -80,7 +80,7 @@ fn main() {
         let nice = TASK_PARAMS[i].nice;
         tasks.push(thread::spawn(move || {
             #[cfg(feature = "axstd")]
-            axtask::set_priority(nice);
+            ax_set_current_priority(nice).ok();
 
             let left = 0;
             let right = data_len;

--- a/scripts/make/cargo.mk
+++ b/scripts/make/cargo.mk
@@ -35,7 +35,7 @@ endef
 all_packages := \
   $(shell ls $(CURDIR)/crates) \
   $(shell ls $(CURDIR)/modules) \
-  axfeat axstd axlibc
+  axfeat arceos_api axstd axlibc
 
 define cargo_doc
   $(call run_cmd,cargo doc,--no-deps --all-features --workspace --exclude "arceos-*" $(verbose))

--- a/ulib/axlibc/src/file.rs
+++ b/ulib/axlibc/src/file.rs
@@ -40,9 +40,8 @@ impl FileLike for File {
 
     fn stat(&self) -> LinuxResult<ctypes::stat> {
         let metadata = self.0.lock().metadata()?;
-        let metadata = metadata.raw_metadata();
         let ty = metadata.file_type() as u8;
-        let perm = metadata.perm().bits() as u32;
+        let perm = metadata.permissions().bits() as u32;
         let st_mode = ((ty as u32) << 12) | perm;
         Ok(ctypes::stat {
             st_ino: 1,

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -26,31 +26,31 @@ smp = ["axfeat/smp"]
 fp_simd = ["axfeat/fp_simd"]
 
 # Interrupts
-irq = ["axfeat/irq"]
+irq = ["arceos_api/irq", "axfeat/irq"]
 
 # Memory
-alloc = ["dep:axalloc", "axfeat/alloc", "axio/alloc"]
+alloc = ["arceos_api/alloc", "axfeat/alloc", "axio/alloc"]
 alloc-tlsf = ["axfeat/alloc-tlsf"]
 alloc-slab = ["axfeat/alloc-slab"]
 alloc-buddy = ["axfeat/alloc-buddy"]
 paging = ["axfeat/paging"]
 
 # Multi-threading and scheduler
-multitask = ["axtask/multitask", "axsync/multitask", "axfeat/multitask"]
+multitask = ["arceos_api/multitask", "axsync/multitask", "axfeat/multitask"]
 sched_fifo = ["axfeat/sched_fifo"]
 sched_rr = ["axfeat/sched_rr"]
 sched_cfs = ["axfeat/sched_cfs"]
 
 # File system
-fs = ["dep:axfs", "axfeat/fs"]
+fs = ["dep:axfs", "arceos_api/fs", "axfeat/fs"]
 myfs = ["axfeat/myfs"]
 
 # Networking
-net = ["dep:axnet", "axfeat/net"]
+net = ["arceos_api/net", "axfeat/net"]
 dns = []
 
 # Display
-display = ["dep:axdisplay", "axfeat/display"]
+display = ["arceos_api/display", "axfeat/display"]
 
 # Device drivers
 bus-mmio = ["axfeat/bus-mmio"]
@@ -68,20 +68,10 @@ log-level-debug = ["axfeat/log-level-debug"]
 log-level-trace = ["axfeat/log-level-trace"]
 
 [dependencies]
-# ArceOS modules
-axfeat = { path = "../../api/axfeat" }
-axruntime = { path = "../../modules/axruntime" }
-axhal = { path = "../../modules/axhal" }
-axlog = { path = "../../modules/axlog" }
-axconfig = { path = "../../modules/axconfig" }
-axalloc = { path = "../../modules/axalloc", optional = true }
 axfs = { path = "../../modules/axfs", optional = true }
-axnet = { path = "../../modules/axnet", optional = true }
-axdisplay = { path = "../../modules/axdisplay", optional = true }
 axsync = { path = "../../modules/axsync", optional = true }
-axtask = { path = "../../modules/axtask", optional = true }
-
-# Other crates
+axfeat = { path = "../../api/axfeat" }
+arceos_api = { path = "../../api/arceos_api" }
 axio = { path = "../../crates/axio" }
 axerrno = { path = "../../crates/axerrno" }
 spinlock = { path = "../../crates/spinlock" }

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -20,7 +20,7 @@ documentation = "https://rcore-os.github.io/arceos/axstd/index.html"
 default = []
 
 # Multicore
-smp = ["axfeat/smp"]
+smp = ["axfeat/smp", "spinlock/smp"]
 
 # Floating point/SIMD
 fp_simd = ["axfeat/fp_simd"]
@@ -36,7 +36,7 @@ alloc-buddy = ["axfeat/alloc-buddy"]
 paging = ["axfeat/paging"]
 
 # Multi-threading and scheduler
-multitask = ["arceos_api/multitask", "axsync/multitask", "axfeat/multitask"]
+multitask = ["arceos_api/multitask", "axfeat/multitask"]
 sched_fifo = ["axfeat/sched_fifo"]
 sched_rr = ["axfeat/sched_rr"]
 sched_cfs = ["axfeat/sched_cfs"]
@@ -69,7 +69,6 @@ log-level-trace = ["axfeat/log-level-trace"]
 
 [dependencies]
 axfs = { path = "../../modules/axfs", optional = true }
-axsync = { path = "../../modules/axsync", optional = true }
 axfeat = { path = "../../api/axfeat" }
 arceos_api = { path = "../../api/arceos_api" }
 axio = { path = "../../crates/axio" }

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -42,8 +42,8 @@ sched_rr = ["axfeat/sched_rr"]
 sched_cfs = ["axfeat/sched_cfs"]
 
 # File system
-fs = ["dep:axfs", "arceos_api/fs", "axfeat/fs"]
-myfs = ["axfeat/myfs"]
+fs = ["arceos_api/fs", "axfeat/fs"]
+myfs = ["arceos_api/myfs", "axfeat/myfs"]
 
 # Networking
 net = ["arceos_api/net", "axfeat/net"]
@@ -68,7 +68,6 @@ log-level-debug = ["axfeat/log-level-debug"]
 log-level-trace = ["axfeat/log-level-trace"]
 
 [dependencies]
-axfs = { path = "../../modules/axfs", optional = true }
 axfeat = { path = "../../api/axfeat" }
 arceos_api = { path = "../../api/arceos_api" }
 axio = { path = "../../crates/axio" }

--- a/ulib/axstd/src/env.rs
+++ b/ulib/axstd/src/env.rs
@@ -9,11 +9,11 @@ use {crate::io, alloc::string::String};
 /// Returns the current working directory as a [`String`].
 #[cfg(feature = "fs")]
 pub fn current_dir() -> io::Result<String> {
-    axfs::api::current_dir()
+    arceos_api::fs::ax_current_dir()
 }
 
 /// Changes the current working directory to the specified path.
 #[cfg(feature = "fs")]
 pub fn set_current_dir(path: &str) -> io::Result<()> {
-    axfs::api::set_current_dir(path)
+    arceos_api::fs::ax_set_current_dir(path)
 }

--- a/ulib/axstd/src/fs.rs
+++ b/ulib/axstd/src/fs.rs
@@ -1,5 +1,0 @@
-//! Filesystem manipulation operations.
-
-pub use axfs::api::{canonicalize, metadata, read, read_to_string, remove_file, write};
-pub use axfs::api::{create_dir, create_dir_all, read_dir, remove_dir, rename};
-pub use axfs::api::{DirEntry, File, FileType, Metadata, OpenOptions, Permissions, ReadDir};

--- a/ulib/axstd/src/fs/dir.rs
+++ b/ulib/axstd/src/fs/dir.rs
@@ -1,0 +1,154 @@
+extern crate alloc;
+
+use alloc::string::String;
+use core::fmt;
+
+use super::FileType;
+use crate::io::Result;
+
+use arceos_api::fs as api;
+
+/// Iterator over the entries in a directory.
+pub struct ReadDir<'a> {
+    path: &'a str,
+    inner: api::AxDirHandle,
+    buf_pos: usize,
+    buf_end: usize,
+    end_of_stream: bool,
+    dirent_buf: [api::AxDirEntry; 31],
+}
+
+/// Entries returned by the [`ReadDir`] iterator.
+pub struct DirEntry<'a> {
+    dir_path: &'a str,
+    entry_name: String,
+    entry_type: FileType,
+}
+
+/// A builder used to create directories in various manners.
+#[derive(Default, Debug)]
+pub struct DirBuilder {
+    recursive: bool,
+}
+
+impl<'a> ReadDir<'a> {
+    pub(super) fn new(path: &'a str) -> Result<Self> {
+        let mut opts = api::AxOpenOptions::new();
+        opts.read(true);
+        let inner = api::ax_open_dir(path, &opts)?;
+
+        const EMPTY: api::AxDirEntry = api::AxDirEntry::default();
+        let dirent_buf = [EMPTY; 31];
+        Ok(ReadDir {
+            path,
+            inner,
+            end_of_stream: false,
+            buf_pos: 0,
+            buf_end: 0,
+            dirent_buf,
+        })
+    }
+}
+
+impl<'a> Iterator for ReadDir<'a> {
+    type Item = Result<DirEntry<'a>>;
+
+    fn next(&mut self) -> Option<Result<DirEntry<'a>>> {
+        if self.end_of_stream {
+            return None;
+        }
+
+        loop {
+            if self.buf_pos >= self.buf_end {
+                match api::ax_read_dir(&mut self.inner, &mut self.dirent_buf) {
+                    Ok(n) => {
+                        if n == 0 {
+                            self.end_of_stream = true;
+                            return None;
+                        }
+                        self.buf_pos = 0;
+                        self.buf_end = n;
+                    }
+                    Err(e) => {
+                        self.end_of_stream = true;
+                        return Some(Err(e));
+                    }
+                }
+            }
+            let entry = &self.dirent_buf[self.buf_pos];
+            self.buf_pos += 1;
+            let name_bytes = entry.name_as_bytes();
+            if name_bytes == b"." || name_bytes == b".." {
+                continue;
+            }
+            let entry_name = unsafe { core::str::from_utf8_unchecked(name_bytes).into() };
+            let entry_type = entry.entry_type();
+
+            return Some(Ok(DirEntry {
+                dir_path: self.path,
+                entry_name,
+                entry_type,
+            }));
+        }
+    }
+}
+
+impl<'a> DirEntry<'a> {
+    /// Returns the full path to the file that this entry represents.
+    ///
+    /// The full path is created by joining the original path to `read_dir`
+    /// with the filename of this entry.
+    pub fn path(&self) -> String {
+        String::from(self.dir_path.trim_end_matches('/')) + "/" + &self.entry_name
+    }
+
+    /// Returns the bare file name of this directory entry without any other
+    /// leading path component.
+    pub fn file_name(&self) -> String {
+        self.entry_name.clone()
+    }
+
+    /// Returns the file type for the file that this entry points at.
+    pub fn file_type(&self) -> FileType {
+        self.entry_type
+    }
+}
+
+impl fmt::Debug for DirEntry<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DirEntry").field(&self.path()).finish()
+    }
+}
+
+impl DirBuilder {
+    /// Creates a new set of options with default mode/security settings for all
+    /// platforms and also non-recursive.
+    pub fn new() -> Self {
+        Self { recursive: false }
+    }
+
+    /// Indicates that directories should be created recursively, creating all
+    /// parent directories. Parents that do not exist are created with the same
+    /// security and permissions settings.
+    pub fn recursive(&mut self, recursive: bool) -> &mut Self {
+        self.recursive = recursive;
+        self
+    }
+
+    /// Creates the specified directory with the options configured in this
+    /// builder.
+    pub fn create(&self, path: &str) -> Result<()> {
+        if self.recursive {
+            self.create_dir_all(path)
+        } else {
+            api::ax_create_dir(path)
+        }
+    }
+
+    fn create_dir_all(&self, _path: &str) -> Result<()> {
+        axerrno::ax_err!(
+            Unsupported,
+            "Recursive directory creation is not supported yet"
+        )
+    }
+}

--- a/ulib/axstd/src/fs/file.rs
+++ b/ulib/axstd/src/fs/file.rs
@@ -1,31 +1,31 @@
-use axio::{prelude::*, Result, SeekFrom};
+use crate::io::{prelude::*, Result, SeekFrom};
 use core::fmt;
 
-use crate::fops;
+use arceos_api::fs as api;
 
 /// A structure representing a type of file with accessors for each file type.
 /// It is returned by [`Metadata::file_type`] method.
-pub type FileType = fops::FileType;
+pub type FileType = api::AxFileType;
 
 /// Representation of the various permissions on a file.
-pub type Permissions = fops::FilePerm;
+pub type Permissions = api::AxFilePerm;
 
 /// An object providing access to an open file on the filesystem.
 pub struct File {
-    inner: fops::File,
+    inner: api::AxFileHandle,
 }
 
 /// Metadata information about a file.
-pub struct Metadata(fops::FileAttr);
+pub struct Metadata(api::AxFileAttr);
 
 /// Options and flags which can be used to configure how a file is opened.
 #[derive(Clone, Debug)]
-pub struct OpenOptions(fops::OpenOptions);
+pub struct OpenOptions(api::AxOpenOptions);
 
 impl OpenOptions {
     /// Creates a blank new set of options ready for configuration.
     pub const fn new() -> Self {
-        OpenOptions(fops::OpenOptions::new())
+        OpenOptions(api::AxOpenOptions::new())
     }
 
     /// Sets the option for read access.
@@ -66,7 +66,7 @@ impl OpenOptions {
 
     /// Opens a file at `path` with the options specified by `self`.
     pub fn open(&self, path: &str) -> Result<File> {
-        fops::File::open(path, &self.0).map(|inner| File { inner })
+        api::ax_open_file(path, &self.0).map(|inner| File { inner })
     }
 }
 
@@ -155,33 +155,33 @@ impl File {
     /// Truncates or extends the underlying file, updating the size of
     /// this file to become `size`.
     pub fn set_len(&self, size: u64) -> Result<()> {
-        self.inner.truncate(size)
+        api::ax_truncate_file(&self.inner, size)
     }
 
     /// Queries metadata about the underlying file.
     pub fn metadata(&self) -> Result<Metadata> {
-        self.inner.get_attr().map(Metadata)
+        api::ax_file_attr(&self.inner).map(Metadata)
     }
 }
 
 impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.inner.read(buf)
+        api::ax_read_file(&mut self.inner, buf)
     }
 }
 
 impl Write for File {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.write(buf)
+        api::ax_write_file(&mut self.inner, buf)
     }
 
     fn flush(&mut self) -> Result<()> {
-        self.inner.flush()
+        api::ax_flush_file(&self.inner)
     }
 }
 
 impl Seek for File {
     fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-        self.inner.seek(pos)
+        api::ax_seek_file(&mut self.inner, pos)
     }
 }

--- a/ulib/axstd/src/fs/mod.rs
+++ b/ulib/axstd/src/fs/mod.rs
@@ -1,0 +1,77 @@
+//! Filesystem manipulation operations.
+
+mod dir;
+mod file;
+
+use crate::io::{self, prelude::*};
+
+#[cfg(feature = "alloc")]
+use alloc::{string::String, vec::Vec};
+
+pub use self::dir::{DirBuilder, DirEntry, ReadDir};
+pub use self::file::{File, FileType, Metadata, OpenOptions, Permissions};
+
+/// Read the entire contents of a file into a bytes vector.
+#[cfg(feature = "alloc")]
+pub fn read(path: &str) -> io::Result<Vec<u8>> {
+    let mut file = File::open(path)?;
+    let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut bytes = Vec::with_capacity(size as usize);
+    file.read_to_end(&mut bytes)?;
+    Ok(bytes)
+}
+
+/// Read the entire contents of a file into a string.
+#[cfg(feature = "alloc")]
+pub fn read_to_string(path: &str) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let size = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut string = String::with_capacity(size as usize);
+    file.read_to_string(&mut string)?;
+    Ok(string)
+}
+
+/// Write a slice as the entire contents of a file.
+pub fn write<C: AsRef<[u8]>>(path: &str, contents: C) -> io::Result<()> {
+    File::create(path)?.write_all(contents.as_ref())
+}
+
+/// Given a path, query the file system to get information about a file,
+/// directory, etc.
+pub fn metadata(path: &str) -> io::Result<Metadata> {
+    File::open(path)?.metadata()
+}
+
+/// Returns an iterator over the entries within a directory.
+pub fn read_dir(path: &str) -> io::Result<ReadDir> {
+    ReadDir::new(path)
+}
+
+/// Creates a new, empty directory at the provided path.
+pub fn create_dir(path: &str) -> io::Result<()> {
+    DirBuilder::new().create(path)
+}
+
+/// Recursively create a directory and all of its parent components if they
+/// are missing.
+pub fn create_dir_all(path: &str) -> io::Result<()> {
+    DirBuilder::new().recursive(true).create(path)
+}
+
+/// Removes an empty directory.
+pub fn remove_dir(path: &str) -> io::Result<()> {
+    arceos_api::fs::ax_remove_dir(path)
+}
+
+/// Removes a file from the filesystem.
+pub fn remove_file(path: &str) -> io::Result<()> {
+    arceos_api::fs::ax_remove_file(path)
+}
+
+/// Rename a file or directory to a new name.
+/// Delete the original file if `old` already exists.
+///
+/// This only works then the new path is in the same mounted fs.
+pub fn rename(old: &str, new: &str) -> io::Result<()> {
+    arceos_api::fs::ax_rename(old, new)
+}

--- a/ulib/axstd/src/io/stdio.rs
+++ b/ulib/axstd/src/io/stdio.rs
@@ -12,7 +12,7 @@ impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut read_len = 0;
         while read_len < buf.len() {
-            if let Some(c) = axhal::console::getchar() {
+            if let Some(c) = arceos_api::stdio::ax_console_read_byte() {
                 buf[read_len] = c;
                 read_len += 1;
             } else {
@@ -25,8 +25,7 @@ impl Read for StdinRaw {
 
 impl Write for StdoutRaw {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        axhal::console::write_bytes(buf);
-        Ok(buf.len())
+        arceos_api::stdio::ax_console_write_bytes(buf)
     }
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
@@ -167,7 +166,7 @@ pub fn __print_impl(args: core::fmt::Arguments) {
     if cfg!(feature = "smp") {
         // synchronize using the lock in axlog, to avoid interleaving
         // with kernel logs
-        axlog::print_fmt(args).unwrap();
+        arceos_api::stdio::ax_console_write_fmt(args).unwrap();
     } else {
         stdout().lock().write_fmt(args).unwrap();
     }

--- a/ulib/axstd/src/lib.rs
+++ b/ulib/axstd/src/lib.rs
@@ -50,9 +50,6 @@
 #![feature(doc_auto_cfg)]
 #![feature(ip_in_core)]
 
-#[cfg(not(test))]
-extern crate axruntime;
-
 #[cfg(feature = "alloc")]
 extern crate alloc;
 

--- a/ulib/axstd/src/net/socket_addr.rs
+++ b/ulib/axstd/src/net/socket_addr.rs
@@ -141,7 +141,7 @@ mod dns {
                 return Ok(vec![SocketAddr::V4(addr)].into_iter());
             }
 
-            Ok(axnet::dns_query(host)?
+            Ok(arceos_api::net::ax_dns_query(host)?
                 .into_iter()
                 .map(|ip| SocketAddr::new(ip, port))
                 .collect::<Vec<_>>()
@@ -166,7 +166,7 @@ mod dns {
                 .parse()
                 .map_err(|_| axerrno::ax_err_type!(InvalidInput, "invalid port value"))?;
 
-            Ok(axnet::dns_query(host)?
+            Ok(arceos_api::net::ax_dns_query(host)?
                 .into_iter()
                 .map(|ip| SocketAddr::new(ip, port))
                 .collect::<Vec<_>>()

--- a/ulib/axstd/src/os.rs
+++ b/ulib/axstd/src/os.rs
@@ -2,10 +2,7 @@
 
 /// ArceOS-specific definitions.
 pub mod arceos {
-    #[cfg(feature = "display")]
-    pub use axdisplay;
+    pub use arceos_api as api;
     #[cfg(feature = "fs")]
     pub use axfs;
-    #[cfg(feature = "multitask")]
-    pub use axtask;
 }

--- a/ulib/axstd/src/os.rs
+++ b/ulib/axstd/src/os.rs
@@ -3,6 +3,4 @@
 /// ArceOS-specific definitions.
 pub mod arceos {
     pub use arceos_api as api;
-    #[cfg(feature = "fs")]
-    pub use axfs;
 }

--- a/ulib/axstd/src/process.rs
+++ b/ulib/axstd/src/process.rs
@@ -6,5 +6,5 @@
 
 /// Shutdown the whole system.
 pub fn exit(_exit_code: i32) -> ! {
-    axhal::misc::terminate();
+    arceos_api::sys::ax_terminate();
 }

--- a/ulib/axstd/src/sync/mod.rs
+++ b/ulib/axstd/src/sync/mod.rs
@@ -8,7 +8,12 @@ pub use core::sync::atomic;
 pub use alloc::sync::{Arc, Weak};
 
 #[cfg(feature = "multitask")]
-pub use axsync::{Mutex, MutexGuard};
+mod mutex;
+
+#[cfg(feature = "multitask")]
+#[doc(cfg(feature = "multitask"))]
+pub use self::mutex::{Mutex, MutexGuard};
 
 #[cfg(not(feature = "multitask"))]
-pub use spinlock::{SpinNoIrq as Mutex, SpinNoIrqGuard as MutexGuard};
+#[doc(cfg(not(feature = "multitask")))]
+pub use spinlock::{SpinRaw as Mutex, SpinRawGuard as MutexGuard}; // never used in IRQ context

--- a/ulib/axstd/src/sync/mutex.rs
+++ b/ulib/axstd/src/sync/mutex.rs
@@ -1,0 +1,198 @@
+//! A naïve sleeping mutex.
+
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use arceos_api::task::{self as api, AxWaitQueueHandle};
+
+/// A mutual exclusion primitive useful for protecting shared data, similar to
+/// [`std::sync::Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html).
+///
+/// When the mutex is locked, the current task will block and be put into the
+/// wait queue. When the mutex is unlocked, all tasks waiting on the queue
+/// will be woken up.
+pub struct Mutex<T: ?Sized> {
+    wq: AxWaitQueueHandle,
+    owner_id: AtomicU64,
+    data: UnsafeCell<T>,
+}
+
+/// A guard that provides mutable data access.
+///
+/// When the guard falls out of scope it will release the lock.
+pub struct MutexGuard<'a, T: ?Sized + 'a> {
+    lock: &'a Mutex<T>,
+    data: *mut T,
+}
+
+// Same unsafe impls as `std::sync::Mutex`
+unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
+
+impl<T> Mutex<T> {
+    /// Creates a new [`Mutex`] wrapping the supplied data.
+    #[inline(always)]
+    pub const fn new(data: T) -> Self {
+        Self {
+            wq: AxWaitQueueHandle::new(),
+            owner_id: AtomicU64::new(0),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    /// Consumes this [`Mutex`] and unwraps the underlying data.
+    #[inline(always)]
+    pub fn into_inner(self) -> T {
+        // We know statically that there are no outstanding references to
+        // `self` so there's no need to lock.
+        let Mutex { data, .. } = self;
+        data.into_inner()
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    /// Returns `true` if the lock is currently held.
+    ///
+    /// # Safety
+    ///
+    /// This function provides no synchronization guarantees and so its result should be considered 'out of date'
+    /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
+    #[inline(always)]
+    pub fn is_locked(&self) -> bool {
+        self.owner_id.load(Ordering::Relaxed) != 0
+    }
+
+    /// Locks the [`Mutex`] and returns a guard that permits access to the inner data.
+    ///
+    /// The returned value may be dereferenced for data access
+    /// and the lock will be dropped when the guard falls out of scope.
+    pub fn lock(&self) -> MutexGuard<T> {
+        let current_id = api::ax_current_task_id();
+        loop {
+            // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
+            // when called in a loop.
+            match self.owner_id.compare_exchange_weak(
+                0,
+                current_id,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                Err(owner_id) => {
+                    assert_ne!(
+                        owner_id, current_id,
+                        "Thread({}) tried to acquire mutex it already owns.",
+                        current_id,
+                    );
+                    // Wait until the lock looks unlocked before retrying
+                    api::ax_wait_queue_wait(&self.wq, || !self.is_locked(), None);
+                }
+            }
+        }
+        MutexGuard {
+            lock: self,
+            data: unsafe { &mut *self.data.get() },
+        }
+    }
+
+    /// Try to lock this [`Mutex`], returning a lock guard if successful.
+    #[inline(always)]
+    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+        let current_id = api::ax_current_task_id();
+        // The reason for using a strong compare_exchange is explained here:
+        // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
+        if self
+            .owner_id
+            .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            Some(MutexGuard {
+                lock: self,
+                data: unsafe { &mut *self.data.get() },
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Force unlock the [`Mutex`].
+    ///
+    /// # Safety
+    ///
+    /// This is *extremely* unsafe if the lock is not held by the current
+    /// thread. However, this can be useful in some instances for exposing
+    /// the lock to FFI that doesn’t know how to deal with RAII.
+    pub unsafe fn force_unlock(&self) {
+        let owner_id = self.owner_id.swap(0, Ordering::Release);
+        let current_id = api::ax_current_task_id();
+        assert_eq!(
+            owner_id, current_id,
+            "Thread({}) tried to release mutex it doesn't own",
+            current_id,
+        );
+        // wake up one waiting thread.
+        api::ax_wait_queue_wake(&self.wq, 1);
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the [`Mutex`] mutably, and a mutable reference is guaranteed to be exclusive in
+    /// Rust, no actual locking needs to take place -- the mutable borrow statically guarantees no locks exist. As
+    /// such, this is a 'zero-cost' operation.
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        // We know statically that there are no other references to `self`, so
+        // there's no need to lock the inner mutex.
+        unsafe { &mut *self.data.get() }
+    }
+}
+
+impl<T: ?Sized + Default> Default for Mutex<T> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.try_lock() {
+            Some(guard) => write!(f, "Mutex {{ data: ")
+                .and_then(|()| (*guard).fmt(f))
+                .and_then(|()| write!(f, "}}")),
+            None => write!(f, "Mutex {{ <locked> }}"),
+        }
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MutexGuard<'a, T> {
+    type Target = T;
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        // We know statically that only we are referencing data
+        unsafe { &*self.data }
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut T {
+        // We know statically that only we are referencing data
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
+    /// The dropping of the [`MutexGuard`] will release the lock it was created from.
+    fn drop(&mut self) {
+        unsafe { self.lock.force_unlock() }
+    }
+}

--- a/ulib/axstd/src/thread/mod.rs
+++ b/ulib/axstd/src/thread/mod.rs
@@ -5,31 +5,23 @@ mod multi;
 #[cfg(feature = "multitask")]
 pub use multi::*;
 
+use arceos_api::task as api;
+
 /// Current thread gives up the CPU time voluntarily, and switches to another
 /// ready thread.
 ///
 /// For single-threaded configuration (`multitask` feature is disabled), we just
 /// relax the CPU and wait for incoming interrupts.
 pub fn yield_now() {
-    #[cfg(feature = "multitask")]
-    axtask::yield_now();
-    #[cfg(not(feature = "multitask"))]
-    if cfg!(feature = "irq") {
-        axhal::arch::wait_for_irqs();
-    } else {
-        core::hint::spin_loop();
-    }
+    api::ax_yield_now();
 }
 
 /// Exits the current thread.
 ///
 /// For single-threaded configuration (`multitask` feature is disabled),
 /// it directly terminates the main thread and shutdown.
-pub fn exit(_exit_code: i32) -> ! {
-    #[cfg(feature = "multitask")]
-    axtask::exit(_exit_code);
-    #[cfg(not(feature = "multitask"))]
-    axhal::misc::terminate();
+pub fn exit(exit_code: i32) -> ! {
+    api::ax_exit(exit_code);
 }
 
 /// Current thread is going to sleep for the given duration.
@@ -37,16 +29,13 @@ pub fn exit(_exit_code: i32) -> ! {
 /// If one of `multitask` or `irq` features is not enabled, it uses busy-wait
 /// instead.
 pub fn sleep(dur: core::time::Duration) {
-    sleep_until(axhal::time::current_time() + dur);
+    sleep_until(arceos_api::time::ax_current_time() + dur);
 }
 
 /// Current thread is going to sleep, it will be woken up at the given deadline.
 ///
 /// If one of `multitask` or `irq` features is not enabled, it uses busy-wait
 /// instead.
-pub fn sleep_until(deadline: axhal::time::TimeValue) {
-    #[cfg(feature = "multitask")]
-    axtask::sleep_until(deadline);
-    #[cfg(not(feature = "multitask"))]
-    axhal::time::busy_wait_until(deadline);
+pub fn sleep_until(deadline: arceos_api::time::AxTimeValue) {
+    api::ax_sleep_until(deadline);
 }

--- a/ulib/axstd/src/time.rs
+++ b/ulib/axstd/src/time.rs
@@ -1,6 +1,6 @@
 //! Temporal quantification.
 
-use axhal::time::TimeValue;
+use arceos_api::time::AxTimeValue;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 pub use core::time::Duration;
@@ -8,12 +8,12 @@ pub use core::time::Duration;
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with [`Duration`].
 #[derive(Clone, Copy)]
-pub struct Instant(TimeValue);
+pub struct Instant(AxTimeValue);
 
 impl Instant {
     /// Returns an instant corresponding to "now".
     pub fn now() -> Instant {
-        Instant(axhal::time::current_time())
+        Instant(arceos_api::time::ax_current_time())
     }
 
     /// Returns the amount of time elapsed from another instant to this one,


### PR DESCRIPTION
Now `axstd` can only call functions provided by ArceOS modules through well-defined interfaces.

TODO:

* Add `arceos_posix_api` for `axlibc`