### PR TITLE
feat: introduced the `check_region_access` method in the `AddrSpace`

### DIFF
--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -266,7 +266,7 @@ impl AddrSpace {
             }
 
             // This area overlaps with the memory region
-            if area.flags().contains(access_flags) {
+            if !area.flags().contains(access_flags) {
                 return false;
             }
 

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -252,11 +252,13 @@ impl AddrSpace {
     ///
     /// Returns `true` if the memory region given by `range` is all mapped and
     /// has proper permission flags (i.e. containing `access_flags`).
-    pub fn check_region_access(
+    pub fn can_access_range(
         &self,
-        mut range: VirtAddrRange,
+        start: VirtAddr,
+        size: usize,
         access_flags: MappingFlags,
     ) -> bool {
+        let mut range = VirtAddrRange::from_start_size(start, size);
         for area in self.areas.iter() {
             if area.end() <= range.start {
                 continue;

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -248,6 +248,37 @@ impl AddrSpace {
         self.areas.clear(&mut self.pt).unwrap();
     }
 
+    /// Checks whether an access to the specified memory region is valid.
+    ///
+    /// Returns `true` if the memory region given by `range` is all mapped and
+    /// has proper permission flags (i.e. containing `access_flags`).
+    pub fn check_region_access(
+        &self,
+        mut range: VirtAddrRange,
+        access_flags: MappingFlags,
+    ) -> bool {
+        for area in self.areas.iter() {
+            if area.end() <= range.start {
+                continue;
+            }
+            if area.start() > range.start {
+                return false;
+            }
+
+            // This area overlaps with the memory region
+            if area.flags().contains(access_flags) {
+                return false;
+            }
+
+            range.start = area.end();
+            if range.is_empty() {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Handles a page fault at the given address.
     ///
     /// `access_flags` indicates the access type that caused the page fault.


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

## Description
`check_region_access` verifies if a given memory region is fully mapped and has the required access permissions (`MappingFlags`). It iterates through memory areas, checking for overlaps and validating permission flags.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.