### PR TITLE
feat: build without axstd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,13 @@ endif
 
 ifneq ($(wildcard $(APP)/Cargo.toml),)
   APP_TYPE := rust
+  AX_LIB ?= axstd
 else
   APP_TYPE := c
+  AX_LIB ?= axlibc
 endif
+
+NO_AXSTD ?= n
 
 # Feature parsing
 include scripts/make/features.mk

--- a/scripts/make/features.mk
+++ b/scripts/make/features.mk
@@ -13,14 +13,17 @@
 
 ifeq ($(APP_TYPE),c)
   ax_feat_prefix := axfeat/
-  lib_feat_prefix := axlibc/
   lib_features := fp_simd irq alloc multitask fs net fd pipe select epoll
 else
-  # TODO: it's better to use `axfeat/` as `ax_feat_prefix`, but all apps need to have `axfeat` as a dependency
-  ax_feat_prefix := axstd/
-  lib_feat_prefix := axstd/
+  ifeq ($(NO_AXSTD),y)
+    ax_feat_prefix := axfeat/
+  else
+    ax_feat_prefix := axstd/
+  endif
   lib_features :=
 endif
+
+lib_feat_prefix := $(AX_LIB)/
 
 override FEATURES := $(shell echo $(FEATURES) | tr ',' ' ')
 


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: [feat: build without axstd #21](https://github.com/oscomp/arceos/pull/21)

## Description
This PR fixes this by introducing a `NO_AXSTD` option (similar to `no_std` in Rust) to use `axfeat/` as `ax_feat_prefix` and `AX_LIB` to control `lib_feat_prefix` (note that this is separate from `NO_AXSTD` as apps might want to use arceos_posix_api as `AX_LIB`).

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.