### PR TITLE
feat: save FP_STATE for RISC-V and Loongarch64

### DIFF
--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -1,4 +1,5 @@
 use core::arch::naked_asm;
+use core::mem::offset_of;
 use memory_addr::VirtAddr;
 
 /// General registers of Loongarch64.
@@ -47,8 +48,8 @@ pub struct GeneralRegisters {
 pub struct FpStatus {
     /// the state of the LoongArch64 Floating-Point Unit (FPU)
     pub fp: [u64; 32],
-    pub fcc: usize,  // 条件标志寄存器
-    pub fcsr: usize, // FCSR0寄存器
+    pub fcc: [u8; 8], // 条件标志寄存器
+    pub fcsr: usize,  // FCSR0寄存器
 }
 
 /// Saved registers when a trap (interrupt or exception) occurs.
@@ -275,33 +276,37 @@ impl TaskContext {
 
 #[cfg(feature = "fp_simd")]
 #[unsafe(naked)]
-unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
+unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
         PUSH_FLOAT_REGS $a0
-        addi.d  $t8, $a0, 256
+        addi.d $t8, $a0, {fcc_offset}
         SAVE_FCC $t8
-        addi.d  $t8, $a0, 264
+        addi.d $t8, $a0, {fcsr_offset}
         SAVE_FCSR $t8
         ret
-        "
+        ",
+        fcc_offset = const offset_of!(FpStatus, fcc),
+        fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
 }
 
 #[cfg(feature = "fp_simd")]
 #[unsafe(naked)]
-unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
+unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
     naked_asm!(
         include_fp_asm_macros!(),
         "
         POP_FLOAT_REGS $a0
-        addi.d  $t8, $a0, 256
+        addi.d $t8, $a0, {fcc_offset}
         RESTORE_FCC $t8
-        addi.d  $t8, $a0, 264
+        addi.d $t8, $a0, {fcsr_offset}
         RESTORE_FCSR $t8
         ret
-        "
+        ",
+        fcc_offset = const offset_of!(FpStatus, fcc),
+        fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
 }
 

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -40,6 +40,28 @@ pub struct GeneralRegisters {
     pub s8: usize,
 }
 
+/// Floating-point registers of LoongArch64.
+#[cfg(feature = "fp_simd")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FpStatus {
+    /// the state of the LoongArch64 Floating-Point Unit (FPU)
+    pub fp: [u64; 32],
+    pub fcc: usize,  // 条件标志寄存器
+    pub fcsr: usize, // FCSR0寄存器,
+}
+
+#[cfg(feature = "fp_simd")]
+impl Default for FpStatus {
+    fn default() -> Self {
+        Self {
+            fp: [0; 32],
+            fcc: 0,
+            fcsr: 0, // 默认不启用浮点例外,舍入模式为RNE
+        }
+    }
+}
+
 /// Saved registers when a trap (interrupt or exception) occurs.
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
@@ -206,6 +228,9 @@ pub struct TaskContext {
     #[cfg(feature = "uspace")]
     /// user page table root
     pub pgdl: usize,
+    #[cfg(feature = "fp_simd")]
+    /// Floating Point Status
+    pub fp_status: FpStatus,
 }
 
 impl TaskContext {
@@ -246,8 +271,61 @@ impl TaskContext {
                 unsafe { super::write_page_table_root0(pa!(next_ctx.pgdl)) };
             }
         }
+
+        #[cfg(feature = "fp_simd")]
+        {
+            unsafe {
+                save_fp_registers(
+                    &mut self.fp_status.fp,
+                    &mut self.fp_status.fcc,
+                    &mut self.fp_status.fcsr,
+                );
+                restore_fp_registers(
+                    &next_ctx.fp_status.fp,
+                    &next_ctx.fp_status.fcc,
+                    &next_ctx.fp_status.fcsr,
+                );
+            }
+        }
+
         unsafe { context_switch(self, next_ctx) }
     }
+}
+
+#[cfg(feature = "fp_simd")]
+#[unsafe(naked)]
+unsafe extern "C" fn save_fp_registers(
+    _fp_registers: &mut [u64; 32],
+    _fcc: &mut usize,
+    _fcsr: &mut usize,
+) {
+    naked_asm!(
+        include_fp_asm_macros!(), // $f24 - $f31
+        "
+        // save old fr context (callee-saved registers)
+        PUSH_FLOAT_REGS $a0
+        // save fcc and fcsr
+        SAVE_FCC $a1
+        SAVE_FCSR $a2
+        ret
+        "
+    )
+}
+
+#[cfg(feature = "fp_simd")]
+#[unsafe(naked)]
+unsafe extern "C" fn restore_fp_registers(_fp_registers: &[u64; 32], _fcc: &usize, _fcsr: &usize) {
+    naked_asm!(
+        include_fp_asm_macros!(), // $f24 - $f31
+        "
+        // restore new context
+        POP_FLOAT_REGS $a0
+        // restore fcc and fcsr
+        RESTORE_FCC $a1
+        RESTORE_FCSR $a2
+        ret
+        "
+    )
 }
 
 #[unsafe(naked)]

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -280,6 +280,10 @@ unsafe extern "C" fn save_fp_registers(_fp_status: &mut FpStatus) {
         include_fp_asm_macros!(),
         "
         PUSH_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        SAVE_FCC $t8
+        addi.d  $t8, $a0, 264
+        SAVE_FCSR $t8
         ret
         "
     )
@@ -292,6 +296,10 @@ unsafe extern "C" fn restore_fp_registers(_fp_status: &FpStatus) {
         include_fp_asm_macros!(),
         "
         POP_FLOAT_REGS $a0
+        addi.d  $t8, $a0, 256
+        RESTORE_FCC $t8
+        addi.d  $t8, $a0, 264
+        RESTORE_FCSR $t8
         ret
         "
     )

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -1,7 +1,7 @@
 use core::arch::naked_asm;
-use memory_addr::VirtAddr;
 #[cfg(feature = "fp_simd")]
 use core::mem::offset_of;
+use memory_addr::VirtAddr;
 
 /// General registers of Loongarch64.
 #[allow(missing_docs)]

--- a/modules/axhal/src/arch/loongarch64/context.rs
+++ b/modules/axhal/src/arch/loongarch64/context.rs
@@ -1,6 +1,7 @@
 use core::arch::naked_asm;
-use core::mem::offset_of;
 use memory_addr::VirtAddr;
+#[cfg(feature = "fp_simd")]
+use core::mem::offset_of;
 
 /// General registers of Loongarch64.
 #[allow(missing_docs)]
@@ -46,10 +47,12 @@ pub struct GeneralRegisters {
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FpStatus {
-    /// the state of the LoongArch64 Floating-Point Unit (FPU)
+    /// Floating-point registers (f0-f31)
     pub fp: [u64; 32],
-    pub fcc: [u8; 8], // 条件标志寄存器
-    pub fcsr: usize,  // FCSR0寄存器
+    /// Floating-point Condition Code register
+    pub fcc: [u8; 8],
+    /// Floating-point Control and Status register
+    pub fcsr: usize,
 }
 
 /// Saved registers when a trap (interrupt or exception) occurs.
@@ -261,13 +264,10 @@ impl TaskContext {
                 unsafe { super::write_page_table_root0(pa!(next_ctx.pgdl)) };
             }
         }
-
         #[cfg(feature = "fp_simd")]
-        {
-            unsafe {
-                save_fp_registers(&mut self.fp_status);
-                restore_fp_registers(&next_ctx.fp_status);
-            }
+        unsafe {
+            save_fp_registers(&mut self.fp_status);
+            restore_fp_registers(&next_ctx.fp_status);
         }
 
         unsafe { context_switch(self, next_ctx) }
@@ -285,8 +285,7 @@ unsafe extern "C" fn save_fp_registers(fp_status: &mut FpStatus) {
         SAVE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         SAVE_FCSR $t8
-        ret
-        ",
+        ret",
         fcc_offset = const offset_of!(FpStatus, fcc),
         fcsr_offset = const offset_of!(FpStatus, fcsr),
     )
@@ -303,8 +302,7 @@ unsafe extern "C" fn restore_fp_registers(fp_status: &FpStatus) {
         RESTORE_FCC $t8
         addi.d $t8, $a0, {fcsr_offset}
         RESTORE_FCSR $t8
-        ret
-        ",
+        ret",
         fcc_offset = const offset_of!(FpStatus, fcc),
         fcsr_offset = const offset_of!(FpStatus, fcsr),
     )

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -81,17 +81,10 @@ macro_rules! include_asm_macros {
 macro_rules! include_fp_asm_macros {
     () => {
         concat!(
-            include_asm_macros!(), // Changed from __asm_macros!
+            include_asm_macros!(),
             r#"
             .ifndef FP_MACROS_FLAG
             .equ FP_MACROS_FLAG, 1
-
-            .macro FSTD fr, base_reg, off
-                fst.d   \fr, \base_reg, \off*8
-            .endm
-            .macro FLDD fr, base_reg, off
-                fld.d   \fr, \base_reg, \off*8
-            .endm
 
             .macro SAVE_FCSR, base
                 movfcsr2gr $t0, $fcsr0
@@ -178,10 +171,18 @@ macro_rules! include_fp_asm_macros {
 
             .macro PUSH_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fst.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                SAVE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                SAVE_FCSR $t8
             .endm
 
             .macro POP_FLOAT_REGS, base_reg
                 PUSH_POP_FLOAT_REGS fld.d, \base_reg
+                addi.d  $t8, \base_reg, 256
+                RESTORE_FCC $t8
+                addi.d  $t8, \base_reg, 264
+                RESTORE_FCSR $t8
             .endm
 
             .endif"#

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -105,33 +105,33 @@ macro_rules! include_fp_asm_macros {
         .endm
 
         .macro RESTORE_FCC, base
-            ld.d	    $t0, \base, 0
-            bstrpick.d	$t1, $t0, 7, 0
-            movgr2cf	$fcc0, $t1
-            bstrpick.d	$t1, $t0, 15, 8
-            movgr2cf	$fcc1, $t1
-            bstrpick.d	$t1, $t0, 23, 16
-            movgr2cf	$fcc2, $t1
-            bstrpick.d	$t1, $t0, 31, 24
-            movgr2cf	$fcc3, $t1
-            bstrpick.d	$t1, $t0, 39, 32
-            movgr2cf	$fcc4, $t1
-            bstrpick.d	$t1, $t0, 47, 40
-            movgr2cf	$fcc5, $t1
-            bstrpick.d	$t1, $t0, 55, 48
-            movgr2cf	$fcc6, $t1
-            bstrpick.d	$t1, $t0, 63, 56
-            movgr2cf	$fcc7, $t1
+            ld.d        $t0, \base, 0
+            bstrpick.d  $t1, $t0, 7, 0
+            movgr2cf    $fcc0, $t1
+            bstrpick.d  $t1, $t0, 15, 8
+            movgr2cf    $fcc1, $t1
+            bstrpick.d  $t1, $t0, 23, 16
+            movgr2cf    $fcc2, $t1
+            bstrpick.d  $t1, $t0, 31, 24
+            movgr2cf    $fcc3, $t1
+            bstrpick.d  $t1, $t0, 39, 32
+            movgr2cf    $fcc4, $t1
+            bstrpick.d  $t1, $t0, 47, 40
+            movgr2cf    $fcc5, $t1
+            bstrpick.d  $t1, $t0, 55, 48
+            movgr2cf    $fcc6, $t1
+            bstrpick.d  $t1, $t0, 63, 56
+            movgr2cf    $fcc7, $t1
         .endm
 
         .macro SAVE_FCSR, base
-            movfcsr2gr	$t0, $fcsr0
+            movfcsr2gr  $t0, $fcsr0
             st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
             ld.w        $t0, \base, 0
-            movgr2fcsr	$fcsr0, $t0
+            movgr2fcsr  $fcsr0, $t0
         .endm
 
         // LoongArch64 specific floating point macros

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -76,3 +76,115 @@ macro_rules! include_asm_macros {
         .endif"
     };
 }
+
+#[cfg(feature = "fp_simd")]
+macro_rules! include_fp_asm_macros {
+    () => {
+        concat!(
+            include_asm_macros!(), // Changed from __asm_macros!
+            r#"
+            .ifndef FP_MACROS_FLAG
+            .equ FP_MACROS_FLAG, 1
+
+            .macro FSTD fr, base_reg, off
+                fst.d   \fr, \base_reg, \off*8
+            .endm
+            .macro FLDD fr, base_reg, off
+                fld.d   \fr, \base_reg, \off*8
+            .endm
+
+            .macro SAVE_FCSR, base
+                movfcsr2gr $t0, $fcsr0
+                st.d $t0, \base, 0*8
+            .endm
+            .macro SAVE_FCC, base
+                movcf2gr $t0, $fcc0
+                movcf2gr $t1, $fcc1
+                movcf2gr $t2, $fcc2
+                movcf2gr $t3, $fcc3
+                movcf2gr $t4, $fcc4
+                movcf2gr $t5, $fcc5
+                movcf2gr $t6, $fcc6
+                movcf2gr $t7, $fcc7
+                st.d $t0, \base, 0
+                st.d $t1, \base, 1
+                st.d $t2, \base, 2
+                st.d $t3, \base, 3
+                st.d $t4, \base, 4
+                st.d $t5, \base, 5
+                st.d $t6, \base, 6
+                st.d $t7, \base, 7
+            .endm
+
+            .macro RESTORE_FCSR, base
+                movgr2fcsr $fcsr0, $t0
+                ld.d $t0, \base, 0*8
+            .endm
+            .macro RESTORE_FCC, base
+                ld.d $t0, \base, 0
+                ld.d $t1, \base, 1
+                ld.d $t2, \base, 2
+                ld.d $t3, \base, 3
+                ld.d $t4, \base, 4
+                ld.d $t5, \base, 5
+                ld.d $t6, \base, 6
+                ld.d $t7, \base, 7
+                movgr2cf $fcc0, $t0
+                movgr2cf $fcc1, $t1
+                movgr2cf $fcc2, $t2
+                movgr2cf $fcc3, $t3
+                movgr2cf $fcc4, $t4
+                movgr2cf $fcc5, $t5
+                movgr2cf $fcc6, $t6
+                movgr2cf $fcc7, $t7
+            .endm
+
+
+            // LoongArch64 specific floating point macros
+            .macro PUSH_POP_FLOAT_REGS, op, base_reg
+                \op $f0,  \base_reg, 0*8
+                \op $f1,  \base_reg, 1*8
+                \op $f2,  \base_reg, 2*8
+                \op $f3,  \base_reg, 3*8
+                \op $f4,  \base_reg, 4*8
+                \op $f5,  \base_reg, 5*8
+                \op $f6,  \base_reg, 6*8
+                \op $f7,  \base_reg, 7*8
+                \op $f8,  \base_reg, 8*8
+                \op $f9,  \base_reg, 9*8
+                \op $f10, \base_reg, 10*8
+                \op $f11, \base_reg, 11*8
+                \op $f12, \base_reg, 12*8
+                \op $f13, \base_reg, 13*8
+                \op $f14, \base_reg, 14*8
+                \op $f15, \base_reg, 15*8
+                \op $f16, \base_reg, 16*8
+                \op $f17, \base_reg, 17*8
+                \op $f18, \base_reg, 18*8
+                \op $f19, \base_reg, 19*8
+                \op $f20, \base_reg, 20*8
+                \op $f21, \base_reg, 21*8
+                \op $f22, \base_reg, 22*8
+                \op $f23, \base_reg, 23*8
+                \op $f24, \base_reg, 24*8
+                \op $f25, \base_reg, 25*8
+                \op $f26, \base_reg, 26*8
+                \op $f27, \base_reg, 27*8
+                \op $f28, \base_reg, 28*8
+                \op $f29, \base_reg, 29*8
+                \op $f30, \base_reg, 30*8
+                \op $f31, \base_reg, 31*8
+            .endm
+
+            .macro PUSH_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fst.d, \base_reg
+            .endm
+
+            .macro POP_FLOAT_REGS, base_reg
+                PUSH_POP_FLOAT_REGS fld.d, \base_reg
+            .endm
+
+            .endif"#
+        )
+    };
+}

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -84,52 +84,55 @@ macro_rules! include_fp_asm_macros {
         .ifndef FP_MACROS_FLAG
         .equ FP_MACROS_FLAG, 1
 
-        .macro SAVE_FCSR, base
-            movfcsr2gr $t0, $fcsr0
-            st.d $t0, \base, 0*8
-        .endm
         .macro SAVE_FCC, base
-            movcf2gr $t0, $fcc0
-            movcf2gr $t1, $fcc1
-            movcf2gr $t2, $fcc2
-            movcf2gr $t3, $fcc3
-            movcf2gr $t4, $fcc4
-            movcf2gr $t5, $fcc5
-            movcf2gr $t6, $fcc6
-            movcf2gr $t7, $fcc7
-            st.d $t0, \base, 0
-            st.d $t1, \base, 1
-            st.d $t2, \base, 2
-            st.d $t3, \base, 3
-            st.d $t4, \base, 4
-            st.d $t5, \base, 5
-            st.d $t6, \base, 6
-            st.d $t7, \base, 7
+            movcf2gr    $t0, $fcc0
+            move        $t1, $t0
+            movcf2gr    $t0, $fcc1
+            bstrins.d   $t1, $t0, 15, 8
+            movcf2gr    $t0, $fcc2
+            bstrins.d   $t1, $t0, 23, 16
+            movcf2gr    $t0, $fcc3
+            bstrins.d   $t1, $t0, 31, 24
+            movcf2gr    $t0, $fcc4
+            bstrins.d   $t1, $t0, 39, 32
+            movcf2gr    $t0, $fcc5
+            bstrins.d   $t1, $t0, 47, 40
+            movcf2gr    $t0, $fcc6
+            bstrins.d   $t1, $t0, 55, 48
+            movcf2gr    $t0, $fcc7
+            bstrins.d   $t1, $t0, 63, 56
+            st.d        $t1, \base, 0
+        .endm
+
+        .macro RESTORE_FCC, base
+            ld.d	    $t0, \base, 0
+            bstrpick.d	$t1, $t0, 7, 0
+            movgr2cf	$fcc0, $t1
+            bstrpick.d	$t1, $t0, 15, 8
+            movgr2cf	$fcc1, $t1
+            bstrpick.d	$t1, $t0, 23, 16
+            movgr2cf	$fcc2, $t1
+            bstrpick.d	$t1, $t0, 31, 24
+            movgr2cf	$fcc3, $t1
+            bstrpick.d	$t1, $t0, 39, 32
+            movgr2cf	$fcc4, $t1
+            bstrpick.d	$t1, $t0, 47, 40
+            movgr2cf	$fcc5, $t1
+            bstrpick.d	$t1, $t0, 55, 48
+            movgr2cf	$fcc6, $t1
+            bstrpick.d	$t1, $t0, 63, 56
+            movgr2cf	$fcc7, $t1
+        .endm
+
+        .macro SAVE_FCSR, base
+            movfcsr2gr	$t0, $fcsr0
+            st.w        $t0, \base, 0
         .endm
 
         .macro RESTORE_FCSR, base
-            movgr2fcsr $fcsr0, $t0
-            ld.d $t0, \base, 0*8
+            ld.w        $t0, \base, 0
+            movgr2fcsr	$fcsr0, $t0
         .endm
-        .macro RESTORE_FCC, base
-            ld.d $t0, \base, 0
-            ld.d $t1, \base, 1
-            ld.d $t2, \base, 2
-            ld.d $t3, \base, 3
-            ld.d $t4, \base, 4
-            ld.d $t5, \base, 5
-            ld.d $t6, \base, 6
-            ld.d $t7, \base, 7
-            movgr2cf $fcc0, $t0
-            movgr2cf $fcc1, $t1
-            movgr2cf $fcc2, $t2
-            movgr2cf $fcc3, $t3
-            movgr2cf $fcc4, $t4
-            movgr2cf $fcc5, $t5
-            movgr2cf $fcc6, $t6
-            movgr2cf $fcc7, $t7
-        .endm
-
 
         // LoongArch64 specific floating point macros
         .macro PUSH_POP_FLOAT_REGS, op, base_reg

--- a/modules/axhal/src/arch/loongarch64/macros.rs
+++ b/modules/axhal/src/arch/loongarch64/macros.rs
@@ -80,112 +80,101 @@ macro_rules! include_asm_macros {
 #[cfg(feature = "fp_simd")]
 macro_rules! include_fp_asm_macros {
     () => {
-        concat!(
-            include_asm_macros!(),
-            r#"
-            .ifndef FP_MACROS_FLAG
-            .equ FP_MACROS_FLAG, 1
+        r#"
+        .ifndef FP_MACROS_FLAG
+        .equ FP_MACROS_FLAG, 1
 
-            .macro SAVE_FCSR, base
-                movfcsr2gr $t0, $fcsr0
-                st.d $t0, \base, 0*8
-            .endm
-            .macro SAVE_FCC, base
-                movcf2gr $t0, $fcc0
-                movcf2gr $t1, $fcc1
-                movcf2gr $t2, $fcc2
-                movcf2gr $t3, $fcc3
-                movcf2gr $t4, $fcc4
-                movcf2gr $t5, $fcc5
-                movcf2gr $t6, $fcc6
-                movcf2gr $t7, $fcc7
-                st.d $t0, \base, 0
-                st.d $t1, \base, 1
-                st.d $t2, \base, 2
-                st.d $t3, \base, 3
-                st.d $t4, \base, 4
-                st.d $t5, \base, 5
-                st.d $t6, \base, 6
-                st.d $t7, \base, 7
-            .endm
+        .macro SAVE_FCSR, base
+            movfcsr2gr $t0, $fcsr0
+            st.d $t0, \base, 0*8
+        .endm
+        .macro SAVE_FCC, base
+            movcf2gr $t0, $fcc0
+            movcf2gr $t1, $fcc1
+            movcf2gr $t2, $fcc2
+            movcf2gr $t3, $fcc3
+            movcf2gr $t4, $fcc4
+            movcf2gr $t5, $fcc5
+            movcf2gr $t6, $fcc6
+            movcf2gr $t7, $fcc7
+            st.d $t0, \base, 0
+            st.d $t1, \base, 1
+            st.d $t2, \base, 2
+            st.d $t3, \base, 3
+            st.d $t4, \base, 4
+            st.d $t5, \base, 5
+            st.d $t6, \base, 6
+            st.d $t7, \base, 7
+        .endm
 
-            .macro RESTORE_FCSR, base
-                movgr2fcsr $fcsr0, $t0
-                ld.d $t0, \base, 0*8
-            .endm
-            .macro RESTORE_FCC, base
-                ld.d $t0, \base, 0
-                ld.d $t1, \base, 1
-                ld.d $t2, \base, 2
-                ld.d $t3, \base, 3
-                ld.d $t4, \base, 4
-                ld.d $t5, \base, 5
-                ld.d $t6, \base, 6
-                ld.d $t7, \base, 7
-                movgr2cf $fcc0, $t0
-                movgr2cf $fcc1, $t1
-                movgr2cf $fcc2, $t2
-                movgr2cf $fcc3, $t3
-                movgr2cf $fcc4, $t4
-                movgr2cf $fcc5, $t5
-                movgr2cf $fcc6, $t6
-                movgr2cf $fcc7, $t7
-            .endm
+        .macro RESTORE_FCSR, base
+            movgr2fcsr $fcsr0, $t0
+            ld.d $t0, \base, 0*8
+        .endm
+        .macro RESTORE_FCC, base
+            ld.d $t0, \base, 0
+            ld.d $t1, \base, 1
+            ld.d $t2, \base, 2
+            ld.d $t3, \base, 3
+            ld.d $t4, \base, 4
+            ld.d $t5, \base, 5
+            ld.d $t6, \base, 6
+            ld.d $t7, \base, 7
+            movgr2cf $fcc0, $t0
+            movgr2cf $fcc1, $t1
+            movgr2cf $fcc2, $t2
+            movgr2cf $fcc3, $t3
+            movgr2cf $fcc4, $t4
+            movgr2cf $fcc5, $t5
+            movgr2cf $fcc6, $t6
+            movgr2cf $fcc7, $t7
+        .endm
 
 
-            // LoongArch64 specific floating point macros
-            .macro PUSH_POP_FLOAT_REGS, op, base_reg
-                \op $f0,  \base_reg, 0*8
-                \op $f1,  \base_reg, 1*8
-                \op $f2,  \base_reg, 2*8
-                \op $f3,  \base_reg, 3*8
-                \op $f4,  \base_reg, 4*8
-                \op $f5,  \base_reg, 5*8
-                \op $f6,  \base_reg, 6*8
-                \op $f7,  \base_reg, 7*8
-                \op $f8,  \base_reg, 8*8
-                \op $f9,  \base_reg, 9*8
-                \op $f10, \base_reg, 10*8
-                \op $f11, \base_reg, 11*8
-                \op $f12, \base_reg, 12*8
-                \op $f13, \base_reg, 13*8
-                \op $f14, \base_reg, 14*8
-                \op $f15, \base_reg, 15*8
-                \op $f16, \base_reg, 16*8
-                \op $f17, \base_reg, 17*8
-                \op $f18, \base_reg, 18*8
-                \op $f19, \base_reg, 19*8
-                \op $f20, \base_reg, 20*8
-                \op $f21, \base_reg, 21*8
-                \op $f22, \base_reg, 22*8
-                \op $f23, \base_reg, 23*8
-                \op $f24, \base_reg, 24*8
-                \op $f25, \base_reg, 25*8
-                \op $f26, \base_reg, 26*8
-                \op $f27, \base_reg, 27*8
-                \op $f28, \base_reg, 28*8
-                \op $f29, \base_reg, 29*8
-                \op $f30, \base_reg, 30*8
-                \op $f31, \base_reg, 31*8
-            .endm
+        // LoongArch64 specific floating point macros
+        .macro PUSH_POP_FLOAT_REGS, op, base_reg
+            \op $f0,  \base_reg, 0*8
+            \op $f1,  \base_reg, 1*8
+            \op $f2,  \base_reg, 2*8
+            \op $f3,  \base_reg, 3*8
+            \op $f4,  \base_reg, 4*8
+            \op $f5,  \base_reg, 5*8
+            \op $f6,  \base_reg, 6*8
+            \op $f7,  \base_reg, 7*8
+            \op $f8,  \base_reg, 8*8
+            \op $f9,  \base_reg, 9*8
+            \op $f10, \base_reg, 10*8
+            \op $f11, \base_reg, 11*8
+            \op $f12, \base_reg, 12*8
+            \op $f13, \base_reg, 13*8
+            \op $f14, \base_reg, 14*8
+            \op $f15, \base_reg, 15*8
+            \op $f16, \base_reg, 16*8
+            \op $f17, \base_reg, 17*8
+            \op $f18, \base_reg, 18*8
+            \op $f19, \base_reg, 19*8
+            \op $f20, \base_reg, 20*8
+            \op $f21, \base_reg, 21*8
+            \op $f22, \base_reg, 22*8
+            \op $f23, \base_reg, 23*8
+            \op $f24, \base_reg, 24*8
+            \op $f25, \base_reg, 25*8
+            \op $f26, \base_reg, 26*8
+            \op $f27, \base_reg, 27*8
+            \op $f28, \base_reg, 28*8
+            \op $f29, \base_reg, 29*8
+            \op $f30, \base_reg, 30*8
+            \op $f31, \base_reg, 31*8
+        .endm
 
-            .macro PUSH_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fst.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                SAVE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                SAVE_FCSR $t8
-            .endm
+        .macro PUSH_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fst.d, \base_reg
+        .endm
 
-            .macro POP_FLOAT_REGS, base_reg
-                PUSH_POP_FLOAT_REGS fld.d, \base_reg
-                addi.d  $t8, \base_reg, 256
-                RESTORE_FCC $t8
-                addi.d  $t8, \base_reg, 264
-                RESTORE_FCSR $t8
-            .endm
+        .macro POP_FLOAT_REGS, base_reg
+            PUSH_POP_FLOAT_REGS fld.d, \base_reg
+        .endm
 
-            .endif"#
-        )
+        .endif"#
     };
 }

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -99,6 +99,8 @@ impl UspaceContext {
     pub fn new(entry: usize, ustack_top: VirtAddr, arg0: usize) -> Self {
         const SPIE: usize = 1 << 5;
         const SUM: usize = 1 << 18;
+        // enable floating point unit for user space
+        const FS: usize = 1 << 13;
         Self(TrapFrame {
             regs: GeneralRegisters {
                 a0: arg0,
@@ -106,7 +108,7 @@ impl UspaceContext {
                 ..Default::default()
             },
             sepc: entry,
-            sstatus: SPIE | SUM,
+            sstatus: SPIE | SUM | FS,
         })
     }
 

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -1,5 +1,7 @@
 use core::arch::naked_asm;
 use memory_addr::VirtAddr;
+#[cfg(feature = "fp_simd")]
+use riscv::register::sstatus::FS;
 
 /// General registers of RISC-V.
 #[allow(missing_docs)]
@@ -37,6 +39,28 @@ pub struct GeneralRegisters {
     pub t4: usize,
     pub t5: usize,
     pub t6: usize,
+}
+
+/// Floating-point registers of RISC-V.
+#[cfg(feature = "fp_simd")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FpStatus {
+    /// the state of the RISC-V Floating-Point Unit (FPU)
+    pub fp: [u64; 32],
+    pub fcsr: usize,
+    pub fs: FS,
+}
+
+#[cfg(feature = "fp_simd")]
+impl Default for FpStatus {
+    fn default() -> Self {
+        Self {
+            fs: FS::Initial,
+            fp: [0; 32],
+            fcsr: 0,
+        }
+    }
 }
 
 /// Saved registers when a trap (interrupt or exception) occurs.
@@ -97,10 +121,19 @@ impl UspaceContext {
     /// Creates a new context with the given entry point, user stack pointer,
     /// and the argument.
     pub fn new(entry: usize, ustack_top: VirtAddr, arg0: usize) -> Self {
-        const SPIE: usize = 1 << 5;
-        const SUM: usize = 1 << 18;
-        // enable floating point unit for user space
-        const FS: usize = 1 << 13;
+        const BIT_SPIE: usize = 5;
+        const BIT_SUM: usize = 18;
+
+        let mut sstatus: usize = 0;
+        sstatus |= 1 << BIT_SPIE;
+        sstatus |= 1 << BIT_SUM;
+        #[cfg(feature = "fp_simd")]
+        {
+            // set the initial state of the FPU
+            const BIT_FS: usize = 13;
+            sstatus |= (FS::Initial as usize) << BIT_FS;
+        }
+
         Self(TrapFrame {
             regs: GeneralRegisters {
                 a0: arg0,
@@ -108,7 +141,7 @@ impl UspaceContext {
                 ..Default::default()
             },
             sepc: entry,
-            sstatus: SPIE | SUM | FS,
+            sstatus,
         })
     }
 
@@ -222,7 +255,8 @@ pub struct TaskContext {
     /// The `satp` register value, i.e., the page table root.
     #[cfg(feature = "uspace")]
     pub satp: memory_addr::PhysAddr,
-    // TODO: FP states
+    #[cfg(feature = "fp_simd")]
+    pub fp_status: FpStatus,
 }
 
 impl TaskContext {
@@ -237,6 +271,11 @@ impl TaskContext {
         Self {
             #[cfg(feature = "uspace")]
             satp: crate::paging::kernel_page_table_root(),
+            #[cfg(feature = "fp_simd")]
+            fp_status: FpStatus {
+                fs: FS::Initial,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -276,11 +315,85 @@ impl TaskContext {
                 super::write_page_table_root(next_ctx.satp);
             }
         }
-        unsafe {
-            // TODO: switch FP states
-            context_switch(self, next_ctx)
+        #[cfg(feature = "fp_simd")]
+        {
+            use riscv::register::sstatus;
+            use riscv::register::sstatus::FS;
+            // get the real FP state of the current task
+            let current_fs = sstatus::read().fs();
+            // save the current task's FP state
+            if current_fs == FS::Dirty {
+                // we need to save the current task's FP state
+                unsafe {
+                    save_fp_registers(&mut self.fp_status.fp);
+                }
+                // after saving, we set the FP state to clean
+                self.fp_status.fs = FS::Clean;
+            }
+            // restore the next task's FP state
+            match next_ctx.fp_status.fs {
+                FS::Clean => unsafe {
+                    // the next task's FP state is clean, we should restore it
+                    restore_fp_registers(&next_ctx.fp_status.fp);
+                    // after restoring, we set the FP state
+                    sstatus::set_fs(FS::Clean);
+                },
+                FS::Initial => unsafe {
+                    // restore the FP state as constant values(all 0)
+                    clear_fp_registers();
+                    // we set the FP state to initial
+                    sstatus::set_fs(FS::Initial);
+                },
+                FS::Dirty => {
+                    // should not happen, since we set FS to Clean after saving
+                    panic!("FP state of the next task should not be dirty");
+                }
+                _ => {}
+            }
         }
+
+        unsafe { context_switch(self, next_ctx) }
     }
+}
+
+#[cfg(feature = "fp_simd")]
+#[unsafe(naked)]
+unsafe extern "C" fn save_fp_registers(_fp_registers: &mut [u64; 32]) {
+    naked_asm!(
+        include_fp_asm_macros!(),
+        "
+        PUSH_FLOAT_REGS a0
+        frcsr t0
+        STR t0, a0, 32
+        ret
+        "
+    )
+}
+
+#[cfg(feature = "fp_simd")]
+#[unsafe(naked)]
+unsafe extern "C" fn restore_fp_registers(_fp_registers: &[u64; 32]) {
+    naked_asm!(
+        include_fp_asm_macros!(),
+        "
+        POP_FLOAT_REGS a0
+        LDR t0, a0, 32
+        fscsr x0, t0
+        ret
+        "
+    )
+}
+
+#[cfg(feature = "fp_simd")]
+#[unsafe(naked)]
+unsafe extern "C" fn clear_fp_registers() {
+    naked_asm!(
+        include_fp_asm_macros!(),
+        "
+        CLEAR_FLOAT_REGS
+        ret
+        "
+    )
 }
 
 #[unsafe(naked)]

--- a/modules/axhal/src/arch/riscv/macros.rs
+++ b/modules/axhal/src/arch/riscv/macros.rs
@@ -34,6 +34,100 @@ macro_rules! __asm_macros {
     };
 }
 
+#[cfg(feature = "fp_simd")]
+macro_rules! include_fp_asm_macros {
+    () => {
+        concat!(
+            __asm_macros!(),
+            r#"
+            .ifndef FP_MACROS_FLAG
+            .equ FP_MACROS_FLAG, 1
+
+            .macro PUSH_POP_FLOAT_REGS, op, base
+                .attribute arch, "rv64gc"
+                \op f0, 0 * 8(\base)
+                \op f1, 1 * 8(\base)
+                \op f2, 2 * 8(\base)
+                \op f3, 3 * 8(\base)
+                \op f4, 4 * 8(\base)
+                \op f5, 5 * 8(\base)
+                \op f6, 6 * 8(\base)
+                \op f7, 7 * 8(\base)
+                \op f8, 8 * 8(\base)
+                \op f9, 9 * 8(\base)
+                \op f10, 10 * 8(\base)
+                \op f11, 11 * 8(\base)
+                \op f12, 12 * 8(\base)
+                \op f13, 13 * 8(\base)
+                \op f14, 14 * 8(\base)
+                \op f15, 15 * 8(\base)
+                \op f16, 16 * 8(\base)
+                \op f17, 17 * 8(\base)
+                \op f18, 18 * 8(\base)
+                \op f19, 19 * 8(\base)
+                \op f20, 20 * 8(\base)
+                \op f21, 21 * 8(\base)
+                \op f22, 22 * 8(\base)
+                \op f23, 23 * 8(\base)
+                \op f24, 24 * 8(\base)
+                \op f25, 25 * 8(\base)
+                \op f26, 26 * 8(\base)
+                \op f27, 27 * 8(\base)
+                \op f28, 28 * 8(\base)
+                \op f29, 29 * 8(\base)
+                \op f30, 30 * 8(\base)
+                \op f31, 31 * 8(\base)
+            .endm
+
+            .macro PUSH_FLOAT_REGS, base
+                PUSH_POP_FLOAT_REGS fsd, \base
+            .endm
+
+            .macro POP_FLOAT_REGS, base
+                PUSH_POP_FLOAT_REGS fld, \base
+            .endm
+
+            .macro CLEAR_FLOAT_REGS, base
+                fmv.d.x f0, x0
+                fmv.d.x f1, x0
+                fmv.d.x f2, x0
+                fmv.d.x f3, x0
+                fmv.d.x f4, x0
+                fmv.d.x f5, x0
+                fmv.d.x f5, x0
+                fmv.d.x f6, x0
+                fmv.d.x f7, x0
+                fmv.d.x f8, x0
+                fmv.d.x f9, x0
+                fmv.d.x f10, x0
+                fmv.d.x f11, x0
+                fmv.d.x f12, x0
+                fmv.d.x f13, x0
+                fmv.d.x f14, x0
+                fmv.d.x f15, x0
+                fmv.d.x f16, x0
+                fmv.d.x f17, x0
+                fmv.d.x f18, x0
+                fmv.d.x f19, x0
+                fmv.d.x f20, x0
+                fmv.d.x f21, x0
+                fmv.d.x f22, x0
+                fmv.d.x f23, x0
+                fmv.d.x f24, x0
+                fmv.d.x f25, x0
+                fmv.d.x f26, x0
+                fmv.d.x f27, x0
+                fmv.d.x f28, x0
+                fmv.d.x f29, x0
+                fmv.d.x f30, x0
+                fmv.d.x f31, x0
+            .endm
+
+            .endif"#
+        )
+    };
+}
+
 macro_rules! include_asm_macros {
     () => {
         concat!(

--- a/modules/axhal/src/arch/riscv/trap.S
+++ b/modules/axhal/src/arch/riscv/trap.S
@@ -31,10 +31,18 @@
     csrw    sscratch, t0
 .endif
 
+    // restore sepc
     LDR     t0, sp, 31
-    LDR     t1, sp, 32
     csrw    sepc, t0
-    csrw    sstatus, t1
+    // restore sstatus, but don't change FS
+    LDR     t0, sp, 32              // t0 = sstatus to restore
+    csrr    t1, sstatus             // t1 = current sstatus
+    li      t2, 0x6000              // t2 = mask for FS
+    and     t1, t1, t2              // t1 = current FS
+    not     t2, t2                  // t2 = ~(mask for FS)
+    and     t0, t0, t2              // t0 = sstatus to restore(cleared FS)
+    or      t0, t0, t1              // t0 = sstatus to restore with current FS
+    csrw    sstatus, t0             // restore sstatus
 
     POP_GENERAL_REGS
     LDR     sp, sp, 1                   // load sp from tf.regs.sp


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [Support fp_simd for RISC-V #27](https://github.com/oscomp/arceos/pull/27) and [ for LA #41](https://github.com/oscomp/arceos/pull/41)

## Background
https://github.com/oscomp/arceos/issues/26:  fp_state scheduling context preservation is NOT available on riscv and loongarch64.

## Description
It introduces significant updates to support floating-point SIMD operations for LoongArch64 and RISC-V architectures.
Including changes to context management, assembly macros, and task switching logic, ensuring proper handling of floating-point registers and states during task execution and context switching.

- added a new FpStatus struct.
- extended TaskContext, UspaceContext to handle floating-point states.
- add `include_fp_asm_macros` for both architectures.

## Additional Notes
Compared to the original commits, `#[naked]` has been updated into `#[unsafe(naked)]` to adapt to the latest toolchain
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.