### PR TITLE
[fix] AddrSpace clone && fdon't map to zero address for lazily allocated memory area 

### DIFF
--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -315,6 +315,11 @@ impl AddrSpace {
                 .areas
                 .map(new_area, &mut new_aspace.pt, false)
                 .map_err(mapping_err_to_ax_err)?;
+
+            if matches!(backend, Backend::Linear { .. }) {
+                continue;
+            }
+
             // Copy data from old memory area to new memory area.
             for vaddr in
                 PageIter4K::new(area.start(), area.end()).expect("Failed to create page iterator")

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -302,22 +302,20 @@ impl AddrSpace {
         false
     }
 
-    /// 克隆 AddrSpace。这将创建一个新的页表，并将旧页表中的所有区域（包括内核区域）映射到新的页表中，但仅将用户区域的映射到新的 MemorySet 中。
-    ///
-    /// 如果发生错误，新创建的 MemorySet 将被丢弃并返回错误。
+    /// Clone a [`AddrSpace`] by re-mapping all [`MemoryArea`]s in a new page table and copying data in user space.
     pub fn clone_or_err(&mut self) -> AxResult<Self> {
         let mut new_aspace = crate::new_user_aspace(self.base(), self.size())?;
 
         for area in self.areas.iter() {
             let backend = area.backend();
-            // 将原始区域映射到新的页表中。
+            // Remap the memory area in the new address space.
             let new_area =
                 MemoryArea::new(area.start(), area.size(), area.flags(), backend.clone());
             new_aspace
                 .areas
                 .map(new_area, &mut new_aspace.pt, false)
                 .map_err(mapping_err_to_ax_err)?;
-            // 将原区域的数据复制到新区域中。
+            // Copy data from old memory area to new memory area.
             for vaddr in
                 PageIter4K::new(area.start(), area.end()).expect("Failed to create page iterator")
             {

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use axerrno::{AxError, AxResult, ax_err};
 use axhal::mem::phys_to_virt;
-use axhal::paging::{MappingFlags, PageTable};
+use axhal::paging::{MappingFlags, PageTable, PagingError};
 use memory_addr::{
     MemoryAddr, PAGE_SIZE_4K, PageIter4K, PhysAddr, VirtAddr, VirtAddrRange, is_aligned_4k,
 };
@@ -147,6 +147,39 @@ impl AddrSpace {
         Ok(())
     }
 
+    /// Add a new zero-initialized allocation mapping.
+    pub fn alloc_for_lazy(&mut self, start: VirtAddr, size: usize) -> AxResult {
+        let end = (start + size).align_up_4k();
+        let mut start = start.align_down_4k();
+        let size = end - start;
+        if !self.contains_range(start, size) {
+            return ax_err!(InvalidInput, "address out of range");
+        }
+        while let Some(area) = self.areas.find(start) {
+            let area_backend = area.backend();
+            if let Backend::Alloc { populate } = area_backend {
+                if !*populate {
+                    let count = (area.end().min(end) - start).align_up_4k() / PAGE_SIZE_4K;
+                    for i in 0..count {
+                        let addr = start + i * PAGE_SIZE_4K;
+                        Backend::handle_page_fault_alloc(
+                            addr,
+                            area.flags(),
+                            &mut self.pt,
+                            *populate,
+                        );
+                    }
+                }
+            }
+            start = area.end();
+            assert!(start.is_aligned_4k());
+        }
+        if start < end {
+            ax_err!(InvalidInput, "address out of range")?;
+        }
+        Ok(())
+    }
+
     /// Removes mappings within the specified virtual address range.
     ///
     /// Returns an error if the address range is out of the address space or not
@@ -267,6 +300,57 @@ impl AddrSpace {
             }
         }
         false
+    }
+
+    /// 克隆 AddrSpace。这将创建一个新的页表，并将旧页表中的所有区域（包括内核区域）映射到新的页表中，但仅将用户区域的映射到新的 MemorySet 中。
+    ///
+    /// 如果发生错误，新创建的 MemorySet 将被丢弃并返回错误。
+    pub fn clone_or_err(&mut self) -> AxResult<Self> {
+        let mut new_aspace = crate::new_user_aspace(self.base(), self.size())?;
+
+        for area in self.areas.iter() {
+            let backend = area.backend();
+            // 将原始区域映射到新的页表中。
+            let new_area =
+                MemoryArea::new(area.start(), area.size(), area.flags(), backend.clone());
+            new_aspace
+                .areas
+                .map(new_area, &mut new_aspace.pt, false)
+                .map_err(mapping_err_to_ax_err)?;
+            // 将原区域的数据复制到新区域中。
+            for vaddr in
+                PageIter4K::new(area.start(), area.end()).expect("Failed to create page iterator")
+            {
+                let addr = match self.pt.query(vaddr) {
+                    Ok((paddr, _, _)) => paddr,
+                    // If the page is not mapped, skip it.
+                    Err(PagingError::NotMapped) => continue,
+                    Err(_) => return Err(AxError::BadAddress),
+                };
+                let new_addr = match new_aspace.pt.query(vaddr) {
+                    Ok((paddr, _, _)) => paddr,
+                    // If the page is not mapped, try map it.
+                    Err(PagingError::NotMapped) => {
+                        if !backend.handle_page_fault(vaddr, area.flags(), &mut new_aspace.pt) {
+                            return Err(AxError::NoMemory);
+                        }
+                        match new_aspace.pt.query(vaddr) {
+                            Ok((paddr, _, _)) => paddr,
+                            Err(_) => return Err(AxError::BadAddress),
+                        }
+                    }
+                    Err(_) => return Err(AxError::BadAddress),
+                };
+                unsafe {
+                    core::ptr::copy_nonoverlapping(
+                        phys_to_virt(addr).as_ptr(),
+                        phys_to_virt(new_addr).as_mut_ptr(),
+                        PAGE_SIZE_4K,
+                    )
+                };
+            }
+        }
+        Ok(new_aspace)
     }
 }
 

--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -26,7 +26,6 @@ impl Backend {
     }
 
     pub(crate) fn map_alloc(
-        &self,
         start: VirtAddr,
         size: usize,
         flags: MappingFlags,
@@ -62,7 +61,6 @@ impl Backend {
     }
 
     pub(crate) fn unmap_alloc(
-        &self,
         start: VirtAddr,
         size: usize,
         pt: &mut PageTable,
@@ -86,7 +84,6 @@ impl Backend {
     }
 
     pub(crate) fn handle_page_fault_alloc(
-        &self,
         vaddr: VirtAddr,
         orig_flags: MappingFlags,
         pt: &mut PageTable,

--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -50,14 +50,10 @@ impl Backend {
                     }
                 }
             }
-            true
         } else {
-            // Map to a empty entry for on-demand mapping.
-            let flags = MappingFlags::empty();
-            pt.map_region(start, |_| 0.into(), size, flags, false, false)
-                .map(|tlb| tlb.ignore())
-                .is_ok()
+            // create mapping entries on demand later in `handle_page_fault_alloc`.
         }
+        true
     }
 
     pub(crate) fn unmap_alloc(
@@ -94,9 +90,9 @@ impl Backend {
         } else if let Some(frame) = alloc_frame(true) {
             // Allocate a physical frame lazily and map it to the fault address.
             // `vaddr` does not need to be aligned. It will be automatically
-            // aligned during `pt.remap` regardless of the page size.
-            pt.remap(vaddr, frame, orig_flags)
-                .map(|(_, tlb)| tlb.flush())
+            // aligned during `pt.map` regardless of the page size.
+            pt.map(vaddr, frame, PageSize::Size4K, orig_flags)
+                .map(|tlb| tlb.flush())
                 .is_ok()
         } else {
             false

--- a/modules/axmm/src/backend/linear.rs
+++ b/modules/axmm/src/backend/linear.rs
@@ -10,7 +10,6 @@ impl Backend {
     }
 
     pub(crate) fn map_linear(
-        &self,
         start: VirtAddr,
         size: usize,
         flags: MappingFlags,
@@ -32,7 +31,6 @@ impl Backend {
     }
 
     pub(crate) fn unmap_linear(
-        &self,
         start: VirtAddr,
         size: usize,
         pt: &mut PageTable,

--- a/modules/axmm/src/backend/mod.rs
+++ b/modules/axmm/src/backend/mod.rs
@@ -44,15 +44,15 @@ impl MappingBackend for Backend {
     type PageTable = PageTable;
     fn map(&self, start: VirtAddr, size: usize, flags: MappingFlags, pt: &mut PageTable) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.map_linear(start, size, flags, pt, pa_va_offset),
-            Self::Alloc { populate } => self.map_alloc(start, size, flags, pt, populate),
+            Self::Linear { pa_va_offset } => Self::map_linear(start, size, flags, pt, pa_va_offset),
+            Self::Alloc { populate } => Self::map_alloc(start, size, flags, pt, populate),
         }
     }
 
     fn unmap(&self, start: VirtAddr, size: usize, pt: &mut PageTable) -> bool {
         match *self {
-            Self::Linear { pa_va_offset } => self.unmap_linear(start, size, pt, pa_va_offset),
-            Self::Alloc { populate } => self.unmap_alloc(start, size, pt, populate),
+            Self::Linear { pa_va_offset } => Self::unmap_linear(start, size, pt, pa_va_offset),
+            Self::Alloc { populate } => Self::unmap_alloc(start, size, pt, populate),
         }
     }
 
@@ -80,7 +80,7 @@ impl Backend {
         match *self {
             Self::Linear { .. } => false, // Linear mappings should not trigger page faults.
             Self::Alloc { populate } => {
-                self.handle_page_fault_alloc(vaddr, orig_flags, page_table, populate)
+                Self::handle_page_fault_alloc(vaddr, orig_flags, page_table, populate)
             }
         }
     }


### PR DESCRIPTION
# Background
This PR is a reviewed feature from downstream [oscamp/arceos](https://github.com/oscomp/arceos).
Partial modifications are based on the[[feat] Support for ext4 junior ](https://github.com/arceos-org/arceos/commit/111dbc27acbc7e445767d288c2c08efb25f1e401)support.
# Description
- fix ：AddrSpace::clone_or_err cannot handle allocation mappings with populate=false by skipping unmapped pages in the source area and trying to allocate pages for unmapped pages in the destination area.
And some minor adjustments.
