### PR TITLE
[dockerfile] prepare toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN apt-get update \
 
 RUN cargo install cargo-binutils axconfig-gen
 
+COPY rust-toolchain.toml /rust-toolchain.toml
+
+RUN rustc --version
+
 RUN wget https://musl.cc/aarch64-linux-musl-cross.tgz \
     && wget https://musl.cc/riscv64-linux-musl-cross.tgz \
     && wget https://musl.cc/x86_64-linux-musl-cross.tgz \


### PR DESCRIPTION
Therefore, you don't need to re-download the toolchain each time you create a container.