### PR TITLE
feat: `POST_TRAP` callback linker support

### DIFF
--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -96,6 +96,8 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
+    linkme_POST_TRAP : { *(linkme_POST_TRAP) }
+    linkm2_POST_TRAP : { *(linkm2_POST_TRAP) }
     axns_resource : { *(axns_resource) }
 }
 INSERT AFTER .tbss;


### PR DESCRIPTION
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).

For further information, please refer to: oscomp/arceos#34.

Main update in https://github.com/arceos-org/axcpu/pull/8

## Description

This pull request adds a new section to the linker script to handle post-trap routines for two different memory segments. 

Linker script updates:

* [`modules/axhal/linker.lds.S`](diffhunk://#diff-cca1a20516f765d46bf52ce5dd45f0a0496023161e7dc8b7c20723abcbb16761R99-R100): Added `linkme_POST_TRAP` and `linkm2_POST_TRAP` sections to the `SECTIONS` block to include post-trap routines for the respective memory segments.

## Additional Notes
This is a step towards gradually merging downstream [oscamp/arceos](https://github.com/oscomp/arceos) into the main branch.