### PR TITLE
replace `Mutex` with `lock_api` in axstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "axfeat",
  "axio",
  "kspin",
+ "lock_api",
 ]
 
 [[package]]

--- a/ulib/axstd/Cargo.toml
+++ b/ulib/axstd/Cargo.toml
@@ -81,3 +81,4 @@ arceos_api = { workspace = true }
 axio = "0.1"
 axerrno = "0.1"
 kspin = "0.1"
+lock_api = { version = "0.4", default-features = false }

--- a/ulib/axstd/src/sync/mod.rs
+++ b/ulib/axstd/src/sync/mod.rs
@@ -12,7 +12,7 @@ mod mutex;
 
 #[cfg(feature = "multitask")]
 #[doc(cfg(feature = "multitask"))]
-pub use self::mutex::{Mutex, MutexGuard};
+pub use self::mutex::{Mutex, MutexGuard, RawMutex};
 
 #[cfg(not(feature = "multitask"))]
 #[doc(cfg(not(feature = "multitask")))]

--- a/ulib/axstd/src/sync/mutex.rs
+++ b/ulib/axstd/src/sync/mutex.rs
@@ -1,74 +1,37 @@
 //! A naïve sleeping mutex.
 
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use arceos_api::task::{self as api, AxWaitQueueHandle};
 
-/// A mutual exclusion primitive useful for protecting shared data, similar to
-/// [`std::sync::Mutex`](https://doc.rust-lang.org/std/sync/struct.Mutex.html).
+/// A [`lock_api::RawMutex`] implementation.
 ///
 /// When the mutex is locked, the current task will block and be put into the
 /// wait queue. When the mutex is unlocked, all tasks waiting on the queue
 /// will be woken up.
-pub struct Mutex<T: ?Sized> {
+pub struct RawMutex {
     wq: AxWaitQueueHandle,
     owner_id: AtomicU64,
-    data: UnsafeCell<T>,
 }
 
-/// A guard that provides mutable data access.
-///
-/// When the guard falls out of scope it will release the lock.
-pub struct MutexGuard<'a, T: ?Sized + 'a> {
-    lock: &'a Mutex<T>,
-    data: *mut T,
-}
-
-// Same unsafe impls as `std::sync::Mutex`
-unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
-unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
-
-impl<T> Mutex<T> {
-    /// Creates a new [`Mutex`] wrapping the supplied data.
+impl RawMutex {
+    /// Creates a [`RawMutex`].
     #[inline(always)]
-    pub const fn new(data: T) -> Self {
+    pub const fn new() -> Self {
         Self {
             wq: AxWaitQueueHandle::new(),
             owner_id: AtomicU64::new(0),
-            data: UnsafeCell::new(data),
         }
-    }
-
-    /// Consumes this [`Mutex`] and unwraps the underlying data.
-    #[inline(always)]
-    pub fn into_inner(self) -> T {
-        // We know statically that there are no outstanding references to
-        // `self` so there's no need to lock.
-        let Mutex { data, .. } = self;
-        data.into_inner()
     }
 }
 
-impl<T: ?Sized> Mutex<T> {
-    /// Returns `true` if the lock is currently held.
-    ///
-    /// # Safety
-    ///
-    /// This function provides no synchronization guarantees and so its result should be considered 'out of date'
-    /// the instant it is called. Do not use it for synchronization purposes. However, it may be useful as a heuristic.
-    #[inline(always)]
-    pub fn is_locked(&self) -> bool {
-        self.owner_id.load(Ordering::Relaxed) != 0
-    }
+unsafe impl lock_api::RawMutex for RawMutex {
+    const INIT: Self = RawMutex::new();
 
-    /// Locks the [`Mutex`] and returns a guard that permits access to the inner data.
-    ///
-    /// The returned value may be dereferenced for data access
-    /// and the lock will be dropped when the guard falls out of scope.
-    pub fn lock(&self) -> MutexGuard<T> {
+    type GuardMarker = lock_api::GuardSend;
+
+    #[inline(always)]
+    fn lock(&self) {
         let current_id = api::ax_current_task_id();
         loop {
             // Can fail to lock even if the spinlock is not locked. May be more efficient than `try_lock`
@@ -90,40 +53,20 @@ impl<T: ?Sized> Mutex<T> {
                 }
             }
         }
-        MutexGuard {
-            lock: self,
-            data: unsafe { &mut *self.data.get() },
-        }
     }
 
-    /// Try to lock this [`Mutex`], returning a lock guard if successful.
     #[inline(always)]
-    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+    fn try_lock(&self) -> bool {
         let current_id = api::ax_current_task_id();
         // The reason for using a strong compare_exchange is explained here:
         // https://github.com/Amanieu/parking_lot/pull/207#issuecomment-575869107
-        if self
-            .owner_id
+        self.owner_id
             .compare_exchange(0, current_id, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
-        {
-            Some(MutexGuard {
-                lock: self,
-                data: unsafe { &mut *self.data.get() },
-            })
-        } else {
-            None
-        }
     }
 
-    /// Force unlock the [`Mutex`].
-    ///
-    /// # Safety
-    ///
-    /// This is *extremely* unsafe if the lock is not held by the current
-    /// thread. However, this can be useful in some instances for exposing
-    /// the lock to FFI that doesn’t know how to deal with RAII.
-    pub unsafe fn force_unlock(&self) {
+    #[inline(always)]
+    unsafe fn unlock(&self) {
         let owner_id = self.owner_id.swap(0, Ordering::Release);
         let current_id = api::ax_current_task_id();
         assert_eq!(
@@ -134,63 +77,13 @@ impl<T: ?Sized> Mutex<T> {
         api::ax_wait_queue_wake(&self.wq, 1);
     }
 
-    /// Returns a mutable reference to the underlying data.
-    ///
-    /// Since this call borrows the [`Mutex`] mutably, and a mutable reference is guaranteed to be exclusive in
-    /// Rust, no actual locking needs to take place -- the mutable borrow statically guarantees no locks exist. As
-    /// such, this is a 'zero-cost' operation.
     #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut T {
-        // We know statically that there are no other references to `self`, so
-        // there's no need to lock the inner mutex.
-        unsafe { &mut *self.data.get() }
+    fn is_locked(&self) -> bool {
+        self.owner_id.load(Ordering::Relaxed) != 0
     }
 }
 
-impl<T: Default> Default for Mutex<T> {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::new(Default::default())
-    }
-}
-
-impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.try_lock() {
-            Some(guard) => write!(f, "Mutex {{ data: ")
-                .and_then(|()| (*guard).fmt(f))
-                .and_then(|()| write!(f, "}}")),
-            None => write!(f, "Mutex {{ <locked> }}"),
-        }
-    }
-}
-
-impl<T: ?Sized> Deref for MutexGuard<'_, T> {
-    type Target = T;
-    #[inline(always)]
-    fn deref(&self) -> &T {
-        // We know statically that only we are referencing data
-        unsafe { &*self.data }
-    }
-}
-
-impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut T {
-        // We know statically that only we are referencing data
-        unsafe { &mut *self.data }
-    }
-}
-
-impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized> Drop for MutexGuard<'_, T> {
-    /// The dropping of the [`MutexGuard`] will release the lock it was created from.
-    fn drop(&mut self) {
-        unsafe { self.lock.force_unlock() }
-    }
-}
+/// An alias of [`lock_api::Mutex`].
+pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
+/// An alias of [`lock_api::MutexGuard`].
+pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;


### PR DESCRIPTION
The same series update as [feat: replace Mutex with lock_api #238](https://github.com/arceos-org/arceos/pull/238)

It adapts axstd::sync::Mutex with [lock_api](https://docs.rs/lock_api), and adds the RawMutex type and allows the use of more complete APIs provided by lock_api, such as lock_arc, map, etc.