### PR TITLE
feat: support requeue, len, is_empty in WaitQueue

### DIFF
--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -206,14 +206,16 @@ impl WaitQueue {
     /// Requeues at most `count` tasks in the wait queue to the target wait queue.
     ///
     /// Returns the number of tasks requeued.
-    pub fn requeue(&self, count: usize, target: &WaitQueue) -> usize {
+    pub fn requeue(&self, mut count: usize, target: &WaitQueue) -> usize {
         let tasks: Vec<_> = {
             let mut wq = self.queue.lock();
-            let count = count.min(wq.len());
+            count = count.min(wq.len());
             wq.drain(..count).collect()
         };
-        let mut wq = target.queue.lock();
-        wq.extend(tasks);
+        if !tasks.is_empty() {
+            let mut wq = target.queue.lock();
+            wq.extend(tasks);
+        }
         count
     }
 

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -216,6 +216,16 @@ impl WaitQueue {
         wq.extend(tasks);
         count
     }
+
+    /// Returns the number of tasks in the wait queue.
+    pub fn len(&self) -> usize {
+        self.queue.lock().len()
+    }
+
+    /// Returns true if the wait queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.queue.lock().is_empty()
+    }
 }
 
 fn unblock_one_task(task: AxTaskRef, resched: bool) {

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -203,9 +203,16 @@ impl WaitQueue {
         }
     }
 
-    /// Requeues at most `count` tasks in the wait queue to the target wait queue.
+    /// Transfers up to `count` tasks from this wait queue to another wait queue.
     ///
-    /// Returns the number of tasks requeued.
+    /// Note: If the current wait queue contains fewer than `count` tasks, all available tasks will be moved.
+    ///
+    /// ## Arguments
+    /// * `count` - The maximum number of tasks to be moved.
+    /// * `target` - The target wait queue to which tasks will be moved.
+    ///
+    /// ## Returns
+    /// The number of tasks actually requeued.  
     pub fn requeue(&self, mut count: usize, target: &WaitQueue) -> usize {
         let tasks: Vec<_> = {
             let mut wq = self.queue.lock();


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [Various changes needed to support signal #34](https://github.com/oscomp/arceos/pull/34), [Add WaitQueue::len and WaitQueue::is_empty #39](https://github.com/oscomp/arceos/pull/39), [Fix: WaitQueue::requeue wrong implementation #40](https://github.com/oscomp/arceos/pull/40)

## Description
It adds various methods in WaitQueue, which is useful when implementing futex functionalities.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.