### PR TITLE
[fix]: incorrect writev implementation

### DIFF
--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -66,7 +66,15 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            ret += write_impl(fd, iov.iov_base, iov.iov_len)?;
+            let result = sys_write(fd, iov.iov_base, iov.iov_len);
+            if result < 0 {
+                return Ok(result);
+            }
+            ret += result;
+
+            if result < iov.iov_len as isize {
+                break;
+            }
         }
 
         Ok(ret)

--- a/api/arceos_posix_api/src/imp/io.rs
+++ b/api/arceos_posix_api/src/imp/io.rs
@@ -66,7 +66,10 @@ pub unsafe fn sys_writev(fd: c_int, iov: *const ctypes::iovec, iocnt: c_int) -> 
         let iovs = unsafe { core::slice::from_raw_parts(iov, iocnt as usize) };
         let mut ret = 0;
         for iov in iovs.iter() {
-            let result = sys_write(fd, iov.iov_base, iov.iov_len);
+            if iov.iov_len == 0 {
+                continue;
+            }
+            let result = write_impl(fd, iov.iov_base, iov.iov_len)?;
             if result < 0 {
                 return Ok(result);
             }


### PR DESCRIPTION
The original code assumes that each sys_write must be completely successful and does not handle:
1、The system call returns an error
2、Partial write (actual number of bytes written < number of bytes requested)

The new implementation complies with the standard:
The modified logic strictly follows the specification of the UNIX writev(2) system call:
If an error occurs, it will be terminated immediately and an error code will be returned
When a partial write occurs, the amount of data that has been successfully written will be retained and returned
The final return value ret accurately represents the total number of bytes actually written​