### PR TITLE
feat(mm): add populate_area, fix protect impl

### DIFF
--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use axerrno::{AxError, AxResult, ax_err};
 use axhal::mem::phys_to_virt;
-use axhal::paging::{MappingFlags, PageTable};
+use axhal::paging::{MappingFlags, PageTable, PagingError};
 use memory_addr::{
     MemoryAddr, PAGE_SIZE_4K, PageIter4K, PhysAddr, VirtAddr, VirtAddrRange, is_aligned_4k,
 };
@@ -159,21 +159,19 @@ impl AddrSpace {
         while let Some(area) = self.areas.find(start) {
             let backend = area.backend();
             if let Backend::Alloc { populate } = backend {
-                // Area is already populated.
-                if *populate {
-                    continue;
-                }
-                for addr in PageIter4K::new(start, area.end().min(end)).unwrap() {
-                    match self.pt.query(addr) {
-                        Ok(_) => {}
-                        // If the page is not mapped, try map it.
-                        Err(PagingError::NotMapped) => {
-                            if !backend.handle_page_fault(addr, area.flags(), &mut self.pt) {
-                                return Err(AxError::NoMemory);
+                if !*populate {
+                    for addr in PageIter4K::new(start, area.end().min(end)).unwrap() {
+                        match self.pt.query(addr) {
+                            Ok(_) => {}
+                            // If the page is not mapped, try map it.
+                            Err(PagingError::NotMapped) => {
+                                if !backend.handle_page_fault(addr, area.flags(), &mut self.pt) {
+                                    return Err(AxError::NoMemory);
+                                }
                             }
-                        }
-                        Err(_) => return Err(AxError::BadAddress),
-                    };
+                            Err(_) => return Err(AxError::BadAddress),
+                        };
+                    }
                 }
             }
             start = area.end();
@@ -196,12 +194,7 @@ impl AddrSpace {
     /// Returns an error if the address range is out of the address space or not
     /// aligned.
     pub fn unmap(&mut self, start: VirtAddr, size: usize) -> AxResult {
-        if !self.contains_range(start, size) {
-            return ax_err!(InvalidInput, "address out of range");
-        }
-        if !start.is_aligned_4k() || !is_aligned_4k(size) {
-            return ax_err!(InvalidInput, "address not aligned");
-        }
+        self.validate_region(start, size)?;
 
         self.areas
             .unmap(start, size, &mut self.pt)


### PR DESCRIPTION
# Background
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).
# Description
This PR has added the `populate_area` function to update the address detection logic in the `protect` function.  Also, replace manual validation with validate_region.
# Additional notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.