### PR TITLE
Introduce user-defined task extended data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,9 +1022,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca25419c2b34080d526d6836a53dcab129767ab6a9904587c87265ae6d41aa9"
+checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
 
 [[package]]
 name = "minimal-lexical"

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod trap;
 use core::arch::asm;
 
 use aarch64_cpu::registers::{DAIF, TPIDR_EL0, TTBR0_EL1, TTBR1_EL1, VBAR_EL1};
-use memory_addr::{pa, PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr};
 use tock_registers::interfaces::{Readable, Writeable};
 
 pub use self::context::{FpState, TaskContext, TrapFrame};

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -1,7 +1,6 @@
 use core::arch::global_asm;
 
 use aarch64_cpu::registers::{ESR_EL1, FAR_EL1};
-use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use tock_registers::interfaces::Readable;
 

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -4,7 +4,7 @@ mod macros;
 mod context;
 mod trap;
 
-use memory_addr::{pa, PhysAddr, VirtAddr};
+use memory_addr::{PhysAddr, VirtAddr};
 use riscv::asm;
 use riscv::register::{satp, sstatus, stvec};
 

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -1,4 +1,3 @@
-use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use riscv::register::scause::{self, Exception as E, Trap};
 use riscv::register::stval;

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -1,5 +1,5 @@
 use core::{arch::asm, fmt};
-use memory_addr::{va, VirtAddr};
+use memory_addr::VirtAddr;
 
 /// Saved registers when a trap (interrupt or exception) occurs.
 #[allow(missing_docs)]

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -7,7 +7,7 @@ mod trap;
 
 use core::arch::asm;
 
-use memory_addr::{pa, MemoryAddr, PhysAddr, VirtAddr};
+use memory_addr::{MemoryAddr, PhysAddr, VirtAddr};
 use x86::{controlregs, msr, tlb};
 use x86_64::instructions::interrupts;
 

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -1,4 +1,3 @@
-use memory_addr::{va, VirtAddr};
 use page_table_entry::MappingFlags;
 use x86::{controlregs::cr2, irq::*};
 use x86_64::structures::idt::PageFaultErrorCode;

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -34,6 +34,10 @@
 #[macro_use]
 extern crate log;
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate memory_addr;
+
 mod platform;
 
 #[macro_use]

--- a/modules/axhal/src/mem.rs
+++ b/modules/axhal/src/mem.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[doc(no_inline)]
-pub use memory_addr::{pa, va, MemoryAddr, PhysAddr, VirtAddr, PAGE_SIZE_4K};
+pub use memory_addr::{MemoryAddr, PhysAddr, VirtAddr, PAGE_SIZE_4K};
 
 bitflags::bitflags! {
     /// The flags of a physical memory region.

--- a/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
@@ -3,7 +3,7 @@
 use crate::mem::phys_to_virt;
 use dw_apb_uart::DW8250;
 use kspin::SpinNoIrq;
-use memory_addr::{pa, PhysAddr};
+use memory_addr::PhysAddr;
 
 const UART_BASE: PhysAddr = pa!(axconfig::UART_PADDR);
 

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{pa, MemRegion, PhysAddr};
+use crate::mem::MemRegion;
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.

--- a/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr};
 
 /// Hart number of bsta1000b board
 pub const MAX_HARTS: usize = 8;

--- a/modules/axhal/src/platform/aarch64_common/boot.rs
+++ b/modules/axhal/src/platform/aarch64_common/boot.rs
@@ -1,6 +1,5 @@
 use aarch64_cpu::{asm, asm::barrier, registers::*};
 use core::ptr::addr_of_mut;
-use memory_addr::{pa, PhysAddr};
 use page_table_entry::aarch64::{MemAttr, A64PTE};
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 

--- a/modules/axhal/src/platform/aarch64_common/generic_timer.rs
+++ b/modules/axhal/src/platform/aarch64_common/generic_timer.rs
@@ -61,7 +61,7 @@ pub(crate) fn init_early() {
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
         use arm_pl031::Rtc;
-        use memory_addr::{pa, PhysAddr};
+        use memory_addr::PhysAddr;
 
         const PL031_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);
 

--- a/modules/axhal/src/platform/aarch64_common/gic.rs
+++ b/modules/axhal/src/platform/aarch64_common/gic.rs
@@ -1,7 +1,7 @@
 use crate::{irq::IrqHandler, mem::phys_to_virt};
 use arm_gicv2::{translate_irq, GicCpuInterface, GicDistributor, InterruptType};
 use kspin::SpinNoIrq;
-use memory_addr::{pa, PhysAddr};
+use memory_addr::PhysAddr;
 
 /// The maximum number of IRQs.
 pub const MAX_IRQ_COUNT: usize = 1024;

--- a/modules/axhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/axhal/src/platform/aarch64_common/pl011.rs
@@ -2,7 +2,7 @@
 
 use arm_pl011::Pl011Uart;
 use kspin::SpinNoIrq;
-use memory_addr::{pa, PhysAddr};
+use memory_addr::PhysAddr;
 
 use crate::mem::phys_to_virt;
 

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::{pa, MemRegion, PhysAddr};
+use crate::mem::MemRegion;
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.

--- a/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/aarch64_qemu_virt/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(cpu_id: usize, stack_top: PhysAddr) {

--- a/modules/axhal/src/platform/aarch64_raspi/mem.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mem.rs
@@ -1,4 +1,4 @@
-use crate::mem::*;
+use crate::mem::{MemRegion, MemRegionFlags};
 use page_table_entry::{aarch64::A64PTE, GenericPTE, MappingFlags};
 
 /// Returns platform-specific memory regions.
@@ -17,7 +17,6 @@ pub(crate) unsafe fn init_boot_page_table(
     boot_pt_l0: *mut [A64PTE; 512],
     boot_pt_l1: *mut [A64PTE; 512],
 ) {
-    use memory_addr::pa;
     let boot_pt_l0 = &mut *boot_pt_l0;
     let boot_pt_l1 = &mut *boot_pt_l1;
     // 0x0000_0000_0000 ~ 0x0080_0000_0000, table

--- a/modules/axhal/src/platform/aarch64_raspi/mp.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{pa, phys_to_virt, va, virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{phys_to_virt, virt_to_phys, PhysAddr};
 
 static mut SECONDARY_STACK_TOP: usize = 0;
 

--- a/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{va, virt_to_phys, PhysAddr, VirtAddr};
+use crate::mem::{virt_to_phys, PhysAddr};
 
 /// Starts the given secondary CPU with its boot stack.
 pub fn start_secondary_cpu(hartid: usize, stack_top: PhysAddr) {

--- a/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/time.rs
@@ -39,7 +39,7 @@ pub(super) fn init_early() {
     #[cfg(feature = "rtc")]
     if axconfig::RTC_PADDR != 0 {
         use crate::mem::phys_to_virt;
-        use memory_addr::{pa, PhysAddr};
+        use memory_addr::PhysAddr;
         use riscv_goldfish::Rtc;
 
         const GOLDFISH_BASE: PhysAddr = pa!(axconfig::RTC_PADDR);

--- a/modules/axhal/src/platform/x86_pc/apic.rs
+++ b/modules/axhal/src/platform/x86_pc/apic.rs
@@ -2,7 +2,7 @@
 
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
-use memory_addr::{pa, PhysAddr};
+use memory_addr::PhysAddr;
 use x2apic::ioapic::IoApic;
 use x2apic::lapic::{xapic_base, LocalApic, LocalApicBuilder};
 use x86_64::instructions::port::Port;

--- a/modules/axhal/src/platform/x86_pc/mem.rs
+++ b/modules/axhal/src/platform/x86_pc/mem.rs
@@ -1,6 +1,6 @@
 // TODO: get memory regions from multiboot info.
 
-use crate::mem::{pa, MemRegion, MemRegionFlags};
+use crate::mem::{MemRegion, MemRegionFlags};
 
 /// Returns platform-specific memory regions.
 pub(crate) fn platform_regions() -> impl Iterator<Item = MemRegion> {

--- a/modules/axhal/src/platform/x86_pc/mp.rs
+++ b/modules/axhal/src/platform/x86_pc/mp.rs
@@ -1,4 +1,4 @@
-use crate::mem::{pa, phys_to_virt, PhysAddr, PAGE_SIZE_4K};
+use crate::mem::{phys_to_virt, PhysAddr, PAGE_SIZE_4K};
 use crate::time::{busy_wait, Duration};
 
 const START_PAGE_IDX: u8 = 6;

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,6 +1,7 @@
-use axconfig::{SMP, TASK_STACK_SIZE};
-use axhal::mem::{va, virt_to_phys};
 use core::sync::atomic::{AtomicUsize, Ordering};
+
+use axconfig::{SMP, TASK_STACK_SIZE};
+use axhal::mem::{virt_to_phys, VirtAddr};
 
 #[link_section = ".bss.stack"]
 static mut SECONDARY_BOOT_STACK: [[u8; TASK_STACK_SIZE]; SMP - 1] = [[0; TASK_STACK_SIZE]; SMP - 1];
@@ -11,7 +12,7 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
     let mut logic_cpu_id = 0;
     for i in 0..SMP {
         if i != primary_cpu_id {
-            let stack_top = virt_to_phys(va!(unsafe {
+            let stack_top = virt_to_phys(VirtAddr::from(unsafe {
                 SECONDARY_BOOT_STACK[logic_cpu_id].as_ptr_range().end as usize
             }));
 

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -7,6 +7,8 @@ pub(crate) use crate::run_queue::{AxRunQueue, RUN_QUEUE};
 #[doc(cfg(feature = "multitask"))]
 pub use crate::task::{CurrentTask, TaskId, TaskInner};
 #[doc(cfg(feature = "multitask"))]
+pub use crate::task_ext::{TaskExtMut, TaskExtRef};
+#[doc(cfg(feature = "multitask"))]
 pub use crate::wait_queue::WaitQueue;
 
 /// The reference type of a task.
@@ -87,6 +89,13 @@ pub fn on_timer_tick() {
     RUN_QUEUE.lock().scheduler_timer_tick();
 }
 
+/// Adds the given task to the run queue, returns the task reference.
+pub fn spawn_task(task: TaskInner) -> AxTaskRef {
+    let task_ref = task.into_arc();
+    RUN_QUEUE.lock().add_task(task_ref.clone());
+    task_ref
+}
+
 /// Spawns a new task with the given parameters.
 ///
 /// Returns the task reference.
@@ -94,9 +103,7 @@ pub fn spawn_raw<F>(f: F, name: String, stack_size: usize) -> AxTaskRef
 where
     F: FnOnce() + Send + 'static,
 {
-    let task = TaskInner::new(f, name, stack_size);
-    RUN_QUEUE.lock().add_task(task.clone());
-    task
+    spawn_task(TaskInner::new(f, name, stack_size))
 }
 
 /// Spawns a new task with the default parameters.

--- a/modules/axtask/src/lib.rs
+++ b/modules/axtask/src/lib.rs
@@ -28,6 +28,10 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(doc_cfg)]
 #![feature(doc_auto_cfg)]
+#![feature(linkage)]
+#![feature(const_mut_refs)]
+#![feature(const_ptr_is_null)]
+#![feature(const_unsafecell_get_mut)]
 
 #[cfg(test)]
 mod tests;
@@ -40,6 +44,7 @@ cfg_if::cfg_if! {
 
         mod run_queue;
         mod task;
+        mod task_ext;
         mod api;
         mod wait_queue;
 

--- a/modules/axtask/src/task_ext.rs
+++ b/modules/axtask/src/task_ext.rs
@@ -1,0 +1,187 @@
+//! User-defined task extended data.
+
+use core::alloc::Layout;
+use core::mem::{align_of, size_of};
+
+#[no_mangle]
+#[linkage = "weak"]
+static __AX_TASK_EXT_SIZE: usize = 0;
+
+#[no_mangle]
+#[linkage = "weak"]
+static __AX_TASK_EXT_ALIGN: usize = 0;
+
+/// A wrapper of pointer to the task extended data.
+pub(crate) struct AxTaskExt {
+    ptr: *mut u8,
+}
+
+impl AxTaskExt {
+    /// Returns the expected size of the task extended structure.
+    pub fn size() -> usize {
+        extern "C" {
+            static __AX_TASK_EXT_SIZE: usize;
+        }
+        unsafe { __AX_TASK_EXT_SIZE }
+    }
+
+    /// Returns the expected alignment of the task extended structure.
+    pub fn align() -> usize {
+        extern "C" {
+            static __AX_TASK_EXT_SIZE: usize;
+        }
+        unsafe { __AX_TASK_EXT_SIZE }
+    }
+
+    /// Construct an empty task extended structure that contains no data
+    /// (zero size).
+    pub const fn empty() -> Self {
+        Self {
+            ptr: core::ptr::null_mut(),
+        }
+    }
+
+    /// Returns `true` if the task extended structure is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.ptr.is_null()
+    }
+
+    /// Allocates the space for the task extended data, but does not
+    /// initialize the data.
+    pub unsafe fn uninited() -> Self {
+        let size = Self::size();
+        let align = Self::align();
+        let ptr = if size == 0 {
+            core::ptr::null_mut()
+        } else {
+            let layout = Layout::from_size_align(size, align).unwrap();
+            unsafe { alloc::alloc::alloc(layout) }
+        };
+        Self { ptr }
+    }
+
+    /// Gets the raw pointer to the task extended data.
+    pub const fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
+    /// Write the given object to the task extended data.
+    ///
+    /// Returns [`None`] if the data size is zero, otherwise returns a mutable
+    /// reference to the content.
+    ///
+    /// # Panics
+    ///
+    /// Panics If the sizes and alignments of the two object do not match.
+    pub fn write<T: Sized>(&mut self, data: T) -> Option<&mut T> {
+        let data_size = size_of::<T>();
+        let data_align = align_of::<T>();
+        if data_size != Self::size() {
+            panic!("size mismatch: {} != {}", data_size, Self::size());
+        }
+        if data_align != Self::align() {
+            panic!("align mismatch: {} != {}", data_align, Self::align());
+        }
+
+        if self.ptr.is_null() {
+            *self = unsafe { Self::uninited() };
+        }
+        if data_size > 0 {
+            let ptr = self.ptr as *mut T;
+            assert!(!ptr.is_null());
+            unsafe {
+                ptr.write(data);
+                Some(&mut *ptr)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for AxTaskExt {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            let layout = Layout::from_size_align(Self::size(), 0x10).unwrap();
+            unsafe { alloc::alloc::dealloc(self.ptr, layout) };
+        }
+    }
+}
+
+/// A trait to convert [`TaskInner::task_ext_ptr`] to the reference of the
+/// concrete type.
+///
+/// [`TaskInner::task_ext_ptr`]: crate::TaskInner::task_ext_ptr
+pub trait TaskExtRef<T: Sized> {
+    /// Get a reference to the task extended data.
+    fn task_ext(&self) -> &T;
+}
+
+/// A trait to convert [`TaskInner::task_ext_ptr`] to the mutable reference of
+/// the concrete type.
+///
+/// [`TaskInner::task_ext_ptr`]: crate::TaskInner::task_ext_ptr
+pub trait TaskExtMut<T: Sized> {
+    /// Get a mutable reference to the task extended data.
+    fn task_ext_mut(&mut self) -> &mut T;
+}
+
+/// Define the task extended data.
+///
+/// It automatically implements [`TaskExtRef`] and [`TaskExtMut`] for
+/// [`TaskInner`].
+///
+/// # Example
+///
+/// ```
+/// # #![allow(non_local_definitions)]
+/// use axtask::{def_task_ext, TaskExtRef, TaskInner};
+///
+/// pub struct TaskExtImpl {
+///    proc_id: usize,
+/// }
+///
+/// def_task_ext!(TaskExtImpl);
+///
+/// axtask::init_scheduler();
+///
+/// let mut inner = TaskInner::new(|| {},  "".into(), 0x1000);
+/// assert!(inner.init_task_ext(TaskExtImpl { proc_id: 233 }).is_some());
+/// // cannot initialize twice
+/// assert!(inner.init_task_ext(TaskExtImpl { proc_id: 0xdead }).is_none());
+///
+/// let task = axtask::spawn_task(inner);
+/// assert_eq!(task.task_ext().proc_id, 233);
+/// ```
+///
+/// [`TaskInner`]: crate::TaskInner
+#[macro_export]
+macro_rules! def_task_ext {
+    ($task_ext_struct:ty) => {
+        #[no_mangle]
+        static __AX_TASK_EXT_SIZE: usize = ::core::mem::size_of::<$task_ext_struct>();
+
+        #[no_mangle]
+        static __AX_TASK_EXT_ALIGN: usize = ::core::mem::align_of::<$task_ext_struct>();
+
+        impl $crate::TaskExtRef<$task_ext_struct> for $crate::TaskInner {
+            fn task_ext(&self) -> &$task_ext_struct {
+                unsafe {
+                    let ptr = self.task_ext_ptr() as *const $task_ext_struct;
+                    assert!(!ptr.is_null());
+                    &*ptr
+                }
+            }
+        }
+
+        impl $crate::TaskExtMut<$task_ext_struct> for $crate::TaskInner {
+            fn task_ext_mut(&mut self) -> &mut $task_ext_struct {
+                unsafe {
+                    let ptr = self.task_ext_ptr() as *mut $task_ext_struct;
+                    assert!(!ptr.is_null());
+                    &mut *ptr
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
Major changes to `axtask`:

1. Add a `task_ext` field to `TaskInner`, and allow users to define the specific structure via the `def_task_ext!` macro.
2. Add a `spawn_task` API with `TaskInner` as the argument.