### PR TITLE
[fix] add build ci for other platforms, use read_bytes for terminate of x86_64-pc-oslab

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,3 +81,63 @@ jobs:
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make ARCH=${{ matrix.arch }} A=examples/httpserver-c
 
+  build-for-other-platforms:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        rust-toolchain: [nightly, nightly-2024-05-02]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+        components: rust-src, llvm-tools
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo install cargo-binutils
+    - name: Build helloworld for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/helloworld
+    - name: Build httpclient for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpclient FEATURES=driver-ixgbe
+    - name: Build httpserver for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpserver FEATURES=driver-ixgbe
+    - name: Build shell for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/shell
+    - name: Build helloworld for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/helloworld
+    - name: Build httpclient for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpclient FEATURES=driver-ixgbe
+    - name: Build httpserver for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpserver FEATURES=driver-ixgbe
+    - name: Build shell for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/shell
+    - name: Build helloworld for aarch64-raspi4
+      run: make PLATFORM=aarch64-raspi4 A=examples/helloworld
+    - name: Build shell for aarch64-raspi4
+      run: make PLATFORM=aarch64-raspi4 A=examples/shell FEATURES=driver-bcm2835-sdhci
+    - name: Build helloworld for aarch64-bsta1000b
+      run: make PLATFORM=aarch64-bsta1000b A=examples/helloworld
+    
+    - uses: ./.github/workflows/actions/setup-musl
+      with:
+        arch: x86_64
+    - name: Build helloworld-c for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/helloworld-c
+    - name: Build httpclient-c for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpclient-c
+    - name: Build httpserver-c for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/httpserver-c
+

--- a/modules/axhal/src/platform/x86_pc/misc.rs
+++ b/modules/axhal/src/platform/x86_pc/misc.rs
@@ -9,7 +9,8 @@ pub fn terminate() -> ! {
     #[cfg(platform = "x86_64-pc-oslab")]
     {
         axlog::ax_println!("System will reboot, press any key to continue ...");
-        while super::console::getchar().is_none() {}
+        let mut buffer = [0u8; 1];
+        while super::console::read_bytes(&mut buffer) == 0 {}
         axlog::ax_println!("Rebooting ...");
         unsafe { PortWriteOnly::new(0x64).write(0xfeu8) };
     }


### PR DESCRIPTION
fix the bug introduced by https://github.com/arceos-org/arceos/pull/195

getchar is required by `x86_64-pc-oslab` platform in `modules/axhal/src/platform/x86_pc/misc.rs`

```rust
/// Shutdown the whole system (in QEMU), including all CPUs.
///
/// See <https://wiki.osdev.org/Shutdown> for more information.
pub fn terminate() -> ! {
    info!("Shutting down...");

    #[cfg(platform = "x86_64-pc-oslab")]
    {
        axlog::ax_println!("System will reboot, press any key to continue ...");
        while super::console::getchar().is_none() {}
        axlog::ax_println!("Rebooting ...");
        unsafe { PortWriteOnly::new(0x64).write(0xfeu8) };
    }
}
```

also I re-introduced `build-for-other-platforms`, because this bug is found by the ci test from arceos-apps, I think it should be the arceos itself that is responsible for it