### PR TITLE
Update `memory_addr`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,6 @@ jobs:
     - name: Run app tests
       run: |
         make disk_img
-        git clone https://github.com/arceos-org/arceos-apps.git
+        git clone https://github.com/arceos-org/arceos-apps.git --branch update_memory_addr # temporary branch
         cd arceos-apps && cp ../Cargo.lock . && git reset --hard ${{ env.arceos-apps }} && cd ..
         make -C arceos-apps test AX_ROOT=$(pwd) ARCH=${{ matrix.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   qemu-version: 8.2.0
   rust-toolchain: nightly-2024-05-02
-  arceos-apps: 'e9f4f3f'
+  arceos-apps: '68054e8'
 
 jobs:
   unit-test:
@@ -43,6 +43,6 @@ jobs:
     - name: Run app tests
       run: |
         make disk_img
-        git clone https://github.com/arceos-org/arceos-apps.git --branch update_memory_addr # temporary branch
+        git clone https://github.com/arceos-org/arceos-apps.git
         cd arceos-apps && cp ../Cargo.lock . && git reset --hard ${{ env.arceos-apps }} && cd ..
         make -C arceos-apps test AX_ROOT=$(pwd) ARCH=${{ matrix.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   qemu-version: 8.2.0
   rust-toolchain: nightly-2024-05-02
-  arceos-apps: '68054e8'
+  arceos-apps: 'e9f4f3f'
 
 jobs:
   unit-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,8 +1023,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "memory_addr"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c59c2ac537a8198f50fe22e8783bdbef2011cd133d5c03748d1e5bc85c9fc4d"
+source = "git+https://github.com/arceos-hypervisor/memory_addr.git?rev=95f42c9#95f42c9421f1bd08a674a66c61c00f896b1966ef"
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,8 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "memory_addr"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/memory_addr.git?rev=46c06e5#46c06e57cd4104f028a1a4844bbd656a79965c8e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca25419c2b34080d526d6836a53dcab129767ab6a9904587c87265ae6d41aa9"
 
 [[package]]
 name = "minimal-lexical"
@@ -1058,8 +1059,9 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "page_table_entry"
-version = "0.3.3"
-source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3#feb4aa3fa4589b5738a3ff40ff875870e4ce2614"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d911cfe86a8529a3fabfafa39a857a57cb8d00046ddca14fa609b289303bc7c"
 dependencies = [
  "aarch64-cpu",
  "bitflags 2.6.0",
@@ -1069,8 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "page_table_multiarch"
-version = "0.3.3"
-source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3#feb4aa3fa4589b5738a3ff40ff875870e4ce2614"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43068c68a7fee18c1749befb515f69f6b1fcc18a4908e0d96e64fc51258d301a"
 dependencies = [
  "log",
  "memory_addr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -151,18 +151,18 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.11"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axalloc"
@@ -173,7 +173,7 @@ dependencies = [
  "cfg-if",
  "kspin",
  "log",
- "memory_addr",
+ "memory_addr 0.2.1",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
  "axmm",
  "kspin",
  "log",
- "memory_addr",
+ "memory_addr 0.3.0",
 ]
 
 [[package]]
@@ -383,7 +383,7 @@ dependencies = [
  "lazyinit",
  "linkme",
  "log",
- "memory_addr",
+ "memory_addr 0.3.0",
  "page_table_entry",
  "page_table_multiarch",
  "percpu",
@@ -441,7 +441,7 @@ dependencies = [
  "kspin",
  "lazyinit",
  "log",
- "memory_addr",
+ "memory_addr 0.3.0",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ dependencies = [
  "kspin",
  "lazyinit",
  "log",
- "memory_addr",
+ "memory_addr 0.3.0",
  "percpu",
  "rand",
  "scheduler",
@@ -559,7 +559,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.70",
+ "syn 2.0.76",
  "which",
 ]
 
@@ -610,15 +610,15 @@ checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cap_access"
@@ -631,11 +631,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -686,9 +686,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_detect"
@@ -704,20 +704,20 @@ checksum = "6af24c4862260a825484470f5526a91ad1031e04ab899be62478241231f62b46"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "critical-section"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "defmt"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2d011b2fee29fb7d659b83c43fce9a2cb4df453e16d441a51448e448f3f98"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -725,22 +725,22 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f0216f6c5acb5ae1a47050a6645024e6edafc2ee32d421955eccfef12ef92e"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
 dependencies = [
  "thiserror",
 ]
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embedded-hal"
@@ -767,10 +767,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "fatfs"
@@ -792,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -824,21 +845,30 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heapless"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
  "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -866,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -882,9 +912,9 @@ checksum = "0640a6c478a68d4899fec305f97afa6e34afce49d4d952d2b9599fd52615b2a7"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -903,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -953,18 +983,18 @@ checksum = "3861aac8febbb038673bf945ee47ac67940ca741b94d1bb3ff6066af2a181338"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -974,29 +1004,35 @@ source = "git+https://github.com/arceos-org/linked_list.git?tag=v0.1.0#34c8db301
 
 [[package]]
 name = "linkme"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb76662d78edc9f9bf56360d6919bdacc8b7761227727e5082f128eeb90bbf5"
+checksum = "3c943daedff228392b791b33bba32e75737756e80a613e32e246c6ce9cbab20a"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dccda732e04fa3baf2e17cf835bfe2601c7c2edafd64417c627dabae3a8cda"
+checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
+name = "linux-raw-sys"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1004,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "managed"
@@ -1016,14 +1052,20 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
 version = "0.2.1"
-source = "git+https://github.com/arceos-hypervisor/memory_addr.git?rev=32bf720#32bf720b08eee5ea404028e39411240641f47d5a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c59c2ac537a8198f50fe22e8783bdbef2011cd133d5c03748d1e5bc85c9fc4d"
+
+[[package]]
+name = "memory_addr"
+version = "0.3.0"
+source = "git+https://github.com/arceos-org/memory_addr.git?rev=46c06e5#46c06e57cd4104f028a1a4844bbd656a79965c8e"
 
 [[package]]
 name = "minimal-lexical"
@@ -1043,39 +1085,37 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "page_table_entry"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e80f2e33e2ba832719660f6fb216c8942fb61a7f715b7c4e9669dcef3b37a"
+version = "0.3.3"
+source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3#feb4aa3fa4589b5738a3ff40ff875870e4ce2614"
 dependencies = [
  "aarch64-cpu",
  "bitflags 2.6.0",
- "memory_addr",
+ "memory_addr 0.3.0",
  "x86_64 0.15.1",
 ]
 
 [[package]]
 name = "page_table_multiarch"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b140289882bdff057ffdee421ae081eb9216be293621fb6f60076ed3f7cfb74"
+version = "0.3.3"
+source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3#feb4aa3fa4589b5738a3ff40ff875870e4ce2614"
 dependencies = [
  "log",
- "memory_addr",
+ "memory_addr 0.3.0",
  "page_table_entry",
  "riscv",
  "x86",
@@ -1089,9 +1129,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percpu"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18ccf6b20ed7e535732172ec446134690500417e1142625dc026e7e19b3d78"
+checksum = "bb9f741dad8f795c2161b4ecde6934b2ee661697ccb7f8ba3752392cd82e9cc9"
 dependencies = [
  "cfg-if",
  "kernel_guard",
@@ -1102,29 +1142,32 @@ dependencies = [
 
 [[package]]
 name = "percpu_macros"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bd51d4112e25524bd18b8a0a4bd2526f35686316ccfe7f6b890bf57b455578"
+checksum = "ef783de4aeafcd0832cb685908773d2cf2b5875d262cfd2708b4bb29732a6d02"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.12"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1162,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1219,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1231,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1242,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "riscv"
@@ -1290,10 +1333,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.14"
+name = "rustix"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "sbi-rt"
@@ -1326,35 +1382,35 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab_allocator"
@@ -1425,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1436,22 +1492,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1485,29 +1541,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa40e09453618c7a927c08c5a990497a2954da7c2aaa6c65e0d4f0fc975f6114"
+checksum = "d6a39747311dabb3d37807037ed1c3c38d39f99198d091b5b79ecd5c8d82f799"
 dependencies = [
  "bitflags 2.6.0",
+ "enumn",
  "log",
  "zerocopy",
 ]
@@ -1538,34 +1595,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1573,55 +1631,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1633,10 +1670,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.5"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1650,51 +1696,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1781,5 +1827,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.76",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -151,18 +151,18 @@ dependencies = [
 
 [[package]]
 name = "atomic-polyfill"
-version = "1.0.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axalloc"
@@ -559,7 +559,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.70",
  "which",
 ]
 
@@ -610,15 +610,15 @@ checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
-version = "1.5.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cap_access"
@@ -631,11 +631,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
- "shlex",
+ "libc",
 ]
 
 [[package]]
@@ -669,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
 dependencies = [
  "glob",
  "libc",
@@ -686,9 +686,9 @@ checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.7"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core_detect"
@@ -704,20 +704,20 @@ checksum = "6af24c4862260a825484470f5526a91ad1031e04ab899be62478241231f62b46"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "defmt"
-version = "0.3.8"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+checksum = "a8a2d011b2fee29fb7d659b83c43fce9a2cb4df453e16d441a51448e448f3f98"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -725,22 +725,22 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "0.3.9"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+checksum = "54f0216f6c5acb5ae1a47050a6645024e6edafc2ee32d421955eccfef12ef92e"
 dependencies = [
  "defmt-parser",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
 dependencies = [
  "thiserror",
 ]
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "embedded-hal"
@@ -767,31 +767,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
-name = "enumn"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.76",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys",
-]
 
 [[package]]
 name = "fatfs"
@@ -813,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -845,30 +824,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
  "rustc_version",
  "spin",
  "stable_deref_trait",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]
@@ -896,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -912,9 +882,9 @@ checksum = "0640a6c478a68d4899fec305f97afa6e34afce49d4d952d2b9599fd52615b2a7"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -933,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -983,18 +953,18 @@ checksum = "3861aac8febbb038673bf945ee47ac67940ca741b94d1bb3ff6066af2a181338"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
-version = "0.8.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "winapi",
 ]
 
 [[package]]
@@ -1004,35 +974,29 @@ source = "git+https://github.com/arceos-org/linked_list.git?tag=v0.1.0#34c8db301
 
 [[package]]
 name = "linkme"
-version = "0.3.28"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c943daedff228392b791b33bba32e75737756e80a613e32e246c6ce9cbab20a"
+checksum = "ccb76662d78edc9f9bf56360d6919bdacc8b7761227727e5082f128eeb90bbf5"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.28"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26336e6dc7cc76e7927d2c9e7e3bb376d7af65a6f56a0b16c47d18a9b1abc5"
+checksum = "f8dccda732e04fa3baf2e17cf835bfe2601c7c2edafd64417c627dabae3a8cda"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1040,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "managed"
@@ -1052,9 +1016,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory_addr"
@@ -1079,18 +1043,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.19"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "page_table_entry"
@@ -1123,9 +1087,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percpu"
-version = "0.1.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9f741dad8f795c2161b4ecde6934b2ee661697ccb7f8ba3752392cd82e9cc9"
+checksum = "8b18ccf6b20ed7e535732172ec446134690500417e1142625dc026e7e19b3d78"
 dependencies = [
  "cfg-if",
  "kernel_guard",
@@ -1136,32 +1100,29 @@ dependencies = [
 
 [[package]]
 name = "percpu_macros"
-version = "0.1.4"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef783de4aeafcd0832cb685908773d2cf2b5875d262cfd2708b4bb29732a6d02"
+checksum = "37bd51d4112e25524bd18b8a0a4bd2526f35686316ccfe7f6b890bf57b455578"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1199,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1256,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1268,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1279,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "riscv"
@@ -1327,23 +1288,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
-dependencies = [
- "bitflags 2.6.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "sbi-rt"
@@ -1376,35 +1324,35 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "slab_allocator"
@@ -1475,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1486,22 +1434,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -1535,30 +1483,29 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"
-version = "0.9.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a39747311dabb3d37807037ed1c3c38d39f99198d091b5b79ecd5c8d82f799"
+checksum = "aa40e09453618c7a927c08c5a990497a2954da7c2aaa6c65e0d4f0fc975f6114"
 dependencies = [
  "bitflags 2.6.0",
- "enumn",
  "log",
  "zerocopy",
 ]
@@ -1589,35 +1536,34 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1625,34 +1571,55 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
- "home",
+ "libc",
  "once_cell",
- "rustix",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1664,19 +1631,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1690,51 +1648,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -1821,5 +1779,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.70",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,7 +1023,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 [[package]]
 name = "memory_addr"
 version = "0.2.1"
-source = "git+https://github.com/arceos-hypervisor/memory_addr.git?rev=95f42c9#95f42c9421f1bd08a674a66c61c00f896b1966ef"
+source = "git+https://github.com/arceos-hypervisor/memory_addr.git?rev=32bf720#32bf720b08eee5ea404028e39411240641f47d5a"
 
 [[package]]
 name = "minimal-lexical"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
  "cfg-if",
  "kspin",
  "log",
- "memory_addr 0.2.1",
+ "memory_addr",
 ]
 
 [[package]]
@@ -207,7 +207,7 @@ dependencies = [
  "axmm",
  "kspin",
  "log",
- "memory_addr 0.3.0",
+ "memory_addr",
 ]
 
 [[package]]
@@ -383,7 +383,7 @@ dependencies = [
  "lazyinit",
  "linkme",
  "log",
- "memory_addr 0.3.0",
+ "memory_addr",
  "page_table_entry",
  "page_table_multiarch",
  "percpu",
@@ -441,7 +441,7 @@ dependencies = [
  "kspin",
  "lazyinit",
  "log",
- "memory_addr 0.3.0",
+ "memory_addr",
 ]
 
 [[package]]
@@ -516,7 +516,7 @@ dependencies = [
  "kspin",
  "lazyinit",
  "log",
- "memory_addr 0.3.0",
+ "memory_addr",
  "percpu",
  "rand",
  "scheduler",
@@ -1058,12 +1058,6 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c59c2ac537a8198f50fe22e8783bdbef2011cd133d5c03748d1e5bc85c9fc4d"
-
-[[package]]
-name = "memory_addr"
 version = "0.3.0"
 source = "git+https://github.com/arceos-org/memory_addr.git?rev=46c06e5#46c06e57cd4104f028a1a4844bbd656a79965c8e"
 
@@ -1105,7 +1099,7 @@ source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3
 dependencies = [
  "aarch64-cpu",
  "bitflags 2.6.0",
- "memory_addr 0.3.0",
+ "memory_addr",
  "x86_64 0.15.1",
 ]
 
@@ -1115,7 +1109,7 @@ version = "0.3.3"
 source = "git+https://github.com/arceos-org/page_table_multiarch.git?rev=feb4aa3#feb4aa3fa4589b5738a3ff40ff875870e4ce2614"
 dependencies = [
  "log",
- "memory_addr 0.3.0",
+ "memory_addr",
  "page_table_entry",
  "riscv",
  "x86",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,4 @@ lto = true
 
 [patch.crates-io]
 # todo: update to new version of `memory_addr` on `crates.io` once it get released
-memory_addr = { git = "https://github.com/arceos-hypervisor/memory_addr.git", rev = "95f42c9" }
+memory_addr = { git = "https://github.com/arceos-hypervisor/memory_addr.git", rev = "32bf720" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,7 @@ axdma = { path = "modules/axdma" }
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+# todo: update to new version of `memory_addr` on `crates.io` once it get released
+memory_addr = { git = "https://github.com/arceos-hypervisor/memory_addr.git", rev = "95f42c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,3 @@ axdma = { path = "modules/axdma" }
 
 [profile.release]
 lto = true
-
-[patch.crates-io]
-# todo: update to new version of `memory_addr` on `crates.io` once it get released
-memory_addr = { git = "https://github.com/arceos-org/memory_addr.git", rev = "46c06e5" }
-page_table_entry = { git = "https://github.com/arceos-org/page_table_multiarch.git", rev = "feb4aa3" }
-page_table_multiarch = { git = "https://github.com/arceos-org/page_table_multiarch.git", rev = "feb4aa3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,6 @@ lto = true
 
 [patch.crates-io]
 # todo: update to new version of `memory_addr` on `crates.io` once it get released
-memory_addr = { git = "https://github.com/arceos-hypervisor/memory_addr.git", rev = "32bf720" }
+memory_addr = { git = "https://github.com/arceos-org/memory_addr.git", rev = "46c06e5" }
+page_table_entry = { git = "https://github.com/arceos-org/page_table_multiarch.git", rev = "feb4aa3" }
+page_table_multiarch = { git = "https://github.com/arceos-org/page_table_multiarch.git", rev = "feb4aa3" }

--- a/modules/axalloc/Cargo.toml
+++ b/modules/axalloc/Cargo.toml
@@ -16,7 +16,7 @@ slab = ["allocator/slab"]
 buddy = ["allocator/buddy"]
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 cfg-if = "1.0"
 kspin = "0.1"
 memory_addr = "0.3"

--- a/modules/axalloc/Cargo.toml
+++ b/modules/axalloc/Cargo.toml
@@ -19,6 +19,6 @@ buddy = ["allocator/buddy"]
 log = "0.4"
 cfg-if = "1.0"
 kspin = "0.1"
-memory_addr = "0.2"
+memory_addr = "0.3"
 axerrno = "0.1"
 allocator = { git = "https://github.com/arceos-org/allocator.git", tag ="v0.1.0", features = ["bitmap"] }

--- a/modules/axdisplay/Cargo.toml
+++ b/modules/axdisplay/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdisplay"
 documentation = "https://arceos-org.github.io/arceos/axdisplay/index.html"
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 lazyinit = "0.2"
 axdriver = { workspace = true, features = ["display"] }
 axsync = { workspace = true }

--- a/modules/axdma/Cargo.toml
+++ b/modules/axdma/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/arceos-org/arceos/tree/main/modules/axdma"
 documentation = "https://arceos-org.github.io/arceos/axdma/index.html"
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 kspin = "0.1"
 memory_addr = "0.3"
 axerrno = "0.1"

--- a/modules/axdma/Cargo.toml
+++ b/modules/axdma/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://arceos-org.github.io/arceos/axdma/index.html"
 [dependencies]
 log = "0.4"
 kspin = "0.1"
-memory_addr = "0.2"
+memory_addr = "0.3"
 axerrno = "0.1"
 allocator = { git = "https://github.com/arceos-org/allocator.git", tag = "v0.1.0" }
 axalloc = { workspace = true }

--- a/modules/axdma/src/dma.rs
+++ b/modules/axdma/src/dma.rs
@@ -5,7 +5,7 @@ use axalloc::{global_allocator, DefaultByteAllocator};
 use axhal::{mem::virt_to_phys, paging::MappingFlags};
 use kspin::SpinNoIrq;
 use log::{debug, error};
-use memory_addr::{VirtAddr, PAGE_SIZE_4K, va};
+use memory_addr::{va, VirtAddr, PAGE_SIZE_4K};
 
 use crate::{phys_to_bus, BusAddr, DMAInfo};
 

--- a/modules/axdma/src/dma.rs
+++ b/modules/axdma/src/dma.rs
@@ -5,7 +5,7 @@ use axalloc::{global_allocator, DefaultByteAllocator};
 use axhal::{mem::virt_to_phys, paging::MappingFlags};
 use kspin::SpinNoIrq;
 use log::{debug, error};
-use memory_addr::{VirtAddr, PAGE_SIZE_4K};
+use memory_addr::{VirtAddr, PAGE_SIZE_4K, va};
 
 use crate::{phys_to_bus, BusAddr, DMAInfo};
 
@@ -40,7 +40,7 @@ impl DmaAllocator {
         let mut is_expanded = false;
         loop {
             if let Ok(data) = self.alloc.alloc(layout) {
-                let cpu_addr = VirtAddr::from(data.as_ptr() as usize);
+                let cpu_addr = va!(data.as_ptr() as usize);
                 return Ok(DMAInfo {
                     cpu_addr: data,
                     bus_addr: virt_to_bus(cpu_addr),
@@ -55,7 +55,7 @@ impl DmaAllocator {
                 let num_pages = 4.min(available_pages);
                 let expand_size = num_pages * PAGE_SIZE_4K;
                 let vaddr_raw = global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K)?;
-                let vaddr = VirtAddr::from(vaddr_raw);
+                let vaddr = va!(vaddr_raw);
                 self.update_flags(
                     vaddr,
                     num_pages,
@@ -73,7 +73,7 @@ impl DmaAllocator {
         let num_pages = layout_pages(&layout);
         let vaddr_raw =
             global_allocator().alloc_pages(num_pages, PAGE_SIZE_4K.max(layout.align()))?;
-        let vaddr = VirtAddr::from(vaddr_raw);
+        let vaddr = va!(vaddr_raw);
         self.update_flags(
             vaddr,
             num_pages,
@@ -108,7 +108,7 @@ impl DmaAllocator {
             let virt_raw = dma.cpu_addr.as_ptr() as usize;
             global_allocator().dealloc_pages(virt_raw, num_pages);
             let _ = self.update_flags(
-                VirtAddr::from(virt_raw),
+                va!(virt_raw),
                 num_pages,
                 MappingFlags::READ | MappingFlags::WRITE,
             );

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -32,7 +32,7 @@ ixgbe = ["net", "axdriver_net/ixgbe", "dep:axalloc", "dep:axhal", "dep:axdma"]
 default = ["bus-pci"]
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 cfg-if = "1.0"
 axdriver_base = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.0" }
 axdriver_block = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.0", optional = true }

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -21,7 +21,7 @@ use-ramdisk = []
 default = ["devfs", "ramfs", "fatfs", "procfs", "sysfs"]
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 cfg-if = "1.0"
 lazyinit = "0.2"
 cap_access = "0.1"

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -30,7 +30,7 @@ kspin = "0.1"
 int_ratio = "0.1"
 lazyinit = "0.2"
 percpu = "0.1"
-memory_addr = "0.2"
+memory_addr = "0.3"
 handler_table = "0.1"
 page_table_entry = "0.3"
 page_table_multiarch = { version = "0.3", optional = true }

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -20,7 +20,7 @@ rtc = ["x86_rtc", "riscv_goldfish", "arm_pl031"]
 default = []
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 cfg-if = "1.0"
 linkme = "0.3"
 bitflags = "2.6"

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -32,8 +32,8 @@ lazyinit = "0.2"
 percpu = "0.1"
 memory_addr = "0.3"
 handler_table = "0.1"
-page_table_entry = "0.3"
-page_table_multiarch = { version = "0.3", optional = true }
+page_table_entry = "0.4"
+page_table_multiarch = { version = "0.4", optional = true }
 axlog = { workspace = true }
 axconfig = { workspace = true }
 axalloc = { workspace = true, optional = true }

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod trap;
 use core::arch::asm;
 
 use aarch64_cpu::registers::{DAIF, TPIDR_EL0, TTBR0_EL1, TTBR1_EL1, VBAR_EL1};
-use memory_addr::{PhysAddr, VirtAddr, pa};
+use memory_addr::{pa, PhysAddr, VirtAddr};
 use tock_registers::interfaces::{Readable, Writeable};
 
 pub use self::context::{FpState, TaskContext, TrapFrame};

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod trap;
 use core::arch::asm;
 
 use aarch64_cpu::registers::{DAIF, TPIDR_EL0, TTBR0_EL1, TTBR1_EL1, VBAR_EL1};
-use memory_addr::{PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr, pa};
 use tock_registers::interfaces::{Readable, Writeable};
 
 pub use self::context::{FpState, TaskContext, TrapFrame};
@@ -48,13 +48,13 @@ pub fn halt() {
 #[inline]
 pub fn read_page_table_root() -> PhysAddr {
     let root = TTBR1_EL1.get();
-    PhysAddr::from(root as usize)
+    pa!(root as usize)
 }
 
 /// Reads the `TTBR0_EL1` register.
 pub fn read_page_table_root0() -> PhysAddr {
     let root = TTBR0_EL1.get();
-    PhysAddr::from(root as usize)
+    pa!(root as usize)
 }
 
 /// Writes the register to update the current page table root.

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -1,7 +1,7 @@
 use core::arch::global_asm;
 
 use aarch64_cpu::registers::{ESR_EL1, FAR_EL1};
-use memory_addr::{VirtAddr, va};
+use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use tock_registers::interfaces::Readable;
 

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -1,7 +1,7 @@
 use core::arch::global_asm;
 
 use aarch64_cpu::registers::{ESR_EL1, FAR_EL1};
-use memory_addr::VirtAddr;
+use memory_addr::{VirtAddr, va};
 use page_table_entry::MappingFlags;
 use tock_registers::interfaces::Readable;
 
@@ -47,7 +47,7 @@ fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
     if is_user {
         access_flags |= MappingFlags::USER;
     }
-    let vaddr = VirtAddr::from(FAR_EL1.get() as usize);
+    let vaddr = va!(FAR_EL1.get() as usize);
 
     // Only handle Translation fault and Permission fault
     if !matches!(iss & 0b111100, 0b0100 | 0b1100) // IFSC or DFSC bits
@@ -76,7 +76,7 @@ fn handle_data_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
     if is_user {
         access_flags |= MappingFlags::USER;
     }
-    let vaddr = VirtAddr::from(FAR_EL1.get() as usize);
+    let vaddr = va!(FAR_EL1.get() as usize);
 
     // Only handle Translation fault and Permission fault
     if !matches!(iss & 0b111100, 0b0100 | 0b1100) // IFSC or DFSC bits

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -4,7 +4,7 @@ mod macros;
 mod context;
 mod trap;
 
-use memory_addr::{PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr, pa};
 use riscv::asm;
 use riscv::register::{satp, sstatus, stvec};
 
@@ -48,7 +48,7 @@ pub fn halt() {
 /// Returns the physical address of the page table root.
 #[inline]
 pub fn read_page_table_root() -> PhysAddr {
-    PhysAddr::from(satp::read().ppn() << 12)
+    pa!(satp::read().ppn() << 12)
 }
 
 /// Writes the register to update the current page table root.

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -4,7 +4,7 @@ mod macros;
 mod context;
 mod trap;
 
-use memory_addr::{PhysAddr, VirtAddr, pa};
+use memory_addr::{pa, PhysAddr, VirtAddr};
 use riscv::asm;
 use riscv::register::{satp, sstatus, stvec};
 

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -1,4 +1,4 @@
-use memory_addr::VirtAddr;
+use memory_addr::{VirtAddr, va};
 use page_table_entry::MappingFlags;
 use riscv::register::scause::{self, Exception as E, Trap};
 use riscv::register::stval;
@@ -21,7 +21,7 @@ fn handle_page_fault(tf: &TrapFrame, mut access_flags: MappingFlags, is_user: bo
     if is_user {
         access_flags |= MappingFlags::USER;
     }
-    let vaddr = VirtAddr::from(stval::read());
+    let vaddr = va!(stval::read());
     if !handle_trap!(PAGE_FAULT, vaddr, access_flags, is_user) {
         panic!(
             "Unhandled {} Page Fault @ {:#x}, fault_vaddr={:#x} ({:?}):\n{:#x?}",

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -1,4 +1,4 @@
-use memory_addr::{VirtAddr, va};
+use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use riscv::register::scause::{self, Exception as E, Trap};
 use riscv::register::stval;

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -1,5 +1,5 @@
 use core::{arch::asm, fmt};
-use memory_addr::{VirtAddr, va};
+use memory_addr::{va, VirtAddr};
 
 /// Saved registers when a trap (interrupt or exception) occurs.
 #[allow(missing_docs)]

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -1,5 +1,5 @@
 use core::{arch::asm, fmt};
-use memory_addr::VirtAddr;
+use memory_addr::{VirtAddr, va};
 
 /// Saved registers when a trap (interrupt or exception) occurs.
 #[allow(missing_docs)]
@@ -147,7 +147,7 @@ impl TaskContext {
     /// Creates a new default context for a new task.
     pub const fn new() -> Self {
         Self {
-            kstack_top: VirtAddr::from(0),
+            kstack_top: va!(0),
             rsp: 0,
             fs_base: 0,
             #[cfg(feature = "fp_simd")]

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -7,7 +7,7 @@ mod trap;
 
 use core::arch::asm;
 
-use memory_addr::{pa, PhysAddr, VirtAddr};
+use memory_addr::{pa, PhysAddr, VirtAddr, MemoryAddr};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
 

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -7,7 +7,7 @@ mod trap;
 
 use core::arch::asm;
 
-use memory_addr::{PhysAddr, VirtAddr, pa};
+use memory_addr::{pa, PhysAddr, VirtAddr};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
 

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -7,7 +7,7 @@ mod trap;
 
 use core::arch::asm;
 
-use memory_addr::{PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr, pa};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
 
@@ -60,7 +60,7 @@ pub fn halt() {
 /// Returns the physical address of the page table root.
 #[inline]
 pub fn read_page_table_root() -> PhysAddr {
-    PhysAddr::from(unsafe { controlregs::cr3() } as usize).align_down_4k()
+    pa!(unsafe { controlregs::cr3() } as usize).align_down_4k()
 }
 
 /// Writes the register to update the current page table root.

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -7,7 +7,7 @@ mod trap;
 
 use core::arch::asm;
 
-use memory_addr::{pa, PhysAddr, VirtAddr, MemoryAddr};
+use memory_addr::{pa, MemoryAddr, PhysAddr, VirtAddr};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
 

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -1,4 +1,4 @@
-use memory_addr::VirtAddr;
+use memory_addr::{VirtAddr, va};
 use page_table_entry::MappingFlags;
 use x86::{controlregs::cr2, irq::*};
 use x86_64::structures::idt::PageFaultErrorCode;
@@ -13,7 +13,7 @@ const IRQ_VECTOR_END: u8 = 0xff;
 fn handle_page_fault(tf: &TrapFrame) {
     let access_flags = err_code_to_flags(tf.error_code)
         .unwrap_or_else(|e| panic!("Invalid #PF error code: {:#x}", e));
-    let vaddr = VirtAddr::from(unsafe { cr2() });
+    let vaddr = va!(unsafe { cr2() });
     if !handle_trap!(PAGE_FAULT, vaddr, access_flags, tf.is_user()) {
         panic!(
             "Unhandled {} #PF @ {:#x}, fault_vaddr={:#x}, error_code={:#x} ({:?}):\n{:#x?}",

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -1,4 +1,4 @@
-use memory_addr::{VirtAddr, va};
+use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use x86::{controlregs::cr2, irq::*};
 use x86_64::structures::idt::PageFaultErrorCode;

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[doc(no_inline)]
-pub use memory_addr::{PhysAddr, VirtAddr, PAGE_SIZE_4K, pa, va};
+pub use memory_addr::{pa, va, PhysAddr, VirtAddr, PAGE_SIZE_4K};
 
 bitflags::bitflags! {
     /// The flags of a physical memory region.

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[doc(no_inline)]
-pub use memory_addr::{PhysAddr, VirtAddr, PAGE_SIZE_4K};
+pub use memory_addr::{PhysAddr, VirtAddr, PAGE_SIZE_4K, pa, va};
 
 bitflags::bitflags! {
     /// The flags of a physical memory region.
@@ -54,7 +54,7 @@ pub struct MemRegion {
 /// [`PHYS_VIRT_OFFSET`]: axconfig::PHYS_VIRT_OFFSET
 #[inline]
 pub const fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-    PhysAddr::from(vaddr.as_usize() - axconfig::PHYS_VIRT_OFFSET)
+    pa!(vaddr.as_usize() - axconfig::PHYS_VIRT_OFFSET)
 }
 
 /// Converts a physical address to a virtual address.
@@ -67,7 +67,7 @@ pub const fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
 /// [`PHYS_VIRT_OFFSET`]: axconfig::PHYS_VIRT_OFFSET
 #[inline]
 pub const fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-    VirtAddr::from(paddr.as_usize() + axconfig::PHYS_VIRT_OFFSET)
+    va!(paddr.as_usize() + axconfig::PHYS_VIRT_OFFSET)
 }
 
 /// Returns an iterator over all physical memory regions.
@@ -130,7 +130,7 @@ pub(crate) fn default_mmio_regions() -> impl Iterator<Item = MemRegion> {
 #[allow(dead_code)]
 pub(crate) fn default_free_regions() -> impl Iterator<Item = MemRegion> {
     let start = virt_to_phys((_ekernel as usize).into()).align_up_4k();
-    let end = PhysAddr::from(axconfig::PHYS_MEMORY_END).align_down_4k();
+    let end = pa!(axconfig::PHYS_MEMORY_END).align_down_4k();
     core::iter::once(MemRegion {
         paddr: start,
         size: end.as_usize() - start.as_usize(),

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[doc(no_inline)]
-pub use memory_addr::{pa, va, PhysAddr, VirtAddr, PAGE_SIZE_4K};
+pub use memory_addr::{pa, va, PhysAddr, VirtAddr, MemoryAddr, PAGE_SIZE_4K};
 
 bitflags::bitflags! {
     /// The flags of a physical memory region.

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[doc(no_inline)]
-pub use memory_addr::{pa, va, PhysAddr, VirtAddr, MemoryAddr, PAGE_SIZE_4K};
+pub use memory_addr::{pa, va, MemoryAddr, PhysAddr, VirtAddr, PAGE_SIZE_4K};
 
 bitflags::bitflags! {
     /// The flags of a physical memory region.

--- a/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
@@ -3,7 +3,7 @@
 use crate::mem::phys_to_virt;
 use dw_apb_uart::DW8250;
 use kspin::SpinNoIrq;
-use memory_addr::{PhysAddr, pa};
+use memory_addr::{pa, PhysAddr};
 
 const UART_BASE: PhysAddr = pa!(axconfig::UART_PADDR);
 

--- a/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
@@ -3,9 +3,9 @@
 use crate::mem::phys_to_virt;
 use dw_apb_uart::DW8250;
 use kspin::SpinNoIrq;
-use memory_addr::PhysAddr;
+use memory_addr::{PhysAddr, pa};
 
-const UART_BASE: PhysAddr = PhysAddr::from(axconfig::UART_PADDR);
+const UART_BASE: PhysAddr = pa!(axconfig::UART_PADDR);
 
 static UART: SpinNoIrq<DW8250> = SpinNoIrq::new(DW8250::new(phys_to_virt(UART_BASE).as_usize()));
 

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{MemRegion, PhysAddr};
+use crate::mem::{MemRegion, PhysAddr, pa};
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.
@@ -13,22 +13,22 @@ pub(crate) unsafe fn init_boot_page_table(
     let boot_pt_l0 = &mut *boot_pt_l0;
     let boot_pt_l1 = &mut *boot_pt_l1;
     // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
-    boot_pt_l0[0] = A64PTE::new_table(PhysAddr::from(boot_pt_l1.as_ptr() as usize));
+    boot_pt_l0[0] = A64PTE::new_table(pa!(boot_pt_l1.as_ptr() as usize));
     // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
     boot_pt_l1[0] = A64PTE::new_page(
-        PhysAddr::from(0),
+        pa!(0),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
         true,
     );
     // 1G block, device memory
     boot_pt_l1[1] = A64PTE::new_page(
-        PhysAddr::from(0x40000000),
+        pa!(0x40000000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
         true,
     );
     // 1G block, normal memory
     boot_pt_l1[2] = A64PTE::new_page(
-        PhysAddr::from(0x80000000),
+        pa!(0x80000000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
         true,
     );

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{MemRegion, PhysAddr, pa};
+use crate::mem::{pa, MemRegion, PhysAddr};
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
+use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
 
 /// Hart number of bsta1000b board
 pub const MAX_HARTS: usize = 8;

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
 
 /// Hart number of bsta1000b board
 pub const MAX_HARTS: usize = 8;
@@ -14,7 +14,7 @@ pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
     extern "C" {
         fn _start_secondary();
     }
-    let entry = virt_to_phys(VirtAddr::from(_start_secondary as usize));
+    let entry = virt_to_phys(va!(_start_secondary as usize));
     crate::platform::aarch64_common::psci::cpu_on(
         CPU_HWID[cpu_id],
         entry.as_usize(),

--- a/modules/axhal/src/platform/aarch64_common/boot.rs
+++ b/modules/axhal/src/platform/aarch64_common/boot.rs
@@ -1,6 +1,6 @@
 use aarch64_cpu::{asm, asm::barrier, registers::*};
 use core::ptr::addr_of_mut;
-use memory_addr::{PhysAddr, pa};
+use memory_addr::{pa, PhysAddr};
 use page_table_entry::aarch64::{MemAttr, A64PTE};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 

--- a/modules/axhal/src/platform/aarch64_common/boot.rs
+++ b/modules/axhal/src/platform/aarch64_common/boot.rs
@@ -1,6 +1,6 @@
 use aarch64_cpu::{asm, asm::barrier, registers::*};
 use core::ptr::addr_of_mut;
-use memory_addr::PhysAddr;
+use memory_addr::{PhysAddr, pa};
 use page_table_entry::aarch64::{MemAttr, A64PTE};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
@@ -78,7 +78,7 @@ unsafe fn init_mmu() {
     barrier::isb(barrier::SY);
 
     // Set both TTBR0 and TTBR1
-    let root_paddr = PhysAddr::from(BOOT_PT_L0.as_ptr() as usize).as_usize() as _;
+    let root_paddr = pa!(BOOT_PT_L0.as_ptr() as usize).as_usize() as _;
     TTBR0_EL1.set(root_paddr);
     TTBR1_EL1.set(root_paddr);
 

--- a/modules/axhal/src/platform/aarch64_common/generic_timer.rs
+++ b/modules/axhal/src/platform/aarch64_common/generic_timer.rs
@@ -61,7 +61,7 @@ pub(crate) fn init_early() {
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
         use arm_pl031::Rtc;
-        use memory_addr::{PhysAddr, pa};
+        use memory_addr::{pa, PhysAddr};
 
         const PL031_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);
 

--- a/modules/axhal/src/platform/aarch64_common/generic_timer.rs
+++ b/modules/axhal/src/platform/aarch64_common/generic_timer.rs
@@ -61,9 +61,9 @@ pub(crate) fn init_early() {
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
         use arm_pl031::Rtc;
-        use memory_addr::PhysAddr;
+        use memory_addr::{PhysAddr, pa};
 
-        const PL031_BASE: PhysAddr = PhysAddr::from(axconfig::RTC_PADDR);
+        const PL031_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);
 
         let rtc = unsafe { Rtc::new(phys_to_virt(PL031_BASE).as_usize() as _) };
         // Get the current time in microseconds since the epoch (1970-01-01) from the aarch64 pl031 RTC.

--- a/modules/axhal/src/platform/aarch64_common/gic.rs
+++ b/modules/axhal/src/platform/aarch64_common/gic.rs
@@ -1,7 +1,7 @@
 use crate::{irq::IrqHandler, mem::phys_to_virt};
 use arm_gicv2::{translate_irq, GicCpuInterface, GicDistributor, InterruptType};
 use kspin::SpinNoIrq;
-use memory_addr::{PhysAddr, pa};
+use memory_addr::{pa, PhysAddr};
 
 /// The maximum number of IRQs.
 pub const MAX_IRQ_COUNT: usize = 1024;

--- a/modules/axhal/src/platform/aarch64_common/gic.rs
+++ b/modules/axhal/src/platform/aarch64_common/gic.rs
@@ -1,7 +1,7 @@
 use crate::{irq::IrqHandler, mem::phys_to_virt};
 use arm_gicv2::{translate_irq, GicCpuInterface, GicDistributor, InterruptType};
 use kspin::SpinNoIrq;
-use memory_addr::PhysAddr;
+use memory_addr::{PhysAddr, pa};
 
 /// The maximum number of IRQs.
 pub const MAX_IRQ_COUNT: usize = 1024;
@@ -12,8 +12,8 @@ pub const TIMER_IRQ_NUM: usize = translate_irq(14, InterruptType::PPI).unwrap();
 /// The UART IRQ number.
 pub const UART_IRQ_NUM: usize = translate_irq(axconfig::UART_IRQ, InterruptType::SPI).unwrap();
 
-const GICD_BASE: PhysAddr = PhysAddr::from(axconfig::GICD_PADDR);
-const GICC_BASE: PhysAddr = PhysAddr::from(axconfig::GICC_PADDR);
+const GICD_BASE: PhysAddr = pa!(axconfig::GICD_PADDR);
+const GICC_BASE: PhysAddr = pa!(axconfig::GICC_PADDR);
 
 static GICD: SpinNoIrq<GicDistributor> =
     SpinNoIrq::new(GicDistributor::new(phys_to_virt(GICD_BASE).as_mut_ptr()));

--- a/modules/axhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/axhal/src/platform/aarch64_common/pl011.rs
@@ -2,7 +2,7 @@
 
 use arm_pl011::Pl011Uart;
 use kspin::SpinNoIrq;
-use memory_addr::{PhysAddr, pa};
+use memory_addr::{pa, PhysAddr};
 
 use crate::mem::phys_to_virt;
 

--- a/modules/axhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/axhal/src/platform/aarch64_common/pl011.rs
@@ -2,11 +2,11 @@
 
 use arm_pl011::Pl011Uart;
 use kspin::SpinNoIrq;
-use memory_addr::PhysAddr;
+use memory_addr::{PhysAddr, pa};
 
 use crate::mem::phys_to_virt;
 
-const UART_BASE: PhysAddr = PhysAddr::from(axconfig::UART_PADDR);
+const UART_BASE: PhysAddr = pa!(axconfig::UART_PADDR);
 
 static UART: SpinNoIrq<Pl011Uart> =
     SpinNoIrq::new(Pl011Uart::new(phys_to_virt(UART_BASE).as_mut_ptr()));

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{MemRegion, PhysAddr};
+use crate::mem::{MemRegion, PhysAddr, pa};
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.
@@ -13,16 +13,16 @@ pub(crate) unsafe fn init_boot_page_table(
     let boot_pt_l0 = &mut *boot_pt_l0;
     let boot_pt_l1 = &mut *boot_pt_l1;
     // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
-    boot_pt_l0[0] = A64PTE::new_table(PhysAddr::from(boot_pt_l1.as_ptr() as usize));
+    boot_pt_l0[0] = A64PTE::new_table(pa!(boot_pt_l1.as_ptr() as usize));
     // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
     boot_pt_l1[0] = A64PTE::new_page(
-        PhysAddr::from(0),
+        pa!(0),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
         true,
     );
     // 0x0000_4000_0000..0x0000_8000_0000, 1G block, normal memory
     boot_pt_l1[1] = A64PTE::new_page(
-        PhysAddr::from(0x4000_0000),
+        pa!(0x4000_0000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
         true,
     );

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{MemRegion, PhysAddr, pa};
+use crate::mem::{pa, MemRegion, PhysAddr};
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
@@ -1,10 +1,10 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
     extern "C" {
         fn _start_secondary();
     }
-    let entry = virt_to_phys(VirtAddr::from(_start_secondary as usize));
+    let entry = virt_to_phys(va!(_start_secondary as usize));
     crate::platform::aarch64_common::psci::cpu_on(cpu_id, entry.as_usize(), stack_top.as_usize());
 }

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
+use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {

--- a/modules/axhal/src/platform/aarch64_raspi/mem.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mem.rs
@@ -17,31 +17,32 @@ pub(crate) unsafe fn init_boot_page_table(
     boot_pt_l0: *mut [A64PTE; 512],
     boot_pt_l1: *mut [A64PTE; 512],
 ) {
+    use memory_addr::pa;
     let boot_pt_l0 = &mut *boot_pt_l0;
     let boot_pt_l1 = &mut *boot_pt_l1;
     // 0x0000_0000_0000 ~ 0x0080_0000_0000, table
-    boot_pt_l0[0] = A64PTE::new_table(PhysAddr::from(boot_pt_l1.as_ptr() as usize));
+    boot_pt_l0[0] = A64PTE::new_table(pa!(boot_pt_l1.as_ptr() as usize));
     // 0x0000_0000_0000..0x0000_4000_0000, 1G block, device memory
     boot_pt_l1[0] = A64PTE::new_page(
-        PhysAddr::from(0),
+        pa!(0),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
         true,
     );
     // 0x0000_4000_0000..0x0000_8000_0000, 1G block, normal memory
     boot_pt_l1[1] = A64PTE::new_page(
-        PhysAddr::from(0x4000_0000),
+        pa!(0x4000_0000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
         true,
     );
     // 0x0000_8000_0000..0x0000_C000_0000, 1G block, normal memory
     boot_pt_l1[2] = A64PTE::new_page(
-        PhysAddr::from(0x8000_0000),
+        pa!(0x8000_0000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::EXECUTE,
         true,
     );
     // 0x0000_C000_0000..0x0001_0000_0000, 1G block, DEVICE memory
     boot_pt_l1[3] = A64PTE::new_page(
-        PhysAddr::from(0xc000_0000),
+        pa!(0xc000_0000),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::DEVICE,
         true,
     );

--- a/modules/axhal/src/platform/aarch64_raspi/mp.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{phys_to_virt, virt_to_phys, PhysAddr, VirtAddr, pa, va};
+use crate::mem::{pa, phys_to_virt, va, virt_to_phys, PhysAddr, VirtAddr};
 
 static mut SECONDARY_STACK_TOP: usize = 0;
 
@@ -22,12 +22,7 @@ unsafe extern "C" fn modify_stack_and_start() {
     );
 }
 
-pub static CPU_SPIN_TABLE: [PhysAddr; 4] = [
-    pa!(0xd8),
-    pa!(0xe0),
-    pa!(0xe8),
-    pa!(0xf0),
-];
+pub static CPU_SPIN_TABLE: [PhysAddr; 4] = [pa!(0xd8), pa!(0xe0), pa!(0xe8), pa!(0xf0)];
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
@@ -41,9 +36,7 @@ pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
 
         // set the boot stack of the given secondary CPU
         SECONDARY_STACK_TOP = stack_top.as_usize();
-        crate::arch::flush_dcache_line(va!(
-            core::ptr::addr_of!(SECONDARY_STACK_TOP) as usize
-        ));
+        crate::arch::flush_dcache_line(va!(core::ptr::addr_of!(SECONDARY_STACK_TOP) as usize));
     }
     aarch64_cpu::asm::sev();
 }

--- a/modules/axhal/src/platform/aarch64_raspi/mp.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{phys_to_virt, virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{phys_to_virt, virt_to_phys, PhysAddr, VirtAddr, pa, va};
 
 static mut SECONDARY_STACK_TOP: usize = 0;
 
@@ -23,15 +23,15 @@ unsafe extern "C" fn modify_stack_and_start() {
 }
 
 pub static CPU_SPIN_TABLE: [PhysAddr; 4] = [
-    PhysAddr::from(0xd8),
-    PhysAddr::from(0xe0),
-    PhysAddr::from(0xe8),
-    PhysAddr::from(0xf0),
+    pa!(0xd8),
+    pa!(0xe0),
+    pa!(0xe8),
+    pa!(0xf0),
 ];
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
-    let entry_paddr = virt_to_phys(VirtAddr::from(modify_stack_and_start as usize)).as_usize();
+    let entry_paddr = virt_to_phys(va!(modify_stack_and_start as usize)).as_usize();
     unsafe {
         // set the boot code address of the given secondary CPU
         let spintable_vaddr = phys_to_virt(CPU_SPIN_TABLE[cpu_id]);
@@ -41,7 +41,7 @@ pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {
 
         // set the boot stack of the given secondary CPU
         SECONDARY_STACK_TOP = stack_top.as_usize();
-        crate::arch::flush_dcache_line(VirtAddr::from(
+        crate::arch::flush_dcache_line(va!(
             core::ptr::addr_of!(SECONDARY_STACK_TOP) as usize
         ));
     }

--- a/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(hartid: usize, stack_top: PhysAddr) {
@@ -9,6 +9,6 @@ pub fn start_secondary_cpu(hartid: usize, stack_top: PhysAddr) {
         warn!("HSM SBI extension is not supported for current SEE.");
         return;
     }
-    let entry = virt_to_phys(VirtAddr::from(_start_secondary as usize));
+    let entry = virt_to_phys(va!(_start_secondary as usize));
     sbi_rt::hart_start(hartid, entry.as_usize(), stack_top.as_usize());
 }

--- a/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{virt_to_phys, PhysAddr, VirtAddr, va};
+use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(hartid: usize, stack_top: PhysAddr) {

--- a/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
@@ -39,10 +39,10 @@ pub(super) fn init_early() {
     #[cfg(feature = "rtc")]
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
-        use memory_addr::PhysAddr;
+        use memory_addr::{PhysAddr, pa};
         use riscv_goldfish::Rtc;
 
-        const GOLDFISH_BASE: PhysAddr = PhysAddr::from(axconfig::RTC_PADDR);
+        const GOLDFISH_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);
         // Get the current time in microseconds since the epoch (1970-01-01) from the riscv RTC.
         // Subtract the timer ticks to get the actual time when ArceOS was booted.
         let epoch_time_nanos =

--- a/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
@@ -39,7 +39,7 @@ pub(super) fn init_early() {
     #[cfg(feature = "rtc")]
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
-        use memory_addr::{PhysAddr, pa};
+        use memory_addr::{pa, PhysAddr};
         use riscv_goldfish::Rtc;
 
         const GOLDFISH_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);

--- a/modules/axhal/src/platform/x86_pc/apic.rs
+++ b/modules/axhal/src/platform/x86_pc/apic.rs
@@ -2,7 +2,7 @@
 
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::{PhysAddr, pa};
+use memory_addr::{pa, PhysAddr};
 use x2apic::ioapic::IoApic;
 use x2apic::lapic::{xapic_base, LocalApic, LocalApicBuilder};
 use x86_64::instructions::port::Port;

--- a/modules/axhal/src/platform/x86_pc/apic.rs
+++ b/modules/axhal/src/platform/x86_pc/apic.rs
@@ -2,7 +2,7 @@
 
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::PhysAddr;
+use memory_addr::{PhysAddr, pa};
 use x2apic::ioapic::IoApic;
 use x2apic::lapic::{xapic_base, LocalApic, LocalApicBuilder};
 use x86_64::instructions::port::Port;
@@ -22,7 +22,7 @@ pub const MAX_IRQ_COUNT: usize = 256;
 /// The timer IRQ number.
 pub const TIMER_IRQ_NUM: usize = APIC_TIMER_VECTOR as usize;
 
-const IO_APIC_BASE: PhysAddr = PhysAddr::from(0xFEC0_0000);
+const IO_APIC_BASE: PhysAddr = pa!(0xFEC0_0000);
 
 static mut LOCAL_APIC: Option<LocalApic> = None;
 static mut IS_X2APIC: bool = false;
@@ -103,7 +103,7 @@ pub(super) fn init_primary() {
         unsafe { IS_X2APIC = true };
     } else {
         info!("Using xAPIC.");
-        let base_vaddr = phys_to_virt(PhysAddr::from(unsafe { xapic_base() } as usize));
+        let base_vaddr = phys_to_virt(pa!(unsafe { xapic_base() } as usize));
         builder.set_xapic_base(base_vaddr.as_usize() as u64);
     }
 

--- a/modules/axhal/src/platform/x86_pc/mem.rs
+++ b/modules/axhal/src/platform/x86_pc/mem.rs
@@ -1,11 +1,11 @@
 // TODO: get memory regions from multiboot info.
 
-use crate::mem::{MemRegion, MemRegionFlags, PhysAddr};
+use crate::mem::{MemRegion, MemRegionFlags, PhysAddr, pa};
 
 /// Returns platform-specific memory regions.
 pub(crate) fn platform_regions() -> impl Iterator<Item = MemRegion> {
     core::iter::once(MemRegion {
-        paddr: PhysAddr::from(0x1000),
+        paddr: pa!(0x1000),
         size: 0x9e000,
         flags: MemRegionFlags::RESERVED | MemRegionFlags::READ | MemRegionFlags::WRITE,
         name: "low memory",

--- a/modules/axhal/src/platform/x86_pc/mem.rs
+++ b/modules/axhal/src/platform/x86_pc/mem.rs
@@ -1,6 +1,6 @@
 // TODO: get memory regions from multiboot info.
 
-use crate::mem::{pa, MemRegion, MemRegionFlags, PhysAddr};
+use crate::mem::{pa, MemRegion, MemRegionFlags};
 
 /// Returns platform-specific memory regions.
 pub(crate) fn platform_regions() -> impl Iterator<Item = MemRegion> {

--- a/modules/axhal/src/platform/x86_pc/mem.rs
+++ b/modules/axhal/src/platform/x86_pc/mem.rs
@@ -1,6 +1,6 @@
 // TODO: get memory regions from multiboot info.
 
-use crate::mem::{MemRegion, MemRegionFlags, PhysAddr, pa};
+use crate::mem::{pa, MemRegion, MemRegionFlags, PhysAddr};
 
 /// Returns platform-specific memory regions.
 pub(crate) fn platform_regions() -> impl Iterator<Item = MemRegion> {

--- a/modules/axhal/src/platform/x86_pc/mp.rs
+++ b/modules/axhal/src/platform/x86_pc/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{phys_to_virt, PhysAddr, PAGE_SIZE_4K, pa};
+use crate::mem::{pa, phys_to_virt, PhysAddr, PAGE_SIZE_4K};
 use crate::time::{busy_wait, Duration};
 
 const START_PAGE_IDX: u8 = 6;

--- a/modules/axhal/src/platform/x86_pc/mp.rs
+++ b/modules/axhal/src/platform/x86_pc/mp.rs
@@ -1,8 +1,8 @@
-use crate::mem::{phys_to_virt, PhysAddr, PAGE_SIZE_4K};
+use crate::mem::{phys_to_virt, PhysAddr, PAGE_SIZE_4K, pa};
 use crate::time::{busy_wait, Duration};
 
 const START_PAGE_IDX: u8 = 6;
-const START_PAGE_PADDR: PhysAddr = PhysAddr::from(START_PAGE_IDX as usize * PAGE_SIZE_4K);
+const START_PAGE_PADDR: PhysAddr = pa!(START_PAGE_IDX as usize * PAGE_SIZE_4K);
 
 core::arch::global_asm!(
     include_str!("ap_start.S"),

--- a/modules/axlog/Cargo.toml
+++ b/modules/axlog/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 
 [dependencies]
 cfg-if = "1.0"
-log = "0.4"
+log = "0.4.21"
 kspin = "0.1"
 crate_interface = "0.1"
 chrono = { version = "0.4", optional = true }

--- a/modules/axmm/Cargo.toml
+++ b/modules/axmm/Cargo.toml
@@ -16,5 +16,5 @@ axconfig = { workspace = true }
 log = "0.4"
 axerrno = "0.1"
 lazyinit = "0.2"
-memory_addr = "0.2"
+memory_addr = "0.3"
 kspin = "0.1"

--- a/modules/axmm/Cargo.toml
+++ b/modules/axmm/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://arceos-org.github.io/arceos/axmm/index.html"
 axhal = { workspace = true, features = ["paging"] }
 axconfig = { workspace = true }
 
-log = "0.4"
+log = "0.4.21"
 axerrno = "0.1"
 lazyinit = "0.2"
 memory_addr = "0.3"

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use axerrno::{ax_err, AxError, AxResult};
 use axhal::paging::{MappingFlags, PageTable};
-use memory_addr::{is_aligned_4k, PhysAddr, VirtAddr, VirtAddrRange};
+use memory_addr::{is_aligned_4k, pa, PhysAddr, VirtAddr, VirtAddrRange};
 
 use crate::paging_err_to_ax_err;
 
@@ -24,7 +24,7 @@ impl AddrSpace {
     }
 
     /// Returns the address space size.
-    pub const fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         self.va_range.size()
     }
 
@@ -39,7 +39,7 @@ impl AddrSpace {
     }
 
     /// Checks if the address space contains the given address range.
-    pub const fn contains_range(&self, start: VirtAddr, size: usize) -> bool {
+    pub fn contains_range(&self, start: VirtAddr, size: usize) -> bool {
         self.va_range
             .contains_range(VirtAddrRange::from_start_size(start, size))
     }
@@ -79,7 +79,7 @@ impl AddrSpace {
         self.pt
             .map_region(
                 start_vaddr,
-                |va| PhysAddr::from(va.as_usize() - offset),
+                |va| pa!(va.as_usize() - offset),
                 size,
                 flags,
                 false, // allow_huge

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use axerrno::{ax_err, AxError, AxResult};
 use axhal::paging::{MappingFlags, PageTable};
-use memory_addr::{is_aligned_4k, pa, PhysAddr, VirtAddr, VirtAddrRange, MemoryAddr};
+use memory_addr::{is_aligned_4k, pa, MemoryAddr, PhysAddr, VirtAddr, VirtAddrRange};
 
 use crate::paging_err_to_ax_err;
 

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use axerrno::{ax_err, AxError, AxResult};
 use axhal::paging::{MappingFlags, PageTable};
-use memory_addr::{is_aligned_4k, pa, PhysAddr, VirtAddr, VirtAddrRange};
+use memory_addr::{is_aligned_4k, pa, PhysAddr, VirtAddr, VirtAddrRange, MemoryAddr};
 
 use crate::paging_err_to_ax_err;
 

--- a/modules/axmm/src/lib.rs
+++ b/modules/axmm/src/lib.rs
@@ -15,7 +15,7 @@ use axhal::mem::phys_to_virt;
 use axhal::paging::PagingError;
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::{PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr, va};
 
 static KERNEL_ASPACE: LazyInit<SpinNoIrq<AddrSpace>> = LazyInit::new();
 
@@ -33,7 +33,7 @@ fn paging_err_to_ax_err(err: PagingError) -> AxError {
 /// Creates a new address space for kernel itself.
 pub fn new_kernel_aspace() -> AxResult<AddrSpace> {
     let mut aspace = AddrSpace::new_empty(
-        VirtAddr::from(axconfig::KERNEL_ASPACE_BASE),
+        va!(axconfig::KERNEL_ASPACE_BASE),
         axconfig::KERNEL_ASPACE_SIZE,
     )?;
     for r in axhal::mem::memory_regions() {

--- a/modules/axmm/src/lib.rs
+++ b/modules/axmm/src/lib.rs
@@ -15,7 +15,7 @@ use axhal::mem::phys_to_virt;
 use axhal::paging::PagingError;
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::{va, PhysAddr, VirtAddr};
+use memory_addr::{va, PhysAddr};
 
 static KERNEL_ASPACE: LazyInit<SpinNoIrq<AddrSpace>> = LazyInit::new();
 

--- a/modules/axmm/src/lib.rs
+++ b/modules/axmm/src/lib.rs
@@ -15,7 +15,7 @@ use axhal::mem::phys_to_virt;
 use axhal::paging::PagingError;
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::{PhysAddr, VirtAddr, va};
+use memory_addr::{va, PhysAddr, VirtAddr};
 
 static KERNEL_ASPACE: LazyInit<SpinNoIrq<AddrSpace>> = LazyInit::new();
 

--- a/modules/axnet/Cargo.toml
+++ b/modules/axnet/Cargo.toml
@@ -14,7 +14,7 @@ smoltcp = []
 default = ["smoltcp"]
 
 [dependencies]
-log = "0.4"
+log = "0.4.21"
 cfg-if = "1.0"
 spin = "0.9"
 lazyinit = "0.2"

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,5 +1,5 @@
 use axconfig::{SMP, TASK_STACK_SIZE};
-use axhal::mem::{virt_to_phys, VirtAddr};
+use axhal::mem::{virt_to_phys, VirtAddr, va};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[link_section = ".bss.stack"]
@@ -11,7 +11,7 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
     let mut logic_cpu_id = 0;
     for i in 0..SMP {
         if i != primary_cpu_id {
-            let stack_top = virt_to_phys(VirtAddr::from(unsafe {
+            let stack_top = virt_to_phys(va!(unsafe {
                 SECONDARY_BOOT_STACK[logic_cpu_id].as_ptr_range().end as usize
             }));
 

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,5 +1,5 @@
 use axconfig::{SMP, TASK_STACK_SIZE};
-use axhal::mem::{va, virt_to_phys, VirtAddr};
+use axhal::mem::{va, virt_to_phys};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[link_section = ".bss.stack"]

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,5 +1,5 @@
 use axconfig::{SMP, TASK_STACK_SIZE};
-use axhal::mem::{virt_to_phys, VirtAddr, va};
+use axhal::mem::{va, virt_to_phys, VirtAddr};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[link_section = ".bss.stack"]

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -28,7 +28,7 @@ test = ["percpu?/sp-naive"]
 
 [dependencies]
 cfg-if = "1.0"
-log = "0.4"
+log = "0.4.21"
 axhal = { workspace = true }
 axconfig = { workspace = true, optional = true }
 percpu = { version = "0.1", optional = true }

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -34,7 +34,7 @@ axconfig = { workspace = true, optional = true }
 percpu = { version = "0.1", optional = true }
 kspin = { version = "0.1", optional = true }
 lazyinit = { version = "0.2", optional = true }
-memory_addr = { version = "0.2", optional = true }
+memory_addr = { version = "0.3", optional = true }
 timer_list = { version = "0.1", optional = true }
 kernel_guard = { version = "0.1", optional = true }
 crate_interface = { version = "0.1", optional = true }

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -10,7 +10,7 @@ use core::sync::atomic::AtomicUsize;
 use axhal::tls::TlsArea;
 
 use axhal::arch::TaskContext;
-use memory_addr::{align_up_4k, VirtAddr};
+use memory_addr::{align_up_4k, VirtAddr, va};
 
 use crate::{AxRunQueue, AxTask, AxTaskRef, WaitQueue};
 
@@ -147,9 +147,9 @@ impl TaskInner {
         let kstack = TaskStack::alloc(align_up_4k(stack_size));
 
         #[cfg(feature = "tls")]
-        let tls = VirtAddr::from(t.tls.tls_ptr() as usize);
+        let tls = va!(t.tls.tls_ptr() as usize);
         #[cfg(not(feature = "tls"))]
-        let tls = VirtAddr::from(0);
+        let tls = va!(0);
 
         t.entry = Some(Box::into_raw(Box::new(entry)));
         t.ctx.get_mut().init(task_entry as usize, kstack.top(), tls);

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -10,7 +10,7 @@ use core::sync::atomic::AtomicUsize;
 use axhal::tls::TlsArea;
 
 use axhal::arch::TaskContext;
-use memory_addr::{align_up_4k, VirtAddr, va};
+use memory_addr::{align_up_4k, va, VirtAddr};
 
 use crate::{AxRunQueue, AxTask, AxTaskRef, WaitQueue};
 


### PR DESCRIPTION
Update `memory_addr` crate to proposed version.

- All `Virt/PhysAddr::from` are replaced with `va!/pa!`.
- 2 `const` removed.

It passes all tests except `c/memtest`.
