### PR TITLE
[feat] replace deprecated sbi_rt legacy console operations in riscv

### DIFF
--- a/api/arceos_api/src/imp/mod.rs
+++ b/api/arceos_api/src/imp/mod.rs
@@ -19,8 +19,14 @@ cfg_display! {
 mod stdio {
     use core::fmt;
 
-    pub fn ax_console_read_byte() -> Option<u8> {
-        axhal::console::getchar().map(|c| if c == b'\r' { b'\n' } else { c })
+    pub fn ax_console_read_bytes(buf: &mut [u8]) -> crate::AxResult<usize> {
+        let len = axhal::console::read_bytes(buf);
+        for c in &mut buf[..len] {
+            if *c == b'\r' {
+                *c = b'\n';
+            }
+        }
+        Ok(len)
     }
 
     pub fn ax_console_write_bytes(buf: &[u8]) -> crate::AxResult<usize> {

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -106,8 +106,8 @@ pub mod mem {
 pub mod stdio {
     use core::fmt;
     define_api! {
-        /// Reads a byte from the console, or returns [`None`] if no input is available.
-        pub fn ax_console_read_byte() -> Option<u8>;
+        /// Reads a slice of bytes from the console, returns the number of bytes written.
+        pub fn ax_console_read_bytes(buf: &mut [u8]) -> crate::AxResult<usize>;
         /// Writes a slice of bytes to the console, returns the number of bytes written.
         pub fn ax_console_write_bytes(buf: &[u8]) -> crate::AxResult<usize>;
         /// Writes a formatted string to the console.

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -60,13 +60,6 @@ pub mod paging;
 /// Console input and output.
 pub mod console {
     pub use super::platform::console::*;
-
-    /// Write a slice of bytes to the console.
-    pub fn write_bytes(bytes: &[u8]) {
-        for c in bytes {
-            putchar(*c);
-        }
-    }
 }
 
 /// Miscellaneous operation, e.g. terminate the system.

--- a/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
@@ -21,6 +21,28 @@ pub fn putchar(c: u8) {
     }
 }
 
+/// Write a slice of bytes to the console.
+pub fn write_bytes(bytes: &[u8]) {
+    for c in bytes {
+        putchar(*c);
+    }
+}
+
+/// Reads bytes from the console into the given mutable slice.
+/// Returns the number of bytes read.
+pub fn read_bytes(bytes: &mut [u8]) -> usize {
+    let mut read_len = 0;
+    while read_len < bytes.len() {
+        if let Some(c) = getchar() {
+            bytes[read_len] = c;
+        } else {
+            break;
+        }
+        read_len += 1;
+    }
+    read_len
+}
+
 /// Reads a byte from the console, or returns [`None`] if no input is available.
 pub fn getchar() -> Option<u8> {
     UART.lock().getchar()

--- a/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
+++ b/modules/axhal/src/platform/aarch64_bsta1000b/dw_apb_uart.rs
@@ -21,6 +21,11 @@ pub fn putchar(c: u8) {
     }
 }
 
+/// Reads a byte from the console, or returns [`None`] if no input is available.
+fn getchar() -> Option<u8> {
+    UART.lock().getchar()
+}
+
 /// Write a slice of bytes to the console.
 pub fn write_bytes(bytes: &[u8]) {
     for c in bytes {
@@ -41,11 +46,6 @@ pub fn read_bytes(bytes: &mut [u8]) -> usize {
         read_len += 1;
     }
     read_len
-}
-
-/// Reads a byte from the console, or returns [`None`] if no input is available.
-pub fn getchar() -> Option<u8> {
-    UART.lock().getchar()
 }
 
 /// UART simply initialize

--- a/modules/axhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/axhal/src/platform/aarch64_common/pl011.rs
@@ -23,6 +23,28 @@ pub fn putchar(c: u8) {
     }
 }
 
+/// Write a slice of bytes to the console.
+pub fn write_bytes(bytes: &[u8]) {
+    for c in bytes {
+        putchar(*c);
+    }
+}
+
+/// Reads bytes from the console into the given mutable slice.
+/// Returns the number of bytes read.
+pub fn read_bytes(bytes: &mut [u8]) -> usize {
+    let mut read_len = 0;
+    while read_len < bytes.len() {
+        if let Some(c) = getchar() {
+            bytes[read_len] = c;
+        } else {
+            break;
+        }
+        read_len += 1;
+    }
+    read_len
+}
+
 /// Reads a byte from the console, or returns [`None`] if no input is available.
 pub fn getchar() -> Option<u8> {
     UART.lock().getchar()

--- a/modules/axhal/src/platform/aarch64_common/pl011.rs
+++ b/modules/axhal/src/platform/aarch64_common/pl011.rs
@@ -23,6 +23,11 @@ pub fn putchar(c: u8) {
     }
 }
 
+/// Reads a byte from the console, or returns [`None`] if no input is available.
+fn getchar() -> Option<u8> {
+    UART.lock().getchar()
+}
+
 /// Write a slice of bytes to the console.
 pub fn write_bytes(bytes: &[u8]) {
     for c in bytes {
@@ -43,11 +48,6 @@ pub fn read_bytes(bytes: &mut [u8]) -> usize {
         read_len += 1;
     }
     read_len
-}
-
-/// Reads a byte from the console, or returns [`None`] if no input is available.
-pub fn getchar() -> Option<u8> {
-    UART.lock().getchar()
 }
 
 /// Initialize the UART

--- a/modules/axhal/src/platform/dummy/mod.rs
+++ b/modules/axhal/src/platform/dummy/mod.rs
@@ -11,6 +11,17 @@ pub mod console {
     pub fn getchar() -> Option<u8> {
         unimplemented!()
     }
+
+    /// Writes bytes to the console from input u8 slice.
+    pub fn write_bytes(_bytes: &[u8]) {
+        unimplemented!()
+    }
+
+    /// Reads bytes from the console into the given mutable slice.
+    /// Returns the number of bytes read.
+    pub fn read_bytes(_bytes: &mut [u8]) -> usize {
+        unimplemented!()
+    }
 }
 
 pub mod misc {

--- a/modules/axhal/src/platform/dummy/mod.rs
+++ b/modules/axhal/src/platform/dummy/mod.rs
@@ -2,16 +2,6 @@
 #![allow(dead_code)]
 
 pub mod console {
-    /// Writes a byte to the console.
-    pub fn putchar(c: u8) {
-        unimplemented!()
-    }
-
-    /// Reads a byte from the console, or returns [`None`] if no input is available.
-    pub fn getchar() -> Option<u8> {
-        unimplemented!()
-    }
-
     /// Writes bytes to the console from input u8 slice.
     pub fn write_bytes(_bytes: &[u8]) {
         unimplemented!()

--- a/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
@@ -2,6 +2,9 @@ use memory_addr::VirtAddr;
 
 use crate::mem::virt_to_phys;
 
+/// The maximum number of bytes that can be read at once.
+const MAX_READ_SIZE: usize = 256;
+
 /// Writes a byte to the console.
 pub fn putchar(c: u8) {
     sbi_rt::console_write_byte(c);
@@ -20,7 +23,7 @@ pub fn write_bytes(bytes: &[u8]) {
 /// Returns the number of bytes read.
 pub fn read_bytes(bytes: &mut [u8]) -> usize {
     sbi_rt::console_read(sbi_rt::Physical::new(
-        bytes.len(),
+        bytes.len().min(MAX_READ_SIZE),
         virt_to_phys(VirtAddr::from_mut_ptr_of(bytes.as_mut_ptr())).as_usize(),
         0,
     ))

--- a/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
@@ -1,5 +1,3 @@
-use core::ptr::addr_of;
-
 use memory_addr::VirtAddr;
 
 use crate::mem::virt_to_phys;
@@ -9,14 +7,22 @@ pub fn putchar(c: u8) {
     sbi_rt::console_write_byte(c);
 }
 
-/// Reads a byte from the console, or returns [`None`] if no input is available.
-pub fn getchar() -> Option<u8> {
-    let c: u8 = 0;
+/// Writes bytes to the console from input u8 slice.
+pub fn write_bytes(bytes: &[u8]) {
+    sbi_rt::console_write(sbi_rt::Physical::new(
+        bytes.len(),
+        virt_to_phys(VirtAddr::from_ptr_of(bytes.as_ptr())).as_usize(),
+        0,
+    ));
+}
+
+/// Reads bytes from the console into the given mutable slice.
+/// Returns the number of bytes read.
+pub fn read_bytes(bytes: &mut [u8]) -> usize {
     sbi_rt::console_read(sbi_rt::Physical::new(
-        1,
-        virt_to_phys(VirtAddr::from_ptr_of(addr_of!(c))).as_usize(),
+        bytes.len(),
+        virt_to_phys(VirtAddr::from_mut_ptr_of(bytes.as_mut_ptr())).as_usize(),
         0,
     ))
-    .ok()
-    .map(|_| c)
+    .value
 }

--- a/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
@@ -3,7 +3,7 @@ use memory_addr::VirtAddr;
 use crate::mem::virt_to_phys;
 
 /// The maximum number of bytes that can be read at once.
-const MAX_READ_SIZE: usize = 256;
+const MAX_RW_SIZE: usize = 256;
 
 /// Writes a byte to the console.
 pub fn putchar(c: u8) {
@@ -13,7 +13,7 @@ pub fn putchar(c: u8) {
 /// Writes bytes to the console from input u8 slice.
 pub fn write_bytes(bytes: &[u8]) {
     sbi_rt::console_write(sbi_rt::Physical::new(
-        bytes.len(),
+        bytes.len().min(MAX_RW_SIZE),
         virt_to_phys(VirtAddr::from_ptr_of(bytes.as_ptr())).as_usize(),
         0,
     ));
@@ -23,7 +23,7 @@ pub fn write_bytes(bytes: &[u8]) {
 /// Returns the number of bytes read.
 pub fn read_bytes(bytes: &mut [u8]) -> usize {
     sbi_rt::console_read(sbi_rt::Physical::new(
-        bytes.len().min(MAX_READ_SIZE),
+        bytes.len().min(MAX_RW_SIZE),
         virt_to_phys(VirtAddr::from_mut_ptr_of(bytes.as_mut_ptr())).as_usize(),
         0,
     ))

--- a/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/console.rs
@@ -1,14 +1,22 @@
+use core::ptr::addr_of;
+
+use memory_addr::VirtAddr;
+
+use crate::mem::virt_to_phys;
+
 /// Writes a byte to the console.
 pub fn putchar(c: u8) {
-    #[allow(deprecated)]
-    sbi_rt::legacy::console_putchar(c as usize);
+    sbi_rt::console_write_byte(c);
 }
 
 /// Reads a byte from the console, or returns [`None`] if no input is available.
 pub fn getchar() -> Option<u8> {
-    #[allow(deprecated)]
-    match sbi_rt::legacy::console_getchar() as isize {
-        -1 => None,
-        c => Some(c as u8),
-    }
+    let c: u8 = 0;
+    sbi_rt::console_read(sbi_rt::Physical::new(
+        1,
+        virt_to_phys(VirtAddr::from_ptr_of(addr_of!(c))).as_usize(),
+        0,
+    ))
+    .ok()
+    .map(|_| c)
 }

--- a/modules/axhal/src/platform/x86_pc/uart16550.rs
+++ b/modules/axhal/src/platform/x86_pc/uart16550.rs
@@ -84,7 +84,7 @@ impl Uart16550 {
 }
 
 /// Writes a byte to the console.
-pub fn putchar(c: u8) {
+fn putchar(c: u8) {
     let mut uart = COM1.lock();
     match c {
         b'\n' => {
@@ -96,7 +96,7 @@ pub fn putchar(c: u8) {
 }
 
 /// Reads a byte from the console, or returns [`None`] if no input is available.
-pub fn getchar() -> Option<u8> {
+fn getchar() -> Option<u8> {
     COM1.lock().getchar()
 }
 

--- a/modules/axhal/src/platform/x86_pc/uart16550.rs
+++ b/modules/axhal/src/platform/x86_pc/uart16550.rs
@@ -100,6 +100,28 @@ pub fn getchar() -> Option<u8> {
     COM1.lock().getchar()
 }
 
+/// Write a slice of bytes to the console.
+pub fn write_bytes(bytes: &[u8]) {
+    for c in bytes {
+        putchar(*c);
+    }
+}
+
+/// Reads bytes from the console into the given mutable slice.
+/// Returns the number of bytes read.
+pub fn read_bytes(bytes: &mut [u8]) -> usize {
+    let mut read_len = 0;
+    while read_len < bytes.len() {
+        if let Some(c) = getchar() {
+            bytes[read_len] = c;
+        } else {
+            break;
+        }
+        read_len += 1;
+    }
+    read_len
+}
+
 pub(super) fn init() {
     COM1.lock().init(115200);
 }

--- a/ulib/axstd/src/io/stdio.rs
+++ b/ulib/axstd/src/io/stdio.rs
@@ -12,12 +12,11 @@ impl Read for StdinRaw {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut read_len = 0;
         while read_len < buf.len() {
-            if let Some(c) = arceos_api::stdio::ax_console_read_byte() {
-                buf[read_len] = c;
-                read_len += 1;
-            } else {
+            let len = arceos_api::stdio::ax_console_read_bytes(buf[read_len..].as_mut())?;
+            if len == 0 {
                 break;
             }
+            read_len += len;
         }
         Ok(read_len)
     }


### PR DESCRIPTION
found by https://github.com/arceos-hypervisor/riscv_vcpu/pull/8

which caused https://github.com/arceos-hypervisor/arceos-umhv/actions/runs/11483702522/job/31959762361 to fail

[console_putchar](https://github.com/rustsbi/rustsbi/blob/4036e1d5abb5f8ceb9fde28658205450f685b4f8/sbi-rt/src/legacy.rs#L31) and [console_getchar](https://github.com/rustsbi/rustsbi/blob/4036e1d5abb5f8ceb9fde28658205450f685b4f8/sbi-rt/src/legacy.rs#L24)
are deprecated