### PR TITLE
解决 MacOS 编译错误，redis 编译需要指定 AR 和 RANLIB

### DIFF
--- a/apps/c/redis/Makefile
+++ b/apps/c/redis/Makefile
@@ -4,7 +4,7 @@ ARCH ?= x86_64
 
 CC := $(ARCH)-linux-musl-gcc
 
-CFLAGS :=
+CFLAGS := -fPIC
 LDFLAGS := -static -no-pie
 
 redis-version := 7.0.12
@@ -14,6 +14,8 @@ redis-bin := redis-server
 
 redis-build-args := \
   CC=$(CC) \
+  AR=$(AR) \
+  RANLIB=$(RANLIB) \
   CFLAGS="$(CFLAGS)" \
   USE_JEMALLOC=no \
   -j

--- a/apps/c/redis/axbuild.mk
+++ b/apps/c/redis/axbuild.mk
@@ -4,10 +4,12 @@ redis-objs := redis-$(redis-version)/src/redis-server.o
 
 app-objs := $(redis-objs)
 
-CFLAGS += -Wno-format
+CFLAGS += -Wno-format -fPIC
 
 redis-build-args := \
   CC=$(CC) \
+  AR=$(AR) \
+  RANLIB=$(RANLIB) \
   CFLAGS="$(CFLAGS)" \
   USE_JEMALLOC=no \
   -j


### PR DESCRIPTION
解决 MacOS 下面执行下面命令编译 redis 时符号找不到以及高地址定位错误问题。
make A=apps/c/redis/ LOG=off NET=y BLK=y ARCH=x86_64 SMP=4 run