### PR TITLE
Modify tls and aspace for arceos-monolithic

### DIFF
--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -345,7 +345,7 @@ impl TaskContext {
             self.ext_state.save();
             next_ctx.ext_state.restore();
         }
-        #[cfg(feature = "tls")]
+        #[cfg(any(feature = "tls", feature = "uspace"))]
         unsafe {
             self.fs_base = super::read_thread_pointer();
             super::write_thread_pointer(next_ctx.fs_base);

--- a/modules/axhal/src/paging.rs
+++ b/modules/axhal/src/paging.rs
@@ -79,7 +79,7 @@ pub fn set_kernel_page_table_root(root_paddr: PhysAddr) {
 ///
 /// # Panics
 ///
-/// It must be called after [`set_kernel_page_table`], otherwise it will panic.
+/// It must be called after [`set_kernel_page_table_root`], otherwise it will panic.
 pub fn kernel_page_table_root() -> PhysAddr {
     *KERNEL_PAGE_TABLE_ROOT
         .get()

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -72,9 +72,9 @@ impl AddrSpace {
     }
 
     /// Finds a free area that can accommodate the given size.
-
+    ///
     /// The search starts from the given hint address, and the area should be within the given limit range.
-
+    ///
     /// Returns the start address of the free area. Returns None if no such area is found.
     pub fn find_free_area(
         &self,

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -71,6 +71,20 @@ impl AddrSpace {
         Ok(())
     }
 
+    /// Finds a free area that can accommodate the given size.
+
+    /// The search starts from the given hint address, and the area should be within the given limit range.
+
+    /// Returns the start address of the free area. Returns None if no such area is found.
+    pub fn find_free_area(
+        &self,
+        hint: VirtAddr,
+        size: usize,
+        limit: VirtAddrRange,
+    ) -> Option<VirtAddr> {
+        self.areas.find_free_area(hint, size, limit)
+    }
+
     /// Add a new linear mapping.
     ///
     /// See [`Backend`] for more details about the mapping backends.


### PR DESCRIPTION
This PR adds some modifications for ArceOS-Monolithic support.
1. It rebases main branch to monolithic branch.
2. It saves and restores tls context under Monolithic kernel architecture.
3. It add some functions to support mmap syscall.