### PR TITLE
Upgrade toolchain to nightly-2025-05-20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, clippy, rustfmt
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
     - name: Check rust version
       run: rustc --version --verbose
@@ -50,7 +50,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
     - run: cargo install cargo-binutils
     - name: Build helloworld
@@ -92,7 +92,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, llvm-tools
-        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none, aarch64-unknown-none-softfloat, loongarch64-unknown-none
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
     - run: cargo install cargo-binutils
     - name: Build helloworld for x86_64-pc-oslab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
         components: rust-src, clippy, rustfmt
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false
     - name: Check rust version
       run: rustc --version --verbose
     - name: Check code format
@@ -52,6 +54,8 @@ jobs:
         components: rust-src, llvm-tools
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false
     - run: cargo install cargo-binutils
     - name: Build helloworld
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
@@ -94,6 +98,8 @@ jobs:
         components: rust-src, llvm-tools
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false
     - run: cargo install cargo-binutils
     - name: Build helloworld for x86_64-pc-oslab
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, riscv64, aarch64, loongarch64]
-        rust-toolchain: [nightly, nightly-2024-12-25]
+        rust-toolchain: [nightly, nightly-2025-05-20]
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
@@ -41,7 +41,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [x86_64, riscv64, aarch64, loongarch64]
-        rust-toolchain: [nightly, nightly-2024-12-25]
+        rust-toolchain: [nightly, nightly-2025-05-20]
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
@@ -85,7 +85,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust-toolchain: [nightly, nightly-2024-12-25]
+        rust-toolchain: [nightly, nightly-2025-05-20]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,8 @@ jobs:
       with:
         toolchain: ${{ env.rust-toolchain }}
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false
     - name: Build docs
       continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: make doc_check_missing

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build & Deploy docs
 on: [push, pull_request]
 
 env:
-  rust-toolchain: nightly-2024-12-25
+  rust-toolchain: nightly-2025-05-20
 
 jobs:
   doc:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       with:
         toolchain: ${{ env.rust-toolchain }}
         components: rust-src
-    - uses: Swatinem/rust-cache@v2
     - name: Run unit tests
       run: make unittest_no_fail_fast
 
@@ -34,6 +33,8 @@ jobs:
         toolchain: ${{ env.rust-toolchain }}
         components: rust-src
     - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: false
     - run: cargo install cargo-binutils
     - uses: ./.github/workflows/actions/setup-qemu
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   qemu-version: 9.2.1
-  rust-toolchain: nightly-2024-12-25
+  rust-toolchain: nightly-2025-05-20
   arceos-apps: 'c8d8fe4'
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2314ebe07a2fef7b1c1a7d15ab817941cd306ace651bb50024b5a8b3e8485359"
 dependencies = [
  "axerrno",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
 ]
 
@@ -459,7 +459,7 @@ dependencies = [
  "axalloc",
  "axconfig",
  "axlog",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "dw_apb_uart",
  "handler_table",
@@ -475,8 +475,8 @@ dependencies = [
  "page_table_entry",
  "page_table_multiarch",
  "percpu",
- "raw-cpuid 11.4.0",
- "riscv",
+ "raw-cpuid 11.5.0",
+ "riscv 0.13.0",
  "riscv_goldfish",
  "sbi-rt",
  "static_assertions",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "axio"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ca9c10ea4cd42bda87a2abde281fb481c76a0b05976fd03697385ea65d5122"
+checksum = "30aa258a37c25c5e9d3ff45ec80e728ff7c499586e3e40719daf7908f10fd5bd"
 dependencies = [
  "axerrno",
 ]
@@ -643,16 +643,14 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -661,7 +659,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.98",
- "which",
 ]
 
 [[package]]
@@ -684,9 +681,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitmap-allocator"
@@ -727,7 +724,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b24894fa5f73bbf9c72196e7f495a1f81d6218a548280a09ada4a937157692"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -756,9 +753,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -949,29 +946,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "fatfs"
 version = "0.4.0"
 source = "git+https://github.com/rafalh/rust-fatfs?rev=85f06e0#85f06e08edbd3368e1b0562f2fc1b6d178bf7b8a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
 ]
 
 [[package]]
 name = "flatten_objects"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a44a8ee8095192119780ad867a02cfb86c44f3cebd16b7161d84e1fb8e26482"
+checksum = "e362dae0b64fc12551b655a09484a643461a283a078fb8a9686d1f58fa46df9a"
 dependencies = [
  "bitmaps",
 ]
@@ -988,12 +975,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
 ]
 
@@ -1042,15 +1030,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -1158,12 +1137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lazyinit"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,29 +1165,23 @@ source = "git+https://github.com/arceos-org/linked_list.git?tag=v0.1.0#34c8db301
 
 [[package]]
 name = "linkme"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566336154b9e58a4f055f6dd4cbab62c7dc0826ce3c0a04e63b2d2ecd784cdae"
+checksum = "a1b1703c00b2a6a70738920544aa51652532cacddfec2e162d2e29eae01e665c"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
+checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -1234,12 +1201,12 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "loongArch64"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd48200d465466664e4e899b204b77b5447d60b1ababdad3a2c49ae85417b552"
+checksum = "7c9f0d275c70310e2a9d2fc23250c5ac826a73fa828a5f256401f85c5c554283"
 dependencies = [
  "bit_field",
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1256,15 +1223,15 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
+checksum = "5438b8df0f13e16e1f46140de247695a95952a5a4479e47197a8711bf1063373"
 
 [[package]]
 name = "memory_set"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335675b7ab07460f532d3b2b557313be73037fdf81b65464d8c0d8bd90d2fbf9"
+checksum = "a4552d02c866c57e8b06b919ea8c2f8f398cad245b8f6aac726657bc972d663d"
 dependencies = [
  "memory_addr",
 ]
@@ -1287,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "ns16550a"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667fbdfccff4775918606516ff6ca51b898ac0842c4bc41c960a55a9832545a6"
+checksum = "e3cd8abe9e54bce27659507b94f355c9334378ab15da332b6986b3583ebf7228"
 
 [[package]]
 name = "num-traits"
@@ -1313,7 +1280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c097d641745a066856a26eed6e486d4430bb3e32c94f1203ea09c63239b360a0"
 dependencies = [
  "aarch64-cpu 10.0.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "memory_addr",
  "x86_64 0.15.2",
 ]
@@ -1327,7 +1294,7 @@ dependencies = [
  "log",
  "memory_addr",
  "page_table_entry",
- "riscv",
+ "riscv 0.12.1",
  "x86",
 ]
 
@@ -1421,21 +1388,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1443,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
 ]
@@ -1461,11 +1433,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.4.0"
+version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529468c1335c1c03919960dfefdb1b3648858c20d7ec2d0663e728e4a717efbc"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1506,15 +1478,27 @@ dependencies = [
  "critical-section",
  "embedded-hal",
  "paste",
+ "riscv-pac",
+]
+
+[[package]]
+name = "riscv"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa3cdbeccae4359f6839a00e8b77e5736caa200ba216caf38d24e4c16e2b586"
+dependencies = [
+ "critical-section",
+ "embedded-hal",
+ "paste",
  "riscv-macros",
  "riscv-pac",
 ]
 
 [[package]]
 name = "riscv-macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
+checksum = "e8c4aa1ea1af6dcc83a61be12e8189f9b293c3ba5a487778a4cd89fb060fdbbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1547,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1558,19 +1542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.8.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
 ]
 
 [[package]]
@@ -1783,7 +1754,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa40e09453618c7a927c08c5a990497a2954da7c2aaa6c65e0d4f0fc975f6114"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "log",
  "zerocopy",
 ]
@@ -1808,9 +1779,12 @@ checksum = "442887c63f2c839b346c192d047a7c87e73d0689c9157b00b53dcc27dd5ea793"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1868,18 +1842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]
@@ -1980,6 +1942,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "x2apic"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
 dependencies = [
  "bit_field",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile 0.4.6",
 ]
@@ -2022,7 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f042214de98141e9c8706e8192b73f56494087cc55ebec28ce10f26c5c364ae"
 dependencies = [
  "bit_field",
- "bitflags 2.8.0",
+ "bitflags 2.9.1",
  "rustversion",
  "volatile 0.4.6",
 ]

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,11 @@ else ifeq ($(ARCH), aarch64)
 else ifeq ($(ARCH), riscv64)
   TARGET := riscv64gc-unknown-none-elf
 else ifeq ($(ARCH), loongarch64)
-  TARGET := loongarch64-unknown-none
+  ifeq ($(findstring fp_simd,$(FEATURES)),)
+    TARGET := loongarch64-unknown-none-softfloat
+  else
+    TARGET := loongarch64-unknown-none
+  endif
 else
   $(error "ARCH" must be one of "x86_64", "riscv64", "aarch64" or "loongarch64")
 endif

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -55,4 +55,4 @@ lazy_static = { version = "1.5", features = ["spin_no_std"] }
 ctor_bare = "0.2"
 
 [build-dependencies]
-bindgen ={ version = "0.69" }
+bindgen ={ version = "0.71" }

--- a/api/arceos_posix_api/build.rs
+++ b/api/arceos_posix_api/build.rs
@@ -76,11 +76,12 @@ typedef struct {{
         impl bindgen::callbacks::ParseCallbacks for MyCallbacks {
             fn include_file(&self, fname: &str) {
                 if !fname.contains("ax_pthread_mutex.h") {
-                    println!("cargo:rerun-if-changed={}", fname);
+                    println!("cargo:rerun-if-changed={fname}");
                 }
             }
         }
 
+        let target = std::env::var("TARGET").unwrap();
         let mut builder = bindgen::Builder::default()
             .header(in_file)
             .clang_arg("-I./../../ulib/axlibc/include")
@@ -88,6 +89,10 @@ typedef struct {{
             .derive_default(true)
             .size_t_is_usize(false)
             .use_core();
+        if let Some(llvm_target) = target.strip_suffix("-softfloat") {
+            // remove "-softfloat" suffix for some targets
+            builder = builder.clang_arg(format!("--target={llvm_target}"));
+        }
         for ty in allow_types {
             builder = builder.allowlist_type(ty);
         }

--- a/modules/axconfig/build.rs
+++ b/modules/axconfig/build.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 fn main() {
     println!("cargo:rerun-if-env-changed=AX_CONFIG_PATH");
     if let Ok(config_path) = std::env::var("AX_CONFIG_PATH") {
-        println!("cargo:rerun-if-changed={}", config_path);
+        println!("cargo:rerun-if-changed={config_path}");
     } else {
         let root_path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         let dummy_config = Path::new(&root_path).join("../../configs/dummy.toml");

--- a/modules/axdriver/build.rs
+++ b/modules/axdriver/build.rs
@@ -5,7 +5,7 @@ const DISPLAY_DEV_FEATURES: &[&str] = &["virtio-gpu"];
 fn make_cfg_values(str_list: &[&str]) -> String {
     str_list
         .iter()
-        .map(|s| format!("{:?}", s))
+        .map(|s| format!("{s:?}"))
         .collect::<Vec<_>>()
         .join(", ")
 }

--- a/modules/axdriver/src/lib.rs
+++ b/modules/axdriver/src/lib.rs
@@ -40,12 +40,12 @@
 //! - `dyn`: use the dynamic device model (see above).
 //! - `bus-mmio`: use device tree to probe all MMIO devices.
 //! - `bus-pci`: use PCI bus to probe all PCI devices. This feature is
-//!    enabeld by default.
+//!   enabled by default.
 //! - `virtio`: use VirtIO devices. This is enabled if any of `virtio-blk`,
 //!   `virtio-net` or `virtio-gpu` is enabled.
 //! - `net`: use network devices. This is enabled if any feature of network
-//!    devices is selected. If this feature is enabled without any network device
-//!    features, a dummy struct is used for [`AxNetDevice`].
+//!   devices is selected. If this feature is enabled without any network device
+//!   features, a dummy struct is used for [`AxNetDevice`].
 //! - `block`: use block storage devices. Similar to the `net` feature.
 //! - `display`: use graphics display devices. Similar to the `net` feature.
 //!

--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -82,19 +82,18 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         let base_vaddr = phys_to_virt(mmio_base.into());
         if let Some((ty, transport)) =
             axdriver_virtio::probe_mmio_device(base_vaddr.as_mut_ptr(), mmio_size)
+            && ty == D::DEVICE_TYPE
         {
-            if ty == D::DEVICE_TYPE {
-                match D::try_new(transport) {
-                    Ok(dev) => return Some(dev),
-                    Err(e) => {
-                        warn!(
-                            "failed to initialize MMIO device at [PA:{:#x}, PA:{:#x}): {:?}",
-                            mmio_base,
-                            mmio_base + mmio_size,
-                            e
-                        );
-                        return None;
-                    }
+            match D::try_new(transport) {
+                Ok(dev) => return Some(dev),
+                Err(e) => {
+                    warn!(
+                        "failed to initialize MMIO device at [PA:{:#x}, PA:{:#x}): {:?}",
+                        mmio_base,
+                        mmio_base + mmio_size,
+                        e
+                    );
+                    return None;
                 }
             }
         }

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -5,16 +5,16 @@
 //! # Cargo Features
 //!
 //! - `fatfs`: Use [FAT] as the main filesystem and mount it on `/`. This feature
-//!    is **enabled** by default.
+//!   is **enabled** by default.
 //! - `devfs`: Mount [`axfs_devfs::DeviceFileSystem`] on `/dev`. This feature is
-//!    **enabled** by default.
+//!   **enabled** by default.
 //! - `ramfs`: Mount [`axfs_ramfs::RamFileSystem`] on `/tmp`. This feature is
-//!    **enabled** by default.
+//!   **enabled** by default.
 //! - `myfs`: Allow users to define their custom filesystems to override the
-//!    default. In this case, [`MyFileSystemIf`] is required to be implemented
-//!    to create and initialize other filesystems. This feature is **disabled** by
-//!    by default, but it will override other filesystem selection features if
-//!    both are enabled.
+//!   default. In this case, [`MyFileSystemIf`] is required to be implemented
+//!   to create and initialize other filesystems. This feature is **disabled** by
+//!   by default, but it will override other filesystem selection features if
+//!   both are enabled.
 //!
 //! [FAT]: https://en.wikipedia.org/wiki/File_Allocation_Table
 //! [`MyFileSystemIf`]: fops::MyFileSystemIf

--- a/modules/axhal/Cargo.toml
+++ b/modules/axhal/Cargo.toml
@@ -23,8 +23,8 @@ default = []
 [dependencies]
 log = "=0.4.21"
 cfg-if = "1.0"
-linkme = "0.3.31"
-bitflags = "2.8"
+linkme = "0.3.33"
+bitflags = "2.9"
 static_assertions = "1.1.0"
 kernel_guard = "0.1"
 kspin = "0.1"
@@ -43,11 +43,11 @@ axalloc = { workspace = true, optional = true }
 x86 = "0.52"
 x86_64 = "0.15"
 x2apic = "0.4"
-raw-cpuid = "11.3"
+raw-cpuid = "11.5"
 x86_rtc = { version = "0.1", optional = true }
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
-riscv = "0.12"
+riscv = "0.13"
 sbi-rt = { version = "0.0.3", features = ["legacy"] }
 riscv_goldfish = { version = "0.1", optional = true }
 
@@ -60,8 +60,8 @@ arm_pl031 = { version = "0.2", optional = true }
 dw_apb_uart = "0.1"
 
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
-loongArch64 = "0.2.4"
-ns16550a = "0.4.0"
+loongArch64 = "0.2.5"
+ns16550a = "0.5.0"
 
 [build-dependencies]
 axconfig = { workspace = true }

--- a/modules/axhal/build.rs
+++ b/modules/axhal/build.rs
@@ -24,7 +24,7 @@ const BUILTIN_PLATFORM_FAMILIES: &[&str] = &[
 fn make_cfg_values(str_list: &[&str]) -> String {
     str_list
         .iter()
-        .map(|s| format!("{:?}", s))
+        .map(|s| format!("{s:?}"))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -36,7 +36,7 @@ fn main() {
         gen_linker_script(&arch, platform).unwrap();
     }
 
-    println!("cargo:rustc-cfg=platform=\"{}\"", platform);
+    println!("cargo:rustc-cfg=platform=\"{platform}\"");
     println!(
         "cargo:rustc-cfg=platform_family=\"{}\"",
         axconfig::plat::FAMILY
@@ -52,7 +52,7 @@ fn main() {
 }
 
 fn gen_linker_script(arch: &str, platform: &str) -> Result<()> {
-    let fname = format!("linker_{}.lds", platform);
+    let fname = format!("linker_{platform}.lds");
     let output_arch = if arch == "x86_64" {
         "i386:x86-64"
     } else if arch.contains("riscv") {

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -259,7 +259,7 @@ impl TaskContext {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
         "
@@ -289,7 +289,7 @@ unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task:
     )
 }
 
-#[naked]
+#[unsafe(naked)]
 #[cfg(feature = "fp_simd")]
 unsafe extern "C" fn fpstate_switch(_current_fpstate: &mut FpState, _next_fpstate: &FpState) {
     naked_asm!(

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -250,41 +250,39 @@ impl TaskContext {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task: &TaskContext) {
-    unsafe {
-        naked_asm!(
-            include_asm_macros!(),
-            "
-            // save old context (callee-saved registers)
-            STD     $ra, $a0, 0
-            STD     $sp, $a0, 1
-            STD     $s0, $a0, 2
-            STD     $s1, $a0, 3
-            STD     $s2, $a0, 4
-            STD     $s3, $a0, 5
-            STD     $s4, $a0, 6
-            STD     $s5, $a0, 7
-            STD     $s6, $a0, 8
-            STD     $s7, $a0, 9
-            STD     $s8, $a0, 10
-            STD     $fp, $a0, 11
+    naked_asm!(
+        include_asm_macros!(),
+        "
+        // save old context (callee-saved registers)
+        STD     $ra, $a0, 0
+        STD     $sp, $a0, 1
+        STD     $s0, $a0, 2
+        STD     $s1, $a0, 3
+        STD     $s2, $a0, 4
+        STD     $s3, $a0, 5
+        STD     $s4, $a0, 6
+        STD     $s5, $a0, 7
+        STD     $s6, $a0, 8
+        STD     $s7, $a0, 9
+        STD     $s8, $a0, 10
+        STD     $fp, $a0, 11
 
-            // restore new context
-            LDD     $fp, $a1, 11
-            LDD     $s8, $a1, 10
-            LDD     $s7, $a1, 9
-            LDD     $s6, $a1, 8
-            LDD     $s5, $a1, 7
-            LDD     $s4, $a1, 6
-            LDD     $s3, $a1, 5
-            LDD     $s2, $a1, 4
-            LDD     $s1, $a1, 3
-            LDD     $s0, $a1, 2
-            LDD     $sp, $a1, 1
-            LDD     $ra, $a1, 0
+        // restore new context
+        LDD     $fp, $a1, 11
+        LDD     $s8, $a1, 10
+        LDD     $s7, $a1, 9
+        LDD     $s6, $a1, 8
+        LDD     $s5, $a1, 7
+        LDD     $s4, $a1, 6
+        LDD     $s3, $a1, 5
+        LDD     $s2, $a1, 4
+        LDD     $s1, $a1, 3
+        LDD     $s0, $a1, 2
+        LDD     $sp, $a1, 1
+        LDD     $ra, $a1, 0
 
-            ret",
-        )
-    }
+        ret",
+    )
 }

--- a/modules/axhal/src/arch/loongarch64/mod.rs
+++ b/modules/axhal/src/arch/loongarch64/mod.rs
@@ -204,6 +204,8 @@ pub unsafe fn write_thread_pointer(tp: usize) {
 pub fn cpu_init() {
     #[cfg(feature = "fp_simd")]
     loongArch64::register::euen::set_fpe(true);
+    #[cfg(feature = "fp_simd")]
+    loongArch64::register::euen::set_sxe(true);
 
     unsafe extern "C" {
         fn exception_entry_base();

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -281,7 +281,7 @@ impl TaskContext {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     naked_asm!(
         include_asm_macros!(),

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -73,19 +73,20 @@ pub unsafe fn write_page_table_root(root_paddr: PhysAddr) {
 /// entry that maps the given virtual address.
 #[inline]
 pub fn flush_tlb(vaddr: Option<VirtAddr>) {
-    unsafe {
-        if let Some(vaddr) = vaddr {
-            asm::sfence_vma(0, vaddr.as_usize())
-        } else {
-            asm::sfence_vma_all();
-        }
+    if let Some(vaddr) = vaddr {
+        asm::sfence_vma(0, vaddr.as_usize())
+    } else {
+        asm::sfence_vma_all();
     }
 }
 
 /// Writes Supervisor Trap Vector Base Address Register (`stvec`).
 #[inline]
 pub fn set_trap_vector_base(stvec: usize) {
-    unsafe { stvec::write(stvec, stvec::TrapMode::Direct) }
+    let mut reg = stvec::read();
+    reg.set_address(stvec);
+    reg.set_trap_mode(stvec::TrapMode::Direct);
+    unsafe { stvec::write(reg) }
 }
 
 /// Reads the thread pointer of the current CPU.

--- a/modules/axhal/src/arch/x86_64/context.rs
+++ b/modules/axhal/src/arch/x86_64/context.rs
@@ -315,10 +315,13 @@ impl TaskContext {
             // is executed), (stack pointer + 8) should be 16-byte aligned.
             let frame_ptr = (kstack_top.as_mut_ptr() as *mut u64).sub(1);
             let frame_ptr = (frame_ptr as *mut ContextSwitchFrame).sub(1);
-            core::ptr::write(frame_ptr, ContextSwitchFrame {
-                rip: entry as _,
-                ..Default::default()
-            });
+            core::ptr::write(
+                frame_ptr,
+                ContextSwitchFrame {
+                    rip: entry as _,
+                    ..Default::default()
+                },
+            );
             self.rsp = frame_ptr as u64;
         }
         self.kstack_top = kstack_top;
@@ -365,28 +368,26 @@ impl TaskContext {
     }
 }
 
-#[naked]
+#[unsafe(naked)]
 unsafe extern "C" fn context_switch(_current_stack: &mut u64, _next_stack: &u64) {
-    unsafe {
-        naked_asm!(
-            "
-            .code64
-            push    rbp
-            push    rbx
-            push    r12
-            push    r13
-            push    r14
-            push    r15
-            mov     [rdi], rsp
+    naked_asm!(
+        "
+        .code64
+        push    rbp
+        push    rbx
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+        mov     [rdi], rsp
 
-            mov     rsp, [rsi]
-            pop     r15
-            pop     r14
-            pop     r13
-            pop     r12
-            pop     rbx
-            pop     rbp
-            ret",
-        )
-    }
+        mov     rsp, [rsi]
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbx
+        pop     rbp
+        ret",
+    )
 }

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -11,8 +11,8 @@
 //! - `aarch64-qemu-virt`: QEMU virt machine with AArch64 ISA.
 //! - `aarch64-raspi`: Raspberry Pi with AArch64 ISA.
 //! - `dummy`: If none of the above platform is selected, the dummy platform
-//!    will be used. In this platform, most of the operations are no-op or
-//!    `unimplemented!()`. This platform is mainly used for [cargo test].
+//!   will be used. In this platform, most of the operations are no-op or
+//!   `unimplemented!()`. This platform is mainly used for [cargo test].
 //!
 //! # Cargo Features
 //!
@@ -25,7 +25,6 @@
 //! [cargo test]: https://doc.rust-lang.org/cargo/guide/tests.html
 
 #![no_std]
-#![feature(naked_functions)]
 #![feature(doc_auto_cfg)]
 #![feature(sync_unsafe_cell)]
 

--- a/modules/axhal/src/platform/aarch64_common/boot.rs
+++ b/modules/axhal/src/platform/aarch64_common/boot.rs
@@ -112,99 +112,93 @@ unsafe fn init_boot_page_table() {
 /// kernel image.
 ///
 /// Documentation: <https://docs.kernel.org/arch/arm64/booting.html>
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn _start() -> ! {
-    unsafe {
-        // PC = bootloader load address
-        // X0 = dtb
-        core::arch::naked_asm!("
-            add     x13, x18, #0x16     // 'MZ' magic
-            b       {entry}             // Branch to kernel start, magic
+    // PC = bootloader load address
+    // X0 = dtb
+    core::arch::naked_asm!("
+        add     x13, x18, #0x16     // 'MZ' magic
+        b       {entry}             // Branch to kernel start, magic
 
-            .quad   0                   // Image load offset from start of RAM, little-endian
-            .quad   _ekernel - _start   // Effective size of kernel image, little-endian
-            .quad   {flags}             // Kernel flags, little-endian
-            .quad   0                   // reserved
-            .quad   0                   // reserved
-            .quad   0                   // reserved
-            .ascii  \"ARM\\x64\"        // Magic number
-            .long   0                   // reserved (used for PE COFF offset)",
-            flags = const FLAG_LE | FLAG_PAGE_SIZE_4K | FLAG_ANY_MEM,
-            entry = sym _start_primary,
-        )
-    }
+        .quad   0                   // Image load offset from start of RAM, little-endian
+        .quad   _ekernel - _start   // Effective size of kernel image, little-endian
+        .quad   {flags}             // Kernel flags, little-endian
+        .quad   0                   // reserved
+        .quad   0                   // reserved
+        .quad   0                   // reserved
+        .ascii  \"ARM\\x64\"        // Magic number
+        .long   0                   // reserved (used for PE COFF offset)",
+        flags = const FLAG_LE | FLAG_PAGE_SIZE_4K | FLAG_ANY_MEM,
+        entry = sym _start_primary,
+    )
 }
 
 /// The earliest entry point for the primary CPU.
-#[naked]
+#[unsafe(naked)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn _start_primary() -> ! {
-    unsafe {
-        // X0 = dtb
-        core::arch::naked_asm!("
-            mrs     x19, mpidr_el1
-            and     x19, x19, #0xffffff     // get current CPU id
-            mov     x20, x0                 // save DTB pointer
+    // X0 = dtb
+    core::arch::naked_asm!("
+        mrs     x19, mpidr_el1
+        and     x19, x19, #0xffffff     // get current CPU id
+        mov     x20, x0                 // save DTB pointer
 
-            adrp    x8, {boot_stack}        // setup boot stack
-            add     x8, x8, {boot_stack_size}
-            mov     sp, x8
+        adrp    x8, {boot_stack}        // setup boot stack
+        add     x8, x8, {boot_stack_size}
+        mov     sp, x8
 
-            bl      {switch_to_el1}         // switch to EL1
-            bl      {enable_fp}             // enable fp/neon
-            bl      {init_boot_page_table}
-            bl      {init_mmu}              // setup MMU
+        bl      {switch_to_el1}         // switch to EL1
+        bl      {enable_fp}             // enable fp/neon
+        bl      {init_boot_page_table}
+        bl      {init_mmu}              // setup MMU
 
-            mov     x8, {phys_virt_offset}  // set SP to the high address
-            add     sp, sp, x8
+        mov     x8, {phys_virt_offset}  // set SP to the high address
+        add     sp, sp, x8
 
-            mov     x0, x19                 // call rust_entry(cpu_id, dtb)
-            mov     x1, x20
-            ldr     x8, ={entry}
-            blr     x8
-            b      .",
-            switch_to_el1 = sym switch_to_el1,
-            init_boot_page_table = sym init_boot_page_table,
-            init_mmu = sym init_mmu,
-            enable_fp = sym enable_fp,
-            boot_stack = sym BOOT_STACK,
-            boot_stack_size = const TASK_STACK_SIZE,
-            phys_virt_offset = const PHYS_VIRT_OFFSET,
-            entry = sym crate::platform::rust_entry,
-        )
-    }
+        mov     x0, x19                 // call rust_entry(cpu_id, dtb)
+        mov     x1, x20
+        ldr     x8, ={entry}
+        blr     x8
+        b      .",
+        switch_to_el1 = sym switch_to_el1,
+        init_boot_page_table = sym init_boot_page_table,
+        init_mmu = sym init_mmu,
+        enable_fp = sym enable_fp,
+        boot_stack = sym BOOT_STACK,
+        boot_stack_size = const TASK_STACK_SIZE,
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        entry = sym crate::platform::rust_entry,
+    )
 }
 
 /// The earliest entry point for the secondary CPUs.
 #[cfg(feature = "smp")]
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn _start_secondary() -> ! {
-    unsafe {
-        core::arch::naked_asm!("
-            mrs     x19, mpidr_el1
-            and     x19, x19, #0xffffff     // get current CPU id
+    core::arch::naked_asm!("
+        mrs     x19, mpidr_el1
+        and     x19, x19, #0xffffff     // get current CPU id
 
-            mov     sp, x0
-            bl      {switch_to_el1}
-            bl      {init_mmu}
-            bl      {enable_fp}
+        mov     sp, x0
+        bl      {switch_to_el1}
+        bl      {init_mmu}
+        bl      {enable_fp}
 
-            mov     x8, {phys_virt_offset}  // set SP to the high address
-            add     sp, sp, x8
+        mov     x8, {phys_virt_offset}  // set SP to the high address
+        add     sp, sp, x8
 
-            mov     x0, x19                 // call rust_entry_secondary(cpu_id)
-            ldr     x8, ={entry}
-            blr     x8
-            b      .",
-            switch_to_el1 = sym switch_to_el1,
-            init_mmu = sym init_mmu,
-            enable_fp = sym enable_fp,
-            phys_virt_offset = const PHYS_VIRT_OFFSET,
-            entry = sym crate::platform::rust_entry_secondary,
-        )
-    }
+        mov     x0, x19                 // call rust_entry_secondary(cpu_id)
+        ldr     x8, ={entry}
+        blr     x8
+        b      .",
+        switch_to_el1 = sym switch_to_el1,
+        init_mmu = sym init_mmu,
+        enable_fp = sym enable_fp,
+        phys_virt_offset = const PHYS_VIRT_OFFSET,
+        entry = sym crate::platform::rust_entry_secondary,
+    )
 }

--- a/modules/axhal/src/platform/aarch64_raspi/mp.rs
+++ b/modules/axhal/src/platform/aarch64_raspi/mp.rs
@@ -6,7 +6,7 @@ unsafe extern "C" {
     fn _start_secondary();
 }
 
-#[naked]
+#[unsafe(naked)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn modify_stack_and_start() {
     core::arch::naked_asm!("

--- a/modules/axhal/src/platform/riscv64_qemu_virt/boot.rs
+++ b/modules/axhal/src/platform/riscv64_qemu_virt/boot.rs
@@ -27,7 +27,7 @@ unsafe fn init_mmu() {
 }
 
 /// The earliest entry point for the primary CPU.
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn _start() -> ! {
@@ -64,7 +64,7 @@ unsafe extern "C" fn _start() -> ! {
 
 /// The earliest entry point for secondary CPUs.
 #[cfg(feature = "smp")]
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = ".text.boot")]
 unsafe extern "C" fn _start_secondary() -> ! {

--- a/modules/axhal/src/platform/x86_pc/time.rs
+++ b/modules/axhal/src/platform/x86_pc/time.rs
@@ -57,11 +57,10 @@ pub(super) fn init_early() {
     if let Some(freq) = CpuId::new()
         .get_processor_frequency_info()
         .map(|info| info.processor_base_frequency())
+        && freq > 0
     {
-        if freq > 0 {
-            axlog::ax_println!("Got TSC frequency by CPUID: {} MHz", freq);
-            unsafe { CPU_FREQ_MHZ = freq as u64 }
-        }
+        axlog::ax_println!("Got TSC frequency by CPUID: {} MHz", freq);
+        unsafe { CPU_FREQ_MHZ = freq as u64 }
     }
 
     unsafe {

--- a/modules/axsync/Cargo.toml
+++ b/modules/axsync/Cargo.toml
@@ -18,6 +18,6 @@ kspin = "0.1"
 axtask = { workspace = true }
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.9"
 axsync = { workspace = true, features = ["multitask"] }
 axtask = { workspace = true, features = ["test"] }

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -51,6 +51,6 @@ cpumask = { version = "0.1", optional = true }
 scheduler = { git = "https://github.com/arceos-org/scheduler.git", tag = "v0.1.0", optional = true }
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.9"
 axhal = { workspace = true, features = ["fp_simd"] }
 axtask = { workspace = true, features = ["test", "multitask"] }

--- a/modules/axtask/src/lib.rs
+++ b/modules/axtask/src/lib.rs
@@ -10,8 +10,8 @@
 //!   management and scheduling is used, as well as more task-related APIs.
 //!   Otherwise, only a few APIs with naive implementation is available.
 //! - `irq`: Interrupts are enabled. If this feature is enabled, timer-based
-//!    APIs can be used, such as [`sleep`], [`sleep_until`], and
-//!    [`WaitQueue::wait_timeout`].
+//!   APIs can be used, such as [`sleep`], [`sleep_until`], and
+//!   [`WaitQueue::wait_timeout`].
 //! - `preempt`: Enable preemptive scheduling.
 //! - `sched_fifo`: Use the [FIFO cooperative scheduler][1]. It also enables the
 //!   `multitask` feature if it is enabled. This feature is enabled by default,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 profile = "minimal"
-channel = "nightly-2024-12-25"
+channel = "nightly-2025-05-20"
 components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-none",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,4 +8,5 @@ targets = [
     "aarch64-unknown-none",
     "aarch64-unknown-none-softfloat",
     "loongarch64-unknown-none",
+    "loongarch64-unknown-none-softfloat",
 ]

--- a/scripts/make/build_c.mk
+++ b/scripts/make/build_c.mk
@@ -34,6 +34,8 @@ ifeq ($(findstring fp_simd,$(FEATURES)),)
     CFLAGS += -mno-sse
   else ifeq ($(ARCH), aarch64)
     CFLAGS += -mgeneral-regs-only
+  else ifeq ($(ARCH), loongarch64)
+    CFLAGS += -msoft-float
   endif
 else
   ifneq ($(filter $(ARCH),riscv64 aarch64),)

--- a/ulib/axlibc/Cargo.toml
+++ b/ulib/axlibc/Cargo.toml
@@ -57,4 +57,4 @@ axio = "0.1"
 axerrno = "0.1"
 
 [build-dependencies]
-bindgen ={ version = "0.69" }
+bindgen ={ version = "0.71" }

--- a/ulib/axlibc/build.rs
+++ b/ulib/axlibc/build.rs
@@ -2,6 +2,7 @@ fn main() {
     fn gen_c_to_rust_bindings(in_file: &str, out_file: &str) {
         println!("cargo:rerun-if-changed={in_file}");
 
+        let target = std::env::var("TARGET").unwrap();
         let allow_types = ["tm", "jmp_buf"];
         let mut builder = bindgen::Builder::default()
             .header(in_file)
@@ -9,6 +10,10 @@ fn main() {
             .derive_default(true)
             .size_t_is_usize(false)
             .use_core();
+        if let Some(llvm_target) = target.strip_suffix("-softfloat") {
+            // remove "-softfloat" suffix for some targets
+            builder = builder.clang_arg(format!("--target={llvm_target}"));
+        }
         for ty in allow_types {
             builder = builder.allowlist_type(ty);
         }

--- a/ulib/axlibc/src/lib.rs
+++ b/ulib/axlibc/src/lib.rs
@@ -28,7 +28,6 @@
 #![cfg_attr(all(not(test), not(doc)), no_std)]
 #![feature(doc_cfg)]
 #![feature(doc_auto_cfg)]
-#![feature(naked_functions)]
 #![feature(thread_local)]
 #![allow(clippy::missing_safety_doc)]
 

--- a/ulib/axlibc/src/setjmp.rs
+++ b/ulib/axlibc/src/setjmp.rs
@@ -3,7 +3,7 @@ use core::ffi::c_int;
 use crate::ctypes;
 
 /// `setjmp` implementation
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
     #[cfg(all(target_arch = "aarch64", feature = "fp_simd"))]
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
 }
 
 /// `longjmp` implementation
-#[naked]
+#[unsafe(naked)]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn longjmp(_buf: *mut ctypes::__jmp_buf_tag, _val: c_int) -> ! {
     #[cfg(all(target_arch = "aarch64", feature = "fp_simd"))]

--- a/ulib/axstd/src/sync/mutex.rs
+++ b/ulib/axstd/src/sync/mutex.rs
@@ -83,8 +83,7 @@ impl<T: ?Sized> Mutex<T> {
                 Err(owner_id) => {
                     assert_ne!(
                         owner_id, current_id,
-                        "Thread({}) tried to acquire mutex it already owns.",
-                        current_id,
+                        "Thread({current_id}) tried to acquire mutex it already owns.",
                     );
                     // Wait until the lock looks unlocked before retrying
                     api::ax_wait_queue_wait_until(&self.wq, || !self.is_locked(), None);
@@ -129,8 +128,7 @@ impl<T: ?Sized> Mutex<T> {
         let current_id = api::ax_current_task_id();
         assert_eq!(
             owner_id, current_id,
-            "Thread({}) tried to release mutex it doesn't own",
-            current_id,
+            "Thread({current_id}) tried to release mutex it doesn't own",
         );
         // wake up one waiting thread.
         api::ax_wait_queue_wake(&self.wq, 1);


### PR DESCRIPTION
* Change `#[naked]` to `#[unsafe(naked)]` to meet the latest toolchain requirements.
* Fix bindgen generation error due to invalid `softfloat` targets used by clang.
* Fix kernel hangs caused by LoongArch64 LSX (SIMD) instructions.
