### PR TITLE
alloc: update memory allocation pointer type from NonZeroUsize to NonNull<u8> in ByteAllocator trait

### DIFF
--- a/api/arceos_api/src/imp/mem.rs
+++ b/api/arceos_api/src/imp/mem.rs
@@ -4,13 +4,13 @@ cfg_alloc! {
 
     pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
         if let Ok(vaddr) = axalloc::global_allocator().alloc(layout) {
-            Some(unsafe { NonNull::new_unchecked(vaddr.get() as _) })
+            Some(vaddr)
         } else {
             None
         }
     }
 
     pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
-        axalloc::global_allocator().dealloc(ptr.addr(), layout)
+        axalloc::global_allocator().dealloc(ptr, layout)
     }
 }

--- a/api/arceos_api/src/imp/mem.rs
+++ b/api/arceos_api/src/imp/mem.rs
@@ -3,11 +3,7 @@ cfg_alloc! {
     use core::ptr::NonNull;
 
     pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
-        if let Ok(vaddr) = axalloc::global_allocator().alloc(layout) {
-            Some(vaddr)
-        } else {
-            None
-        }
+        axalloc::global_allocator().alloc(layout).ok()
     }
 
     pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 #![feature(ip_in_core)]
-#![feature(strict_provenance)]
 #![feature(doc_auto_cfg)]
 #![feature(doc_cfg)]
 #![allow(unused_imports)]

--- a/crates/allocator/src/buddy.rs
+++ b/crates/allocator/src/buddy.rs
@@ -4,7 +4,7 @@
 
 use buddy_system_allocator::Heap;
 use core::alloc::Layout;
-use core::num::NonZeroUsize;
+use core::ptr::NonNull;
 
 use crate::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
 
@@ -36,18 +36,12 @@ impl BaseAllocator for BuddyByteAllocator {
 }
 
 impl ByteAllocator for BuddyByteAllocator {
-    fn alloc(&mut self, layout: Layout) -> AllocResult<NonZeroUsize> {
-        self.inner
-            .alloc(layout)
-            .map(|ptr| ptr.addr())
-            .map_err(|_| AllocError::NoMemory)
+    fn alloc(&mut self, layout: Layout) -> AllocResult<NonNull<u8>> {
+        self.inner.alloc(layout).map_err(|_| AllocError::NoMemory)
     }
 
-    fn dealloc(&mut self, pos: NonZeroUsize, layout: Layout) {
-        self.inner.dealloc(
-            unsafe { core::ptr::NonNull::new_unchecked(pos.get() as _) },
-            layout,
-        )
+    fn dealloc(&mut self, pos: NonNull<u8>, layout: Layout) {
+        self.inner.dealloc(pos, layout)
     }
 
     fn total_bytes(&self) -> usize {

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -9,7 +9,6 @@
 //! - [`IdAllocator`]: Used to allocate unique IDs.
 
 #![no_std]
-#![feature(strict_provenance)]
 #![feature(result_option_inspect)]
 #![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -34,7 +34,7 @@ mod tlsf;
 pub use tlsf::TlsfByteAllocator;
 
 use core::alloc::Layout;
-use core::num::NonZeroUsize;
+use core::ptr::NonNull;
 
 /// The error type used for allocation.
 #[derive(Debug)]
@@ -64,10 +64,10 @@ pub trait BaseAllocator {
 /// Byte-granularity allocator.
 pub trait ByteAllocator: BaseAllocator {
     /// Allocate memory with the given size (in bytes) and alignment.
-    fn alloc(&mut self, layout: Layout) -> AllocResult<NonZeroUsize>;
+    fn alloc(&mut self, layout: Layout) -> AllocResult<NonNull<u8>>;
 
     /// Deallocate memory at the given position, size, and alignment.
-    fn dealloc(&mut self, pos: NonZeroUsize, layout: Layout);
+    fn dealloc(&mut self, pos: NonNull<u8>, layout: Layout);
 
     /// Returns total memory size in bytes.
     fn total_bytes(&self) -> usize;
@@ -161,14 +161,13 @@ mod allocator_api {
                 0 => Ok(NonNull::slice_from_raw_parts(NonNull::dangling(), 0)),
                 size => {
                     let raw_addr = self.0.borrow_mut().alloc(layout).map_err(|_| AllocError)?;
-                    let ptr = unsafe { NonNull::new_unchecked(raw_addr.get() as _) };
-                    Ok(NonNull::slice_from_raw_parts(ptr, size))
+                    Ok(NonNull::slice_from_raw_parts(raw_addr, size))
                 }
             }
         }
 
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            self.0.borrow_mut().dealloc(ptr.addr(), layout)
+            self.0.borrow_mut().dealloc(ptr, layout)
         }
     }
 

--- a/crates/allocator/tests/allocator.rs
+++ b/crates/allocator/tests/allocator.rs
@@ -1,6 +1,5 @@
 #![feature(btreemap_alloc)]
 #![feature(allocator_api)]
-#![feature(strict_provenance)]
 
 use std::alloc::{Allocator, Layout};
 use std::collections::BTreeMap;

--- a/modules/axdriver/src/ixgbe.rs
+++ b/modules/axdriver/src/ixgbe.rs
@@ -9,18 +9,17 @@ unsafe impl IxgbeHal for IxgbeHalImpl {
     fn dma_alloc(size: usize) -> (IxgbePhysAddr, NonNull<u8>) {
         let layout = Layout::from_size_align(size, 8).unwrap();
         let vaddr = if let Ok(vaddr) = global_allocator().alloc(layout) {
-            vaddr.get()
+            vaddr
         } else {
             return (0, NonNull::dangling());
         };
-        let paddr = virt_to_phys(vaddr.into());
-        let ptr = NonNull::new(vaddr as _).unwrap();
-        (paddr.as_usize(), ptr)
+        let paddr = virt_to_phys((vaddr.as_ptr() as usize).into());
+        (paddr.as_usize(), vaddr)
     }
 
     unsafe fn dma_dealloc(_paddr: IxgbePhysAddr, vaddr: NonNull<u8>, size: usize) -> i32 {
         let layout = Layout::from_size_align(size, 8).unwrap();
-        global_allocator().dealloc(vaddr.addr(), layout);
+        global_allocator().dealloc(vaddr, layout);
         0
     }
 

--- a/modules/axdriver/src/lib.rs
+++ b/modules/axdriver/src/lib.rs
@@ -57,7 +57,6 @@
 #![no_std]
 #![feature(doc_auto_cfg)]
 #![feature(associated_type_defaults)]
-#![feature(strict_provenance)]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
This pull request updates the memory allocation pointer type from NonZeroUsize to NonNull<u8> in the ByteAllocator trait of the Rust open-source operating system project.

Motivation/Improvement Reason:

1. The NonZeroUsize type can represent memory page numbers, allocation sizes, or offsets, which can be ambiguous in terms of semantics. Using NonNull<u8> provides a more accurate representation of returning a pointer to a memory segment.
2. Previously, both the tlsf and buddy libraries required conversion from NonZeroUsize to NonNull<u8>. After this change, only the slab library needs to perform the conversion.
3. The Rust standard library's core::alloc::Alloc also uses NonNull<u8>.

This PR modifies the ByteAllocator trait and its implementations to use NonNull<u8> as the memory allocation pointer type. The changes include updating the return type of the alloc method to AllocResult<NonNull<u8>>, and the parameter type of the dealloc method to NonNull<u8>