### PR TITLE
Add DMA alloc support to dev branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   qemu-version: 8.2.0
   rust-toolchain: nightly-2024-05-02
-  arceos-apps: c01cd92
+  arceos-apps: '68054e8'
 
 jobs:
   unit-test:
@@ -44,5 +44,5 @@ jobs:
       run: |
         make disk_img
         git clone https://github.com/arceos-org/arceos-apps.git
-        cd arceos-apps && git reset --hard ${{ env.arceos-apps }} && cd ..
+        cd arceos-apps && cp ../Cargo.lock . && git reset --hard ${{ env.arceos-apps }} && cd ..
         make -C arceos-apps test AX_ROOT=$(pwd) ARCH=${{ matrix.arch }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,12 @@ dependencies = [
 
 [[package]]
 name = "arm_pl031"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3392676d21de757a82e91af9a38c1dad24a93fb024b8e6b9e27f113e876d2d73"
+checksum = "13696b1c2b59992f4223e0ae5bb173c81c63039367ca90eee845346ad2a13421"
+dependencies = [
+ "chrono",
+]
 
 [[package]]
 name = "atomic-polyfill"
@@ -367,7 +370,7 @@ dependencies = [
  "page_table_entry",
  "page_table_multiarch",
  "percpu",
- "raw-cpuid 11.0.2",
+ "raw-cpuid 11.1.0",
  "riscv",
  "riscv_goldfish",
  "sbi-rt",
@@ -678,9 +681,9 @@ checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "crate_interface"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2aab5f8027e4b744b40c4a66403a71292695e83f7e16b3e0a5045d3b2093c"
+checksum = "6af24c4862260a825484470f5526a91ad1031e04ab899be62478241231f62b46"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -927,9 +930,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lazyinit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0525312fb000d0444661821cf950222404103a989a4ddbb4b5ac23b90d0c77b"
+checksum = "3861aac8febbb038673bf945ee47ac67940ca741b94d1bb3ff6066af2a181338"
 
 [[package]]
 name = "libc"
@@ -1002,9 +1005,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory_addr"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea53f55564acdbe43e404118414b5fb45dfe9bea0dfc9bd80b8e5bb02aeb047"
+checksum = "4c59c2ac537a8198f50fe22e8783bdbef2011cd133d5c03748d1e5bc85c9fc4d"
 
 [[package]]
 name = "minimal-lexical"
@@ -1039,9 +1042,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "page_table_entry"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75bcbfcef16b8ede39c4ff975e8dc12556eece0554667ed5dd2dd3ba958a5ad"
+checksum = "0b1e80f2e33e2ba832719660f6fb216c8942fb61a7f715b7c4e9669dcef3b37a"
 dependencies = [
  "aarch64-cpu",
  "bitflags 2.6.0",
@@ -1051,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "page_table_multiarch"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4235f68d9c35dd143b4c005764bd002361407687b9cc7c57465e9f8c77f7fbd3"
+checksum = "4b140289882bdff057ffdee421ae081eb9216be293621fb6f60076ed3f7cfb74"
 dependencies = [
  "log",
  "memory_addr",
@@ -1070,9 +1073,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percpu"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe17617fadbff9b221435e0fb91c7a7387c3bc87afab0ce92b21b0d108bdd17"
+checksum = "8b18ccf6b20ed7e535732172ec446134690500417e1142625dc026e7e19b3d78"
 dependencies = [
  "cfg-if",
  "kernel_guard",
@@ -1191,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.0.2"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1449,15 +1452,15 @@ checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.15"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1679,9 +1682,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "axalloc",
  "axconfig",
  "axdisplay",
+ "axdma",
  "axdriver",
  "axerrno",
  "axfeat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,11 +195,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axdma"
+version = "0.1.0"
+dependencies = [
+ "allocator",
+ "axalloc",
+ "axconfig",
+ "axerrno",
+ "axhal",
+ "axmm",
+ "kspin",
+ "log",
+ "memory_addr",
+]
+
+[[package]]
 name = "axdriver"
 version = "0.1.0"
 dependencies = [
  "axalloc",
  "axconfig",
+ "axdma",
  "axdriver_base",
  "axdriver_block",
  "axdriver_display",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "modules/axhal",
     "modules/axlog",
     "modules/axmm",
+    "modules/axdma",
     "modules/axnet",
     "modules/axruntime",
     "modules/axsync",
@@ -59,6 +60,7 @@ axnet = { path = "modules/axnet" }
 axruntime = { path = "modules/axruntime" }
 axsync = { path = "modules/axsync" }
 axtask = { path = "modules/axtask" }
+axdma = { path = "modules/axdma" }
 
 [profile.release]
 lto = true

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 irq = ["axfeat/irq"]
 alloc = ["dep:axalloc", "axfeat/alloc"]
 paging = ["dep:axmm", "axfeat/paging"]
+dma = ["dep:axdma", "axfeat/dma"]
 multitask = ["axtask/multitask", "axsync/multitask", "axfeat/multitask"]
 fs = ["dep:axfs", "dep:axdriver", "axfeat/fs"]
 net = ["dep:axnet", "dep:axdriver", "axfeat/net"]
@@ -36,6 +37,7 @@ axhal = { workspace = true }
 axsync = { workspace = true }
 axalloc = { workspace = true, optional = true }
 axmm = { workspace = true, optional = true }
+axdma = { workspace = true, optional = true }
 axtask = { workspace = true, optional = true }
 axdriver = { workspace = true, optional = true }
 axfs = { workspace = true, optional = true }

--- a/api/arceos_api/src/imp/mem.rs
+++ b/api/arceos_api/src/imp/mem.rs
@@ -1,5 +1,6 @@
+use core::alloc::Layout;
+
 cfg_alloc! {
-    use core::alloc::Layout;
     use core::ptr::NonNull;
 
     pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>> {
@@ -8,5 +9,17 @@ cfg_alloc! {
 
     pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout) {
         axalloc::global_allocator().dealloc(ptr, layout)
+    }
+}
+
+cfg_dma! {
+    pub use axdma::DMAInfo;
+
+    pub unsafe fn ax_alloc_coherent(layout: Layout) -> Option<DMAInfo> {
+        axdma::alloc_coherent(layout).ok()
+    }
+
+    pub unsafe fn ax_dealloc_coherent(dma: DMAInfo, layout: Layout) {
+        axdma::dealloc_coherent(dma, layout)
     }
 }

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -55,14 +55,50 @@ pub mod mem {
 
     define_api! {
         @cfg "alloc";
-        /// Allocate a continuous memory blocks with the given `layout` in
+        /// Allocates a continuous memory blocks with the given `layout` in
         /// the global allocator.
         ///
         /// Returns [`None`] if the allocation fails.
-        pub fn ax_alloc(layout: Layout) -> Option<NonNull<u8>>;
-        /// Deallocate the memory block at the given `ptr` pointer with the given
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_alloc(layout: Layout) -> Option<NonNull<u8>>;
+        /// Deallocates the memory block at the given `ptr` pointer with the given
         /// `layout`, which should be allocated by [`ax_alloc`].
-        pub fn ax_dealloc(ptr: NonNull<u8>, layout: Layout);
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_dealloc(ptr: NonNull<u8>, layout: Layout);
+    }
+
+    define_api_type! {
+        @cfg "dma";
+        pub type DMAInfo;
+    }
+
+    define_api! {
+        @cfg "dma";
+        /// Allocates **coherent** memory that meets Direct Memory Access (DMA)
+        /// requirements.
+        ///
+        /// Returns [`None`] if the allocation fails.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_alloc_coherent(layout: Layout) -> Option<DMAInfo>;
+        /// Deallocates coherent memory previously allocated.
+        ///
+        /// # Safety
+        ///
+        /// This function is unsafe because it requires users to manually manage
+        /// the buffer life cycle.
+        pub unsafe fn ax_dealloc_coherent(dma: DMAInfo, layout: Layout);
     }
 }
 
@@ -354,6 +390,8 @@ pub mod modules {
     pub use axalloc;
     #[cfg(feature = "display")]
     pub use axdisplay;
+    #[cfg(feature = "dma")]
+    pub use axdma;
     #[cfg(any(feature = "fs", feature = "net", feature = "display"))]
     pub use axdriver;
     #[cfg(feature = "fs")]

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -28,7 +28,7 @@ alloc-slab = ["axalloc/slab"]
 alloc-buddy = ["axalloc/buddy"]
 paging = ["alloc", "axhal/paging", "axruntime/paging"]
 tls = ["alloc", "axhal/tls", "axruntime/tls", "axtask?/tls"]
-dma = ["alloc","paging"]
+dma = ["alloc", "paging"]
 
 # Multi-threading and scheduler
 multitask = ["alloc", "axtask/multitask", "axsync/multitask", "axruntime/multitask"]

--- a/api/axfeat/Cargo.toml
+++ b/api/axfeat/Cargo.toml
@@ -28,6 +28,7 @@ alloc-slab = ["axalloc/slab"]
 alloc-buddy = ["axalloc/buddy"]
 paging = ["alloc", "axhal/paging", "axruntime/paging"]
 tls = ["alloc", "axhal/tls", "axruntime/tls", "axtask?/tls"]
+dma = ["alloc","paging"]
 
 # Multi-threading and scheduler
 multitask = ["alloc", "axtask/multitask", "axsync/multitask", "axruntime/multitask"]

--- a/modules/axalloc/src/lib.rs
+++ b/modules/axalloc/src/lib.rs
@@ -25,11 +25,14 @@ pub use page::GlobalPage;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "slab")] {
-        use allocator::SlabByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::SlabByteAllocator;
     } else if #[cfg(feature = "buddy")] {
-        use allocator::BuddyByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::BuddyByteAllocator;
     } else if #[cfg(feature = "tlsf")] {
-        use allocator::TlsfByteAllocator as DefaultByteAllocator;
+        /// The default byte allocator.
+        pub type DefaultByteAllocator = allocator::TlsfByteAllocator;
     }
 }
 
@@ -99,9 +102,6 @@ impl GlobalAllocator {
     /// It firstly tries to allocate from the byte allocator. If there is no
     /// memory, it asks the page allocator for more memory and adds it to the
     /// byte allocator.
-    ///
-    /// `align_pow2` must be a power of 2, and the returned region bound will be
-    ///  aligned to it.
     pub fn alloc(&self, layout: Layout) -> AllocResult<NonNull<u8>> {
         // simple two-level allocator: if no heap memory, allocate from the page allocator.
         let mut balloc = self.balloc.lock();

--- a/modules/axconfig/defconfig.toml
+++ b/modules/axconfig/defconfig.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0"
 # Kernel address space size.

--- a/modules/axdma/Cargo.toml
+++ b/modules/axdma/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "axdma"
+edition = "2021"
+version.workspace = true
+authors = ["Zhour Rui <zrufo747@outlook.com>"]
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdma"
+documentation = "https://arceos-org.github.io/arceos/axdma/index.html"
+
+[dependencies]
+log = "0.4"
+kspin = "0.1"
+memory_addr = "0.2"
+axerrno = "0.1"
+allocator = { git = "https://github.com/arceos-org/allocator.git", tag = "v0.1.0" }
+axalloc = { workspace = true }
+axmm = { workspace = true }
+axconfig = { workspace = true }
+axhal = { workspace = true, features = ["paging"]  }

--- a/modules/axdma/src/dma.rs
+++ b/modules/axdma/src/dma.rs
@@ -1,0 +1,128 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+use allocator::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
+use axalloc::{global_allocator, DefaultByteAllocator};
+use axhal::{mem::virt_to_phys, paging::MappingFlags};
+use kspin::SpinNoIrq;
+use log::{debug, error};
+use memory_addr::{VirtAddr, PAGE_SIZE_4K};
+
+use crate::{phys_to_bus, BusAddr, DMAInfo};
+
+pub(crate) static ALLOCATOR: SpinNoIrq<DmaAllocator> = SpinNoIrq::new(DmaAllocator::new());
+
+pub(crate) struct DmaAllocator {
+    alloc: DefaultByteAllocator,
+}
+
+impl DmaAllocator {
+    pub const fn new() -> Self {
+        Self {
+            alloc: DefaultByteAllocator::new(),
+        }
+    }
+
+    /// Allocate arbitrary number of bytes. Returns the left bound of the
+    /// allocated region.
+    ///
+    /// It firstly tries to allocate from the coherent byte allocator. If there is no
+    /// memory, it asks the global page allocator for more memory and adds it to the
+    /// byte allocator.
+    pub unsafe fn alloc_coherent(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        if layout.size() >= PAGE_SIZE_4K {
+            self.alloc_coherent_pages(layout)
+        } else {
+            self.alloc_coherent_bytes(layout)
+        }
+    }
+
+    fn alloc_coherent_bytes(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        let mut is_expanded = false;
+        loop {
+            if let Ok(data) = self.alloc.alloc(layout) {
+                let cpu_addr = VirtAddr::from(data.as_ptr() as usize);
+                return Ok(DMAInfo {
+                    cpu_addr: data,
+                    bus_addr: virt_to_bus(cpu_addr),
+                });
+            } else {
+                if is_expanded {
+                    return Err(AllocError::NoMemory);
+                }
+                is_expanded = true;
+                let available_pages = global_allocator().available_pages();
+                // 4 pages or available pages.
+                let num_pages = 4.min(available_pages);
+                let expand_size = num_pages * PAGE_SIZE_4K;
+                let vaddr_raw = global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K)?;
+                let vaddr = VirtAddr::from(vaddr_raw);
+                self.update_flags(
+                    vaddr,
+                    num_pages,
+                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
+                )?;
+                self.alloc
+                    .add_memory(vaddr_raw, expand_size)
+                    .inspect_err(|e| error!("add memory fail: {e:?}"))?;
+                debug!("expand memory @{vaddr:#X}, size: {expand_size:#X} bytes");
+            }
+        }
+    }
+
+    fn alloc_coherent_pages(&mut self, layout: Layout) -> AllocResult<DMAInfo> {
+        let num_pages = layout_pages(&layout);
+        let vaddr_raw =
+            global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K.max(layout.align()))?;
+        let vaddr = VirtAddr::from(vaddr_raw);
+        self.update_flags(
+            vaddr,
+            num_pages,
+            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
+        )?;
+        Ok(DMAInfo {
+            cpu_addr: unsafe { NonNull::new_unchecked(vaddr_raw as *mut u8) },
+            bus_addr: virt_to_bus(vaddr),
+        })
+    }
+
+    fn update_flags(
+        &mut self,
+        vaddr: VirtAddr,
+        num_pages: usize,
+        flags: MappingFlags,
+    ) -> AllocResult<()> {
+        let expand_size = num_pages * PAGE_SIZE_4K;
+        axmm::kernel_aspace()
+            .lock()
+            .protect(vaddr, expand_size, flags)
+            .map_err(|e| {
+                error!("change table flag fail: {e:?}");
+                AllocError::NoMemory
+            })
+    }
+
+    /// Gives back the allocated region to the byte allocator.
+    pub unsafe fn dealloc_coherent(&mut self, dma: DMAInfo, layout: Layout) {
+        if layout.size() >= PAGE_SIZE_4K {
+            let num_pages = layout_pages(&layout);
+            let virt_raw = dma.cpu_addr.as_ptr() as usize;
+            global_allocator().dealloc_pages(virt_raw, num_pages);
+            let _ = self.update_flags(
+                VirtAddr::from(virt_raw),
+                num_pages,
+                MappingFlags::READ | MappingFlags::WRITE,
+            );
+        } else {
+            self.alloc.dealloc(dma.cpu_addr, layout)
+        }
+    }
+}
+
+const fn virt_to_bus(addr: VirtAddr) -> BusAddr {
+    let paddr = virt_to_phys(addr);
+    phys_to_bus(paddr)
+}
+
+const fn layout_pages(layout: &Layout) -> usize {
+    memory_addr::align_up_4k(layout.size()) / PAGE_SIZE_4K
+}

--- a/modules/axdma/src/lib.rs
+++ b/modules/axdma/src/lib.rs
@@ -1,0 +1,93 @@
+//! [ArceOS](https://github.com/arceos-org/arceos) global DMA allocator.
+
+#![no_std]
+
+extern crate alloc;
+
+mod dma;
+
+use core::{alloc::Layout, ptr::NonNull};
+
+use allocator::AllocResult;
+use memory_addr::PhysAddr;
+
+use self::dma::ALLOCATOR;
+
+/// Converts a physical address to a bus address.
+///
+/// It assumes that there is a linear mapping with the offset
+/// [`axconfig::PHYS_BUS_OFFSET`], that maps all the physical memory to the virtual
+/// space at the address plus the offset. So we have
+/// `baddr = paddr + PHYS_BUS_OFFSET`.
+#[inline]
+pub const fn phys_to_bus(paddr: PhysAddr) -> BusAddr {
+    BusAddr::new((paddr.as_usize() + axconfig::PHYS_BUS_OFFSET) as u64)
+}
+
+/// Allocates **coherent** memory that meets Direct Memory Access (DMA) requirements.
+///
+/// This function allocates a block of memory through the global allocator. The memory pages must be contiguous, undivided, and have consistent read and write access.
+///
+/// - `layout`: The memory layout, which describes the size and alignment requirements of the requested memory.
+///
+/// Returns an [`DMAInfo`] structure containing details about the allocated memory, such as the starting address and size. If it's not possible to allocate memory meeting the criteria, returns [`None`].
+/// # Safety
+/// This function is unsafe because it directly interacts with the global allocator, which can potentially cause memory leaks or other issues if not used correctly.
+pub unsafe fn alloc_coherent(layout: Layout) -> AllocResult<DMAInfo> {
+    ALLOCATOR.lock().alloc_coherent(layout)
+}
+
+/// Frees coherent memory previously allocated.
+///
+/// This function releases the memory block that was previously allocated and marked as coherent. It ensures proper deallocation and management of resources associated with the memory block.
+///
+/// - `dma_info`: An instance of [`DMAInfo`] containing the details of the memory block to be freed, such as its starting address and size.
+/// # Safety
+/// This function is unsafe because it directly interacts with the global allocator, which can potentially cause memory leaks or other issues if not used correctly.
+pub unsafe fn dealloc_coherent(dma: DMAInfo, layout: Layout) {
+    ALLOCATOR.lock().dealloc_coherent(dma, layout)
+}
+
+/// A bus memory address.
+///
+/// It's a wrapper type around an [`u64`].
+#[repr(transparent)]
+#[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq)]
+pub struct BusAddr(u64);
+
+impl BusAddr {
+    /// Converts an [`u64`] to a physical address.
+    pub const fn new(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    /// Converts the address to an [`u64`].
+    pub const fn as_u64(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for BusAddr {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl core::fmt::Debug for BusAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("BusAddr")
+            .field(&format_args!("{:#X}", self.0))
+            .finish()
+    }
+}
+
+/// Represents information related to a DMA operation.
+#[derive(Debug, Clone, Copy)]
+pub struct DMAInfo {
+    /// The `cpu_addr` field represents the address at which the CPU accesses this memory region.
+    /// This address is a virtual memory address used by the CPU to access memory.
+    pub cpu_addr: NonNull<u8>,
+    /// The `bus_addr` field represents the physical address of this memory region on the bus.
+    /// The DMA controller uses this address to directly access memory.
+    pub bus_addr: BusAddr,
+}

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -26,7 +26,7 @@ virtio-net = ["net", "virtio", "axdriver_virtio/net"]
 virtio-gpu = ["display", "virtio", "axdriver_virtio/gpu"]
 ramdisk = ["block", "axdriver_block/ramdisk"]
 bcm2835-sdhci = ["block", "axdriver_block/bcm2835-sdhci"]
-ixgbe = ["net", "axdriver_net/ixgbe", "dep:axalloc", "dep:axhal"]
+ixgbe = ["net", "axdriver_net/ixgbe", "dep:axalloc", "dep:axhal", "dep:axdma"]
 # more devices example: e1000 = ["net", "axdriver_net/e1000"]
 
 default = ["bus-pci"]
@@ -43,3 +43,4 @@ axdriver_virtio = { git = "https://github.com/arceos-org/axdriver_crates.git", t
 axalloc = { workspace = true, optional = true }
 axhal = { workspace = true, optional = true }
 axconfig = { workspace = true, optional = true }
+axdma = { workspace = true, optional = true }

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -42,7 +42,7 @@ axalloc = { workspace = true, optional = true }
 x86 = "0.52"
 x86_64 = "0.15"
 x2apic = "0.4"
-raw-cpuid = "11.0"
+raw-cpuid = "11.1"
 x86_rtc = { version = "0.1", optional = true }
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
@@ -55,7 +55,7 @@ aarch64-cpu = "9.4"
 tock-registers = "0.8"
 arm_gicv2 = "0.1"
 arm_pl011 = "0.1"
-arm_pl031 = { version = "0.1", optional = true }
+arm_pl031 = { version = "0.2", optional = true }
 dw_apb_uart = "0.1"
 
 [build-dependencies]

--- a/modules/axhal/src/platform/aarch64_common/generic_timer.rs
+++ b/modules/axhal/src/platform/aarch64_common/generic_timer.rs
@@ -64,10 +64,11 @@ pub(crate) fn init_early() {
         use memory_addr::PhysAddr;
 
         const PL031_BASE: PhysAddr = PhysAddr::from(axconfig::RTC_PADDR);
+
+        let rtc = unsafe { Rtc::new(phys_to_virt(PL031_BASE).as_usize() as _) };
         // Get the current time in microseconds since the epoch (1970-01-01) from the aarch64 pl031 RTC.
         // Subtract the timer ticks to get the actual time when ArceOS was booted.
-        let epoch_time_nanos =
-            Rtc::new(phys_to_virt(PL031_BASE).as_usize()).get_unix_timestamp() * 1_000_000_000;
+        let epoch_time_nanos = rtc.get_unix_timestamp() as u64 * 1_000_000_000;
 
         unsafe {
             RTC_EPOCHOFFSET_NANOS = epoch_time_nanos - ticks_to_nanos(current_ticks());

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -86,7 +86,7 @@ impl AddrSpace {
                 false, // flush_tlb_by_page
             )
             .map_err(paging_err_to_ax_err)?
-            .flush();
+            .flush_all();
         Ok(())
     }
 

--- a/platforms/aarch64-bsta1000b.toml
+++ b/platforms/aarch64-bsta1000b.toml
@@ -9,6 +9,9 @@ family = "aarch64-bsta1000b"
 phys-memory-base = "0x80000000"
 # Size of the whole physical memory.
 phys-memory-size = "0x70000000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Base physical address of the kernel image.
 kernel-base-paddr = "0x81000000"
 # Base virtual address of the kernel image.

--- a/platforms/aarch64-qemu-virt.toml
+++ b/platforms/aarch64-qemu-virt.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_0000_4008_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_0000_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_0000_0000_0000"
 # Kernel address space size.

--- a/platforms/aarch64-raspi4.toml
+++ b/platforms/aarch64-raspi4.toml
@@ -16,6 +16,8 @@ kernel-base-vaddr = "0xffff_0000_0008_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_0000_0000_0000"
+# Offset of bus address and phys address.
+phys-bus-offset = "0xC0000000"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_0000_0000_0000"
 # Kernel address space size.

--- a/platforms/riscv64-qemu-virt.toml
+++ b/platforms/riscv64-qemu-virt.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ffc0_8020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ffc0_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ffc0_0000_0000"
 # Kernel address space size.

--- a/platforms/x86_64-pc-oslab.toml
+++ b/platforms/x86_64-pc-oslab.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ff80_0020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ff80_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ff80_0000_0000"
 # Kernel address space size.

--- a/platforms/x86_64-qemu-q35.toml
+++ b/platforms/x86_64-qemu-q35.toml
@@ -16,6 +16,9 @@ kernel-base-vaddr = "0xffff_ff80_0020_0000"
 # Linear mapping offset, for quick conversions between physical and virtual
 # addresses.
 phys-virt-offset = "0xffff_ff80_0000_0000"
+# Offset of bus address and phys address. some boards, the bus address is
+# different from the physical address.
+phys-bus-offset = "0"
 # Kernel address space base.
 kernel-aspace-base = "0xffff_ff80_0000_0000"
 # Kernel address space size.

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -34,6 +34,7 @@ alloc-tlsf = ["axfeat/alloc-tlsf"]
 alloc-slab = ["axfeat/alloc-slab"]
 alloc-buddy = ["axfeat/alloc-buddy"]
 paging = ["axfeat/paging"]
+dma = ["arceos_api/dma", "axfeat/dma"]
 tls = ["axfeat/tls"]
 
 # Multi-threading and scheduler


### PR DESCRIPTION
In the context of ArceOS, when handling paging, all free regions were initially configured with caching attributes, which posed a challenge for DMA (Direct Memory Access) memory allocation during driver development where non-cached memory was required. The current modification approach involves:

1. On-demand Page Table Allocation: Instead of setting up all page table entries at boot time, the system now dynamically allocates necessary page table entries as they are needed. This strategy allows for more flexibility in configuring memory attributes at the time of memory allocation.

2. DMA Allocation with Non-Caching Attributes: When allocating DMA memory, if the existing page table space is insufficient, new page table entries are set up at this point, enabling the configuration of non-caching attributes. This ensures that DMA operations can access memory without the overhead of caching, which is critical for performance and integrity in certain scenarios.

3. Bytes Allocator Space Management: If the bytes allocator does not have enough available space to fulfill a memory request, it first identifies a segment of physical memory using the page allocator. Then, it configures the page table entries for this physical address range according to the required memory attributes (in this case, non-caching). Once these entries are set up, the newly allocated and configured memory segment is added to the bytes allocator pool. Subsequently, the bytes allocator can use this memory to satisfy the original allocation request.

This approach optimizes memory management by dynamically adjusting to the specific needs of different memory allocations, particularly those requiring non-cached properties, such as DMA operations. It enhances system efficiency and resource utilization by minimizing unnecessary caching where it's not beneficial.