### PR TITLE
[CI] Modify CI and add workflow call to implement externel test

### DIFF
--- a/.github/workflows/actions/checkout/action.yml
+++ b/.github/workflows/actions/checkout/action.yml
@@ -1,0 +1,30 @@
+name: Checkout repo and patch dependencies
+
+inputs:
+  caller-package:
+    description: 'The package that triggers the external test'
+    required: true
+    type: string
+  main-repo:
+    description: 'The main repository that runs the test'
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/checkout@v4
+    if: inputs.caller-package == ''
+  - uses: actions/checkout@v4
+    if: inputs.caller-package != ''
+    with:
+      repository: ${{ inputs.main-repo }}
+      ref: ${{ github.sha }}
+  - name: Patch for the commit to be tested
+    if: inputs.caller-package != ''
+    run: |
+      cargo install dependencies-patch
+      dependencies-patch -c . \
+        -n ${{ inputs.caller-package }} \
+        -t git --git-repo ${{ github.repository }} \
+        --commit ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,21 +28,10 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
-    - uses: actions/checkout@v4
-      if: inputs.package == ''
-    - uses: actions/checkout@v4
-      if: inputs.package != ''
+    - uses: ./actions/checkout
       with:
-        repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.ref }}
-    - name: Patch for the commit to be tested
-      if: inputs.package != ''
-      run: |
-        cargo install dependencies-patch
-        dependencies-patch -c . \
-          -n ${{ inputs.package }} \
-          -t git --git-repo ${{ github.repository }} \
-          --commit ${{ github.sha }}
+        caller-package: ${{ inputs.package }}
+        main-repo: ${{ env.prj-repo }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust-toolchain }}
@@ -77,21 +66,10 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
-    - uses: actions/checkout@v4
-      if: inputs.package == ''
-    - uses: actions/checkout@v4
-      if: inputs.package != ''
+    - uses: ./actions/checkout
       with:
-        repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.ref }}
-    - name: Patch for the commit to be tested
-      if: inputs.package != ''
-      run: |
-        cargo install dependencies-patch
-        dependencies-patch -c . \
-          -n ${{ inputs.package }} \
-          -t git --git-repo ${{ github.repository }} \
-          --commit ${{ github.sha }}
+        caller-package: ${{ inputs.package }}
+        main-repo: ${{ env.prj-repo }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust-toolchain }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,22 @@
 name: Build CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_call:
+    inputs:
+      CallerPackage:
+        description: 'The package that triggers the workflow'
+        required: true
+        type: string
+      TopBranch:
+        description: 'The branch of the main repository'
+        required: false
+        default: 'main'
+        type: string
+
+env:
+  prj-repo: "arceos-org/arceos"
 
 jobs:
   clippy:
@@ -13,6 +29,20 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
     - uses: actions/checkout@v4
+      if: inputs.CallerPackage == ''
+    - uses: actions/checkout@v4
+      if: inputs.CallerPackage != ''
+      with:
+        repository: ${{ env.prj-repo }}
+        ref: ${{ inputs.TopBranch }}
+    - name: Patch for the commit to be tested
+      if: inputs.CallerPackage != ''
+      run: |
+        cargo install dependencies-patch
+        dependencies-patch -c . \
+          -n ${{ inputs.CallerPackage }} \
+          -t git --git-repo ${{ github.repository }} \
+          --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust-toolchain }}
@@ -48,6 +78,20 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
     - uses: actions/checkout@v4
+      if: inputs.CallerPackage == ''
+    - uses: actions/checkout@v4
+      if: inputs.CallerPackage != ''
+      with:
+        repository: ${{ env.prj-repo }}
+        ref: ${{ inputs.TopBranch }}
+    - name: Patch for the commit to be tested
+      if: inputs.CallerPackage != ''
+      run: |
+        cargo install dependencies-patch
+        dependencies-patch -c . \
+          -n ${{ inputs.CallerPackage }} \
+          -t git --git-repo ${{ github.repository }} \
+          --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust-toolchain }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      CallerPackage:
+      package:
         description: 'The package that triggers the workflow'
         required: true
         type: string
-      TopBranch:
+      ref:
         description: 'The branch of the main repository'
         required: false
         default: 'main'
@@ -29,18 +29,18 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage == ''
+      if: inputs.package == ''
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       with:
         repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.TopBranch }}
+        ref: ${{ inputs.ref }}
     - name: Patch for the commit to be tested
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       run: |
         cargo install dependencies-patch
         dependencies-patch -c . \
-          -n ${{ inputs.CallerPackage }} \
+          -n ${{ inputs.package }} \
           -t git --git-repo ${{ github.repository }} \
           --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
@@ -78,18 +78,18 @@ jobs:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage == ''
+      if: inputs.package == ''
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       with:
         repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.TopBranch }}
+        ref: ${{ inputs.ref }}
     - name: Patch for the commit to be tested
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       run: |
         cargo install dependencies-patch
         dependencies-patch -c . \
-          -n ${{ inputs.CallerPackage }} \
+          -n ${{ inputs.package }} \
           -t git --git-repo ${{ github.repository }} \
           --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,45 @@
 name: Test CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  workflow_call:
+    inputs:
+      CallerPackage:
+        description: 'The package that triggers the workflow'
+        required: true
+        type: string
+      TopBranch:
+        description: 'The branch of the main repository'
+        required: false
+        default: 'main'
+        type: string
 
 env:
   qemu-version: 8.2.0
   rust-toolchain: nightly-2024-05-02
   arceos-apps: 'da1caa5'
+  prj-repo: "arceos-org/arceos"
 
 jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      if: inputs.CallerPackage == ''
+    - uses: actions/checkout@v4
+      if: inputs.CallerPackage != ''
+      with:
+        repository: ${{ env.prj-repo }}
+        ref: ${{ inputs.TopBranch }}
+    - name: Patch for the commit to be tested
+      if: inputs.CallerPackage != ''
+      run: |
+        cargo install dependencies-patch
+        dependencies-patch -c . \
+          -n ${{ inputs.CallerPackage }} \
+          -t git --git-repo ${{ github.repository }} \
+          --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}
@@ -28,6 +56,20 @@ jobs:
         arch: [x86_64, riscv64, aarch64]
     steps:
     - uses: actions/checkout@v4
+      if: inputs.CallerPackage == ''
+    - uses: actions/checkout@v4
+      if: inputs.CallerPackage != ''
+      with:
+        repository: ${{ env.prj-repo }}
+        ref: ${{ inputs.TopBranch }}
+    - name: Patch for the commit to be tested
+      if: inputs.CallerPackage != ''
+      run: |
+        cargo install dependencies-patch
+        dependencies-patch -c . \
+          -n ${{ inputs.CallerPackage }} \
+          -t git --git-repo ${{ github.repository }} \
+          --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,21 +25,10 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      if: inputs.package == ''
-    - uses: actions/checkout@v4
-      if: inputs.package != ''
+    - uses: ./actions/checkout
       with:
-        repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.ref }}
-    - name: Patch for the commit to be tested
-      if: inputs.package != ''
-      run: |
-        cargo install dependencies-patch
-        dependencies-patch -c . \
-          -n ${{ inputs.package }} \
-          -t git --git-repo ${{ github.repository }} \
-          --commit ${{ github.sha }}
+        caller-package: ${{ inputs.package }}
+        main-repo: ${{ env.prj-repo }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}
@@ -55,21 +44,10 @@ jobs:
         os: [ubuntu-latest]
         arch: [x86_64, riscv64, aarch64]
     steps:
-    - uses: actions/checkout@v4
-      if: inputs.package == ''
-    - uses: actions/checkout@v4
-      if: inputs.package != ''
+    - uses: ./actions/checkout
       with:
-        repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.ref }}
-    - name: Patch for the commit to be tested
-      if: inputs.package != ''
-      run: |
-        cargo install dependencies-patch
-        dependencies-patch -c . \
-          -n ${{ inputs.package }} \
-          -t git --git-repo ${{ github.repository }} \
-          --commit ${{ github.sha }}
+        caller-package: ${{ inputs.package }}
+        main-repo: ${{ env.prj-repo }}
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,11 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      CallerPackage:
+      package:
         description: 'The package that triggers the workflow'
         required: true
         type: string
-      TopBranch:
+      ref:
         description: 'The branch of the main repository'
         required: false
         default: 'main'
@@ -26,18 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage == ''
+      if: inputs.package == ''
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       with:
         repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.TopBranch }}
+        ref: ${{ inputs.ref }}
     - name: Patch for the commit to be tested
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       run: |
         cargo install dependencies-patch
         dependencies-patch -c . \
-          -n ${{ inputs.CallerPackage }} \
+          -n ${{ inputs.package }} \
           -t git --git-repo ${{ github.repository }} \
           --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable
@@ -56,18 +56,18 @@ jobs:
         arch: [x86_64, riscv64, aarch64]
     steps:
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage == ''
+      if: inputs.package == ''
     - uses: actions/checkout@v4
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       with:
         repository: ${{ env.prj-repo }}
-        ref: ${{ inputs.TopBranch }}
+        ref: ${{ inputs.ref }}
     - name: Patch for the commit to be tested
-      if: inputs.CallerPackage != ''
+      if: inputs.package != ''
       run: |
         cargo install dependencies-patch
         dependencies-patch -c . \
-          -n ${{ inputs.CallerPackage }} \
+          -n ${{ inputs.package }} \
           -t git --git-repo ${{ github.repository }} \
           --commit ${{ github.sha }}
     - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Details about external tests can be seen https://docs.qq.com/doc/DWEVwdGNaYW5Bb1Ji.

A demo crate is https://github.com/arceos-org/kspin/tree/external_test. When it has new commits, it will triggers CI test in the main repo([arceos](https://github.com/arceos-org/arceos) here).