### PR TITLE
Enhance truncate & smoltcp_impl (Nagle/MSS/Capacity); Request axfs_crates Release 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,8 +131,8 @@ dependencies = [
 name = "arceos-shell"
 version = "0.1.0"
 dependencies = [
- "axfs_ramfs",
- "axfs_vfs",
+ "axfs_ramfs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "axfs_vfs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "axstd",
  "crate_interface",
 ]
@@ -424,8 +424,8 @@ dependencies = [
  "axdriver_block",
  "axerrno",
  "axfs_devfs",
- "axfs_ramfs",
- "axfs_vfs",
+ "axfs_ramfs 0.1.1 (git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c)",
+ "axfs_vfs 0.1.1 (git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c)",
  "axio",
  "axns",
  "axsync",
@@ -441,10 +441,9 @@ dependencies = [
 [[package]]
 name = "axfs_devfs"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62eff0490e10cd2c2a74be2979820f0293fa5ebe00ee8bfd87b88ac7dd7d235"
+source = "git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c#155130301c91df11a9529a06e236bb915aa2bf1c"
 dependencies = [
- "axfs_vfs",
+ "axfs_vfs 0.1.1 (git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c)",
  "log",
  "spin",
 ]
@@ -455,7 +454,17 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db46c6dae25a123579d5fdcdcc502d0dc2a8af86646106004c8a9181433271b1"
 dependencies = [
- "axfs_vfs",
+ "axfs_vfs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
+ "spin",
+]
+
+[[package]]
+name = "axfs_ramfs"
+version = "0.1.1"
+source = "git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c#155130301c91df11a9529a06e236bb915aa2bf1c"
+dependencies = [
+ "axfs_vfs 0.1.1 (git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c)",
  "log",
  "spin",
 ]
@@ -465,6 +474,16 @@ name = "axfs_vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2314ebe07a2fef7b1c1a7d15ab817941cd306ace651bb50024b5a8b3e8485359"
+dependencies = [
+ "axerrno",
+ "bitflags 2.9.1",
+ "log",
+]
+
+[[package]]
+name = "axfs_vfs"
+version = "0.1.1"
+source = "git+https://github.com/arceos-org/axfs_crates.git?rev=155130301c91df11a9529a06e236bb915aa2bf1c#155130301c91df11a9529a06e236bb915aa2bf1c"
 dependencies = [
  "axerrno",
  "bitflags 2.9.1",

--- a/examples/shell/Cargo.toml
+++ b/examples/shell/Cargo.toml
@@ -11,7 +11,8 @@ use-ramfs = ["axstd/myfs", "dep:axfs_vfs", "dep:axfs_ramfs", "dep:crate_interfac
 default = []
 
 [dependencies]
-axfs_vfs = { version = "0.1", optional = true }
-axfs_ramfs = { version = "0.1", optional = true }
+
+axfs_vfs = { git = "https://github.com/arceos-org/axfs_crates.git", rev = "155130301c91df11a9529a06e236bb915aa2bf1c", optional = true }
+axfs_ramfs = { git = "https://github.com/arceos-org/axfs_crates.git", rev = "155130301c91df11a9529a06e236bb915aa2bf1c", optional = true }
 crate_interface = { version = "0.1", optional = true }
 axstd = { workspace = true, features = ["alloc", "fs"], optional = true }

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -27,9 +27,9 @@ lazyinit = "0.2"
 cap_access = "0.1"
 axio = { version = "0.1", features = ["alloc"] }
 axerrno = "0.1"
-axfs_vfs = "0.1"
-axfs_devfs = { version = "0.1", optional = true }
-axfs_ramfs = { version = "0.1", optional = true }
+axfs_vfs = { git = "https://github.com/arceos-org/axfs_crates.git", rev = "155130301c91df11a9529a06e236bb915aa2bf1c" }
+axfs_devfs = { git = "https://github.com/arceos-org/axfs_crates.git", rev = "155130301c91df11a9529a06e236bb915aa2bf1c", optional = true }
+axfs_ramfs = { git = "https://github.com/arceos-org/axfs_crates.git", rev = "155130301c91df11a9529a06e236bb915aa2bf1c", optional = true }
 crate_interface = { version = "0.1", optional = true }
 axsync = { workspace = true }
 axdriver = { workspace = true, features = ["block"] }

--- a/modules/axfs/src/fs/fatfs.rs
+++ b/modules/axfs/src/fs/fatfs.rs
@@ -87,8 +87,26 @@ impl VfsNodeOps for FileWrapper<'static> {
 
     fn truncate(&self, size: u64) -> VfsResult {
         let mut file = self.0.lock();
-        file.seek(SeekFrom::Start(size)).map_err(as_vfs_err)?; // TODO: more efficient
-        file.truncate().map_err(as_vfs_err)
+        let current_size = file.seek(SeekFrom::End(0)).map_err(as_vfs_err)?;
+        
+        if size <= current_size {
+            // If the target size is smaller than the current size,
+            // perform a standard truncation operation
+            file.seek(SeekFrom::Start(size)).map_err(as_vfs_err)?; // TODO: more efficient
+            file.truncate().map_err(as_vfs_err)
+        } else {
+            // Calculate the number of bytes to fill
+            let mut zeros_needed = size - current_size;
+            // Create a buffer of zeros
+            let zeros = [0u8; 4096];
+            while zeros_needed > 0 {
+                let to_write = core::cmp::min(zeros_needed, zeros.len() as u64);
+                let write_buf = &zeros[..to_write as usize];
+                file.write(write_buf).map_err(as_vfs_err)?;
+                zeros_needed -= to_write;
+            }
+            Ok(())
+        }
     }
 }
 

--- a/modules/axfs/src/fs/fatfs.rs
+++ b/modules/axfs/src/fs/fatfs.rs
@@ -88,7 +88,7 @@ impl VfsNodeOps for FileWrapper<'static> {
     fn truncate(&self, size: u64) -> VfsResult {
         let mut file = self.0.lock();
         let current_size = file.seek(SeekFrom::End(0)).map_err(as_vfs_err)?;
-        
+
         if size <= current_size {
             // If the target size is smaller than the current size,
             // perform a standard truncation operation

--- a/modules/axfs/src/mounts.rs
+++ b/modules/axfs/src/mounts.rs
@@ -7,11 +7,13 @@ use crate::fs;
 pub(crate) fn devfs() -> Arc<fs::devfs::DeviceFileSystem> {
     let null = fs::devfs::NullDev;
     let zero = fs::devfs::ZeroDev;
+    let urandom = fs::devfs::UrandomDev::default();
     let bar = fs::devfs::ZeroDev;
     let devfs = fs::devfs::DeviceFileSystem::new();
     let foo_dir = devfs.mkdir("foo");
     devfs.add("null", Arc::new(null));
     devfs.add("zero", Arc::new(zero));
+    devfs.add("urandom", Arc::new(urandom));
     foo_dir.add("bar", Arc::new(bar));
     Arc::new(devfs)
 }


### PR DESCRIPTION
I've extended the file size support for `truncate` and added several new interfaces to `smoltcp_impl`, including: `nagle_enabled`,`set_nagle_enabled`, `get_remote_mss`,`recv_capacity`,`send_capacity`

I'd like to request a new release for `axfs_crates`. I will modify `modules/axfs/src/mounts.rs` and `Cargo.lock` and submit again.
