### PR TITLE
Always use `-softfloat` target for aarch64 and loongarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,19 +88,11 @@ include scripts/make/platform.mk
 ifeq ($(ARCH), x86_64)
   TARGET := x86_64-unknown-none
 else ifeq ($(ARCH), aarch64)
-  ifeq ($(findstring fp_simd,$(FEATURES)),)
-    TARGET := aarch64-unknown-none-softfloat
-  else
-    TARGET := aarch64-unknown-none
-  endif
+  TARGET := aarch64-unknown-none-softfloat
 else ifeq ($(ARCH), riscv64)
   TARGET := riscv64gc-unknown-none-elf
 else ifeq ($(ARCH), loongarch64)
-  ifeq ($(findstring fp_simd,$(FEATURES)),)
-    TARGET := loongarch64-unknown-none-softfloat
-  else
-    TARGET := loongarch64-unknown-none
-  endif
+  TARGET := loongarch64-unknown-none-softfloat
 else
   $(error "ARCH" must be one of "x86_64", "riscv64", "aarch64" or "loongarch64")
 endif

--- a/modules/axhal/src/arch/aarch64/context.rs
+++ b/modules/axhal/src/arch/aarch64/context.rs
@@ -293,7 +293,7 @@ unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task:
 #[cfg(feature = "fp_simd")]
 unsafe extern "C" fn fpstate_switch(_current_fpstate: &mut FpState, _next_fpstate: &FpState) {
     naked_asm!(
-        "
+        ".arch armv8
         // save fp/neon context
         mrs     x9, fpcr
         mrs     x10, fpsr

--- a/modules/axhal/src/arch/loongarch64/mod.rs
+++ b/modules/axhal/src/arch/loongarch64/mod.rs
@@ -204,8 +204,6 @@ pub unsafe fn write_thread_pointer(tp: usize) {
 pub fn cpu_init() {
     #[cfg(feature = "fp_simd")]
     loongArch64::register::euen::set_fpe(true);
-    #[cfg(feature = "fp_simd")]
-    loongArch64::register::euen::set_sxe(true);
 
     unsafe extern "C" {
         fn exception_entry_base();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,8 +5,6 @@ components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]
 targets = [
     "x86_64-unknown-none",
     "riscv64gc-unknown-none-elf",
-    "aarch64-unknown-none",
     "aarch64-unknown-none-softfloat",
-    "loongarch64-unknown-none",
     "loongarch64-unknown-none-softfloat",
 ]

--- a/scripts/make/build_c.mk
+++ b/scripts/make/build_c.mk
@@ -27,6 +27,8 @@ endif
 
 ifeq ($(ARCH), riscv64)
   CFLAGS += -march=rv64gc -mabi=lp64d -mcmodel=medany
+else ifeq ($(ARCH), loongarch64)
+  CFLAGS += -msoft-float
 endif
 
 ifeq ($(findstring fp_simd,$(FEATURES)),)
@@ -34,8 +36,6 @@ ifeq ($(findstring fp_simd,$(FEATURES)),)
     CFLAGS += -mno-sse
   else ifeq ($(ARCH), aarch64)
     CFLAGS += -mgeneral-regs-only
-  else ifeq ($(ARCH), loongarch64)
-    CFLAGS += -msoft-float
   endif
 else
   ifneq ($(filter $(ARCH),riscv64 aarch64),)

--- a/ulib/axlibc/src/setjmp.rs
+++ b/ulib/axlibc/src/setjmp.rs
@@ -8,7 +8,7 @@ use crate::ctypes;
 pub unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
     #[cfg(all(target_arch = "aarch64", feature = "fp_simd"))]
     core::arch::naked_asm!(
-        "
+        ".arch armv8
         stp x19, x20, [x0,#0]
         stp x21, x22, [x0,#16]
         stp x23, x24, [x0,#32]
@@ -167,7 +167,8 @@ pub unsafe extern "C" fn setjmp(_buf: *mut ctypes::__jmp_buf_tag) {
 pub unsafe extern "C" fn longjmp(_buf: *mut ctypes::__jmp_buf_tag, _val: c_int) -> ! {
     #[cfg(all(target_arch = "aarch64", feature = "fp_simd"))]
     core::arch::naked_asm!(
-        "ldp x19, x20, [x0,#0]
+        ".arch armv8
+        ldp x19, x20, [x0,#0]
         ldp x21, x22, [x0,#16]
         ldp x23, x24, [x0,#32]
         ldp x25, x26, [x0,#48]


### PR DESCRIPTION
For aarch64 and loongarch64, using a target without `-softfloat` will allow the kernel to use SIMD instructions for some optimization (e.g. `memcpy`). However, properly supporting floating point or SIMD instructions in the kernel would be very cumbersome.

In this PR, we use `-softfloat` target to completely disable kernel FP/SIMD support for aarch64 and loongarch64, regardless of whether the `fp_simd` feature is enabled or not. This means that the `fp_simd` feature will only allow FP/SIMD instructions to be used **in the application, not the kernel**. When the `fp_simd` feature is enabled, only a small piece of extended state switching code is included in the kernel to allow the application using FP/SIMD to run correctly.

However, due to the fact that apps and kernels are linked with the same target in Unikernel, it may cause the app to be unable to use hardware FP/SIMD instructions. But apps in the user mode (monolithic kernel) are not affected. The detailed support table is as the follow:

| FP/SIMD support  | x86_64 | aarch64 | riscv64 | loongarch64 |
|----------|--------|---------|---------|-------------|
| Rust Apps (unikernel) | × | × | × | × |
| C Apps (unikernel) | ✓ | ✓ | × | × |
| Any Apps (monolithic kernel) | ✓ | ✓ | ✓ | ✓ |
