### PR TITLE
fix: make `AxNamespace` `Send + Sync`

### DIFF
--- a/modules/axns/src/lib.rs
+++ b/modules/axns/src/lib.rs
@@ -49,6 +49,9 @@ pub struct AxNamespace {
     alloc: bool,
 }
 
+unsafe impl Send for AxNamespace {}
+unsafe impl Sync for AxNamespace {}
+
 impl AxNamespace {
     /// Returns the base address of the namespace, which points to the start of
     /// all resources.
@@ -101,9 +104,10 @@ impl Drop for AxNamespace {
     fn drop(&mut self) {
         if self.alloc {
             let size = Self::section_size();
-            if size != 0 && !self.base.is_null() {
+            let base = self.base();
+            if size != 0 && !base.is_null() {
                 let layout = Layout::from_size_align(size, 64).unwrap();
-                unsafe { alloc::alloc::dealloc(self.base, layout) };
+                unsafe { alloc::alloc::dealloc(base, layout) };
             }
         }
     }


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [fix: make AxNamespace Send + Sync #30](https://github.com/oscomp/arceos/pull/30)

## Description
This PR changes the base field in AxNamespace from a raw pointer to a address, to make this type Send and Sync. This is necessary for sharing namespaces, otherwise we would have to trick the compiler.

It's the prerequisite requirements of https://github.com/oscomp/starry-next/pull/34

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.