### PR TITLE
Add DMA alloc support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "axalloc",
  "axconfig",
  "axdisplay",
+ "axdma",
  "axdriver",
  "axerrno",
  "axfeat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,11 +195,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axdma"
+version = "0.1.0"
+dependencies = [
+ "allocator",
+ "axalloc",
+ "axconfig",
+ "axerrno",
+ "axhal",
+ "axmm",
+ "kspin",
+ "log",
+ "memory_addr",
+]
+
+[[package]]
 name = "axdriver"
 version = "0.1.0"
 dependencies = [
  "axalloc",
  "axconfig",
+ "axdma",
  "axdriver_base",
  "axdriver_block",
  "axdriver_display",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "modules/axhal",
     "modules/axlog",
     "modules/axmm",
+    "modules/axdma",
     "modules/axnet",
     "modules/axruntime",
     "modules/axsync",
@@ -59,6 +60,7 @@ axnet = { path = "modules/axnet" }
 axruntime = { path = "modules/axruntime" }
 axsync = { path = "modules/axsync" }
 axtask = { path = "modules/axtask" }
+axdma = { path = "modules/axdma" }
 
 [profile.release]
 lto = true

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 irq = ["axfeat/irq"]
 alloc = ["dep:axalloc", "axfeat/alloc"]
 paging = ["dep:axmm", "axfeat/paging"]
+dma = ["dep:axdma", "axfeat/dma"]
 multitask = ["axtask/multitask", "axsync/multitask", "axfeat/multitask"]
 fs = ["dep:axfs", "dep:axdriver", "axfeat/fs"]
 net = ["dep:axnet", "dep:axdriver", "axfeat/net"]
@@ -36,6 +37,7 @@ axhal = { workspace = true }
 axsync = { workspace = true }
 axalloc = { workspace = true, optional = true }
 axmm = { workspace = true, optional = true }
+axdma = { workspace = true, optional = true }
 axtask = { workspace = true, optional = true }
 axdriver = { workspace = true, optional = true }
 axfs = { workspace = true, optional = true }

--- a/api/arceos_api/src/imp/mem.rs
+++ b/api/arceos_api/src/imp/mem.rs
@@ -1,5 +1,6 @@
+use core::alloc::Layout;
+
 cfg_alloc! {
-    use core::alloc::Layout;
     use core::ptr::NonNull;
 
     pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
@@ -8,5 +9,17 @@ cfg_alloc! {
 
     pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
         axalloc::global_allocator().dealloc(ptr, layout)
+    }
+}
+
+cfg_dma! {
+    pub use axdma::DMAInfo;
+
+    pub unsafe fn ax_alloc_coherent(layout: Layout) -> Option<DMAInfo> {
+        axdma::alloc_coherent(layout).ok()
+    }
+
+    pub unsafe fn ax_dealloc_coherent(dma: DMAInfo, layout: Layout) {
+        axdma::dealloc_coherent(dma, layout)
     }
 }

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -55,14 +55,50 @@ pub mod mem {
 
     define_api! {
         @cfg "alloc";
-        /// Allocate a continuous memory blocks with the given `layout` in
+        /// Allocates a continuous memory blocks with the given `layout` in
         /// the global allocator.
         ///
         /// Returns [`None`] if the allocation fails.
-        pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>>;
-        /// Deallocate the memory block at the given `ptr` pointer with the given
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_alloc(layout: Layout) -> Option<NonNull<u8>>;
+        /// Deallocates the memory block at the given `ptr` pointer with the given
         /// `layout`, which should be allocated by [`ax_alloc`].
-        pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout);
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_dealloc(ptr: NonNull<u8>, layout: Layout);
+    }
+
+    define_api_type! {
+        @cfg "dma";
+        pub type DMAInfo;
+    }
+
+    define_api! {
+        @cfg "dma";
+        /// Allocates **coherent** memory that meets Direct Memory Access (DMA)
+        /// requirements.
+        ///
+        /// Returns [`None`] if the allocation fails.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_alloc_coherent(layout: Layout) -> Option<DMAInfo>;
+        /// Deallocates coherent memory previously allocated.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_dealloc_coherent(dma: DMAInfo, layout: Layout);
     }
 }
 
@@ -354,6 +390,8 @@ pub mod modules {
     pub use axalloc;
     #[cfg(feature = "display")]
     pub use axdisplay;
+    #[cfg(feature = "dma")]
+    pub use axdma;
     #[cfg(any(feature = "fs", feature = "net", feature = "display"))]
     pub use axdriver;
     #[cfg(feature = "fs")]

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -28,7 +28,7 @@ alloc-slab = ["axalloc/slab"]
 alloc-buddy = ["axalloc/buddy"]
 paging = ["alloc", "axhal/paging", "axruntime/paging"]
 tls = ["alloc", "axhal/tls", "axruntime/tls", "axtask?/tls"]
-dma = ["alloc","paging"]
+dma = ["alloc", "paging"]
 
 # Multi-threading and scheduler
 multitask = ["alloc", "axtask/multitask", "axsync/multitask", "axruntime/multitask"]

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -28,6 +28,7 @@ alloc-slab = ["axalloc/slab"]
 alloc-buddy = ["axalloc/buddy"]
 paging = ["alloc", "axhal/paging", "axruntime/paging"]
 tls = ["alloc", "axhal/tls", "axruntime/tls", "axtask?/tls"]
+dma = ["alloc","paging"]
 
 # Multi-threading and scheduler
 multitask = ["alloc", "axtask/multitask", "axsync/multitask", "axruntime/multitask"]

--- a/modules/axalloc/src/lib.rs
+++ b/modules/axalloc/src/lib.rs
@@ -25,11 +25,14 @@ pub use page::GlobalPage;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "slab")] {
-        use allocator::SlabByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::SlabByteAllocator;
     } else if #[cfg(feature = "buddy")] {
-        use allocator::BuddyByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::BuddyByteAllocator;
     } else if #[cfg(feature = "tlsf")] {
-        use allocator::TlsfByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::TlsfByteAllocator;
     }
 }
 
@@ -99,9 +102,6 @@ impl GlobalAllocator {
     /// It firstly tries to allocate from the byte allocator. If there is no
     /// memory, it asks the page allocator for more memory and adds it to the
     /// byte allocator.
-    ///
-    /// `align_pow2` must be a power of 2, and the returned region bound will be
-    ///  aligned to it.
     pub fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
         // simple two-level allocator: if no heap memory, allocate from the page allocator.
         let mut balloc = self.balloc.lock();

--- a/modules/axconfig/defconfig.toml
+++ b/modules/axconfig/defconfig.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0"
 # Kernel address space size.

--- a/modules/axdma/Cargo.toml
+++ b/modules/axdma/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "axdma"
+edition = "2021"
+version.workspace = true
+authors = ["Zhour Rui <zrufo747@outlook.com>"]
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdma"
+documentation = "https://arceos-org.github.io/arceos/axdma/index.html"
+
+[dependencies]
+log = "0.4"
+kspin = "0.1"
+memory_addr = "0.2"
+axerrno = "0.1"
+allocator = { git = "https://github.com/arceos-org/allocator.git", tag = "v0.1.0" }
+axalloc = { workspace = true }
+axmm = { workspace = true }
+axconfig = { workspace = true }
+axhal = { workspace = true, features = ["paging"]  }

--- a/modules/axdma/src/dma.rs
+++ b/modules/axdma/src/dma.rs
@@ -1,0 +1,128 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+use allocator::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use axalloc::{global_allocator, DefaultByteAllocator};
+use axhal::{mem::virt_to_phys, paging::MappingFlags};
+use kspin::SpinNoIrq;
+use log::{debug, error};
+use memory_addr::{VirtAddr, PAGE_SIZE_4K};
+
+use crate::{phys_to_bus, BusAddr, DMAInfo};
+
+pub(crate) static ALLOCATOR: SpinNoIrq<DmaAllocator> = SpinNoIrq::new(DmaAllocator::new());
+
+pub(crate) struct DmaAllocator {
+    alloc: DefaultByteAllocator,
+}
+
+impl DmaAllocator {
+    pub const fn new() -> Self {
+        Self {
+            alloc: DefaultByteAllocator::new(),
+        }
+    }
+
+    /// Allocate arbitrary number of bytes. Returns the left bound of the
+    /// allocated region.
+    ///
+    /// It firstly tries to allocate from the coherent byte allocator. If there is no
+    /// memory, it asks the global page allocator for more memory and adds it to the
+    /// byte allocator.
+    pub unsafe fn alloc_coherent(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        if layout.size() >= PAGE_SIZE_4K {
+            self.alloc_coherent_pages(layout)
+        } else {
+            self.alloc_coherent_bytes(layout)
+        }
+    }
+
+    fn alloc_coherent_bytes(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        let mut is_expanded = false;
+        loop {
+            if let Ok(data) = self.alloc.alloc(layout) {
+                let cpu_addr = VirtAddr::from(data.as_ptr() as usize);
+                return Ok(DMAInfo {
+                    cpu_addr: data,
+                    bus_addr: virt_to_bus(cpu_addr),
+                });
+            } else {
+                if is_expanded {
+                    return Err(AllocError::NoMemory);
+                }
+                is_expanded = true;
+                let available_pages = global_allocator().available_pages();
+                // 4 pages or available pages.
+                let num_pages = 4.min(available_pages);
+                let expand_size = num_pages * PAGE_SIZE_4K;
+                let vaddr_raw = global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K)?;
+                let vaddr = VirtAddr::from(vaddr_raw);
+                self.update_flags(
+                    vaddr,
+                    num_pages,
+                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
+                )?;
+                self.alloc
+                    .add_memory(vaddr_raw, expand_size)
+                    .inspect_err(|e| error!("add memory fail: {e:?}"))?;
+                debug!("expand memory @{vaddr:#X}, size: {expand_size:#X} bytes");
+            }
+        }
+    }
+
+    fn alloc_coherent_pages(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        let num_pages = layout_pages(&layout);
+        let vaddr_raw =
+            global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K.max(layout.align()))?;
+        let vaddr = VirtAddr::from(vaddr_raw);
+        self.update_flags(
+            vaddr,
+            num_pages,
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
+        )?;
+        Ok(DMAInfo {
+            cpu_addr: unsafe { NonNull::new_unchecked(vaddr_raw as *mut u8) },
+            bus_addr: virt_to_bus(vaddr),
+        })
+    }
+
+    fn update_flags(
+        &mut self,
+        vaddr: VirtAddr,
+        num_pages: usize,
+        flags: MappingFlags,
+    ) -> AllocResult<()> {
+        let expand_size = num_pages * PAGE_SIZE_4K;
+        axmm::kernel_aspace()
+            .lock()
+            .protect(vaddr, expand_size, flags)
+            .map_err(|e| {
+                error!("change table flag fail: {e:?}");
+                AllocError::NoMemory
+            })
+    }
+
+    /// Gives back the allocated region to the byte allocator.
+    pub unsafe fn dealloc_coherent(&mut self, dma: DMAInfo, layout: Layout) {
+        if layout.size() >= PAGE_SIZE_4K {
+            let num_pages = layout_pages(&layout);
+            let virt_raw = dma.cpu_addr.as_ptr() as usize;
+            global_allocator().dealloc_pages(virt_raw, num_pages);
+            let _ = self.update_flags(
+                VirtAddr::from(virt_raw),
+                num_pages,
+                MappingFlags::READ | MappingFlags::WRITE,
+            );
+        } else {
+            self.alloc.dealloc(dma.cpu_addr, layout)
+        }
+    }
+}
+
+const fn virt_to_bus(addr: VirtAddr) -> BusAddr {
+    let paddr = virt_to_phys(addr);
+    phys_to_bus(paddr)
+}
+
+const fn layout_pages(layout: &Layout) -> usize {
+    memory_addr::align_up_4k(layout.size()) / PAGE_SIZE_4K
+}

--- a/modules/axdma/src/lib.rs
+++ b/modules/axdma/src/lib.rs
@@ -1,0 +1,93 @@
+//! [ArceOS](https://github.com/arceos-org/arceos) global DMA allocator.
+
+#![no_std]
+
+extern crate alloc;
+
+mod dma;
+
+use core::{alloc::Layout, ptr::NonNull};
+
+use allocator::AllocResult;
+use memory_addr::PhysAddr;
+
+use self::dma::ALLOCATOR;
+
+/// Converts a physical address to a bus address.
+///
+/// It assumes that there is a linear mapping with the offset
+/// [`axconfig::PHYS_BUS_OFFSET`], that maps all the physical memory to the virtual
+/// space at the address plus the offset. So we have
+/// `baddr = paddr + PHYS_BUS_OFFSET`.
+#[inline]
+pub const fn phys_to_bus(paddr: PhysAddr) -> BusAddr {
+    BusAddr::new((paddr.as_usize() + axconfig::PHYS_BUS_OFFSET) as u64)
+}
+
+/// Allocates **coherent** memory that meets Direct Memory Access (DMA) requirements.
+///
+/// This function allocates a block of memory through the global allocator. The memory pages must be contiguous, undivided, and have consistent read and write access.
+///
+/// - `layout`: The memory layout, which describes the size and alignment requirements of the requested memory.
+///
+/// Returns an [`DMAInfo`] structure containing details about the allocated memory, such as the starting address and size. If it's not possible to allocate memory meeting the criteria, returns [`None`].
+/// # Safety
+/// This function is unsafe because it directly interacts with the global allocator, which can potentially cause memory leaks or other issues if not used correctly.
+pub unsafe fn alloc_coherent(layout: Layout) -> AllocResult<DMAInfo> {
+    ALLOCATOR.lock().alloc_coherent(layout)
+}
+
+/// Frees coherent memory previously allocated.
+///
+/// This function releases the memory block that was previously allocated and marked as coherent. It ensures proper deallocation and management of resources associated with the memory block.
+///
+/// - `dma_info`: An instance of [`DMAInfo`] containing the details of the memory block to be freed, such as its starting address and size.
+/// # Safety
+/// This function is unsafe because it directly interacts with the global allocator, which can potentially cause memory leaks or other issues if not used correctly.
+pub unsafe fn dealloc_coherent(dma: DMAInfo, layout: Layout) {
+    ALLOCATOR.lock().dealloc_coherent(dma, layout)
+}
+
+/// A bus memory address.
+///
+/// It's a wrapper type around an [`u64`].
+#[repr(transparent)]
+#[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct BusAddr(u64);
+
+impl BusAddr {
+    /// Converts an [`u64`] to a physical address.
+    pub const fn new(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    /// Converts the address to an [`u64`].
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for BusAddr {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl core::fmt::Debug for BusAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("BusAddr")
+            .field(&format_args!("{:#X}", self.0))
+            .finish()
+    }
+}
+
+/// Represents information related to a DMA operation.
+#[derive(Debug, Clone, Copy)]
+pub struct DMAInfo {
+    /// The `cpu_addr` field represents the address at which the CPU accesses this memory region.
+    /// This address is a virtual memory address used by the CPU to access memory.
+    pub cpu_addr: NonNull<u8>,
+    /// The `bus_addr` field represents the physical address of this memory region on the bus.
+    /// The DMA controller uses this address to directly access memory.
+    pub bus_addr: BusAddr,
+}

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -26,7 +26,7 @@ virtio-net = ["net", "virtio", "axdriver_virtio/net"]
 virtio-gpu = ["display", "virtio", "axdriver_virtio/gpu"]
 ramdisk = ["block", "axdriver_block/ramdisk"]
 bcm2835-sdhci = ["block", "axdriver_block/bcm2835-sdhci"]
-ixgbe = ["net", "axdriver_net/ixgbe", "dep:axalloc", "dep:axhal"]
+ixgbe = ["net", "axdriver_net/ixgbe", "dep:axalloc", "dep:axhal", "dep:axdma"]
 # more devices example: e1000 = ["net", "axdriver_net/e1000"]
 
 default = ["bus-pci"]
@@ -43,3 +43,4 @@ axdriver_virtio = { git = "https://github.com/arceos-org/axdriver_crates.git", t
 axalloc = { workspace = true, optional = true }
 axhal = { workspace = true, optional = true }
 axconfig = { workspace = true, optional = true }
+axdma = { workspace = true, optional = true }

--- a/platforms/aarch64-bsta1000b.toml
+++ b/platforms/aarch64-bsta1000b.toml
@@ -9,6 +9,9 @@ family = "aarch64-bsta1000b"
 phys-memory-base = "0x80000000"
 # Size of the whole physical memory.
 phys-memory-size = "0x70000000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Base physical address of the kernel image.
 kernel-base-paddr = "0x81000000"
 # Base virtual address of the kernel image.

--- a/platforms/aarch64-qemu-virt.toml
+++ b/platforms/aarch64-qemu-virt.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_0000_4008_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_0000_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_0000_0000_0000"
 # Kernel address space size.

--- a/platforms/aarch64-raspi4.toml
+++ b/platforms/aarch64-raspi4.toml
@@ -16,6 +16,8 @@ kernel-base-vaddr = "0xffff_0000_0008_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_0000_0000_0000"
+# Offset of bus address and phys address.
+phys-bus-offset = "0xC0000000"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_0000_0000_0000"
 # Kernel address space size.

--- a/platforms/riscv64-qemu-virt.toml
+++ b/platforms/riscv64-qemu-virt.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ffc0_8020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ffc0_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ffc0_0000_0000"
 # Kernel address space size.

--- a/platforms/x86_64-pc-oslab.toml
+++ b/platforms/x86_64-pc-oslab.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ff80_0020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ff80_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ff80_0000_0000"
 # Kernel address space size.

--- a/platforms/x86_64-qemu-q35.toml
+++ b/platforms/x86_64-qemu-q35.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ff80_0020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ff80_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ff80_0000_0000"
 # Kernel address space size.

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -34,6 +34,7 @@ alloc-tlsf = ["axfeat/alloc-tlsf"]
 alloc-slab = ["axfeat/alloc-slab"]
 alloc-buddy = ["axfeat/alloc-buddy"]
 paging = ["axfeat/paging"]
+dma = ["arceos_api/dma", "axfeat/dma"]
 tls = ["axfeat/tls"]
 
 # Multi-threading and scheduler


### PR DESCRIPTION
In the context of ArceOS, when handling paging, all free regions were initially configured with caching attributes, which posed a challenge for DMA (Direct Memory Access) memory allocation during driver development where non-cached memory was required. The current modification approach involves:

1. On-demand Page Table Allocation: Instead of setting up all page table entries at boot time, the system now dynamically allocates necessary page table entries as they are needed. This strategy allows for more flexibility in configuring memory attributes at the time of memory allocation.

2. DMA Allocation with Non-Caching Attributes: When allocating DMA memory, if the existing page table space is insufficient, new page table entries are set up at this point, enabling the configuration of non-caching attributes. This ensures that DMA operations can access memory without the overhead of caching, which is critical for performance and integrity in certain scenarios.

3. Bytes Allocator Space Management: If the bytes allocator does not have enough available space to fulfill a memory request, it first identifies a segment of physical memory using the page allocator. Then, it configures the page table entries for this physical address range according to the required memory attributes (in this case, non-caching). Once these entries are set up, the newly allocated and configured memory segment is added to the bytes allocator pool. Subsequently, the bytes allocator can use this memory to satisfy the original allocation request.

This approach optimizes memory management by dynamically adjusting to the specific needs of different memory allocations, particularly those requiring non-cached properties, such as DMA operations. It enhances system efficiency and resource utilization by minimizing unnecessary caching where it's not beneficial.