### PR TITLE
smoltcp_impl: Add Nagle, and Capacity Interfaces

### DIFF
--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -348,51 +348,43 @@ impl TcpSocket {
     /// Checks if Nagle's algorithm is enabled for this TCP socket.
     #[inline]
     pub fn nodelay(&self) -> AxResult<bool> {
-        let handle = unsafe { self.handle.get().read() };
-        match handle {
-            Some(h) => {
-                Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.nagle_enabled()))
-            }
-            None => ax_err!(NotConnected, "socket is not connected"),
+        if let Some(h) = unsafe { self.handle.get().read() } {
+            Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.nagle_enabled()))
+        } else {
+            ax_err!(NotConnected, "socket is not connected")
         }
     }
 
     /// Enables or disables Nagle's algorithm for this TCP socket.
     #[inline]
-    pub fn set_nodelay(&self, enabled: bool) {
-        let handle = unsafe { self.handle.get().read().unwrap() };
-        SOCKET_SET.with_socket_mut::<tcp::Socket, _, _>(handle, |socket| {
-            socket.set_nagle_enabled(enabled);
-        });
+    pub fn set_nodelay(&self, enabled: bool) -> AxResult<()> {
+        if let Some(h) = unsafe { self.handle.get().read() } {
+            SOCKET_SET.with_socket_mut::<tcp::Socket, _, _>(h, |socket| {
+                socket.set_nagle_enabled(enabled);
+            });
+            Ok(())
+        } else {
+            ax_err!(NotConnected, "socket is not connected")
+        }
     }
 
     /// Returns the maximum capacity of the receive buffer in bytes.
     #[inline]
-    pub fn recv_capacity(&self) -> usize {
-        let handle = unsafe { self.handle.get().read() };
-        match handle {
-            Some(h) => {
-                SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.recv_capacity())
-            }
-            None => {
-                warn!("TCP socket: recv_capacity called on uninitialized socket");
-                0
-            }
+    pub fn recv_capacity(&self) -> AxResult<usize> {
+        if let Some(h) = unsafe { self.handle.get().read() } {
+            Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.recv_capacity()))
+        } else {
+            ax_err!(NotConnected, "socket is not connected")
         }
     }
 
     /// Returns the maximum capacity of the send buffer in bytes.
     #[inline]
-    pub fn send_capacity(&self) -> usize {
-        let handle = unsafe { self.handle.get().read() };
-        match handle {
-            Some(h) => {
-                SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.send_capacity())
-            }
-            None => {
-                warn!("TCP socket: send_capacity called on uninitialized socket");
-                0
-            }
+    pub fn send_capacity(&self) -> AxResult<usize> {
+        if let Some(h) = unsafe { self.handle.get().read() } {
+            Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.send_capacity()))
+        } else {
+            ax_err!(NotConnected, "socket is not connected")
         }
     }
 }

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -24,7 +24,6 @@ const STATE_BUSY: u8 = 1;
 const STATE_CONNECTING: u8 = 2;
 const STATE_CONNECTED: u8 = 3;
 const STATE_LISTENING: u8 = 4;
-const DEFAULT_MSS: usize = 536;
 
 /// A TCP socket that provides POSIX-like APIs.
 ///

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -348,14 +348,19 @@ impl TcpSocket {
 
     /// Checks if Nagle's algorithm is enabled for this TCP socket.
     #[inline]
-    pub fn nagle_enabled(&self) -> bool {
-        let handle = unsafe { self.handle.get().read().unwrap() };
-        SOCKET_SET.with_socket::<tcp::Socket, _, _>(handle, |socket| socket.nagle_enabled())
+    pub fn nodelay(&self) -> AxResult<bool> {
+        let handle = unsafe { self.handle.get().read() };
+        match handle {
+            Some(h) => {
+                Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.nagle_enabled()))
+            }
+            None => ax_err!(NotConnected, "socket is not connected"),
+        }
     }
 
     /// Enables or disables Nagle's algorithm for this TCP socket.
     #[inline]
-    pub fn set_nagle_enabled(&self, enabled: bool) {
+    pub fn set_nodelay(&self, enabled: bool) {
         let handle = unsafe { self.handle.get().read().unwrap() };
         SOCKET_SET.with_socket_mut::<tcp::Socket, _, _>(handle, |socket| {
             socket.set_nagle_enabled(enabled);
@@ -374,25 +379,31 @@ impl TcpSocket {
     /// Returns the maximum capacity of the receive buffer in bytes.
     #[inline]
     pub fn recv_capacity(&self) -> usize {
-        info!("TCP socket: recv_capacity called");
-        let handle = unsafe { self.handle.get().read() }
-            .unwrap_or_else(|| SOCKET_SET.add(SocketSetWrapper::new_tcp_socket()));
-        SOCKET_SET.with_socket::<tcp::Socket, _, _>(handle, |socket| {
-            info!("TCP socket: recv_capacity={}", socket.recv_capacity());
-            socket.recv_capacity()
-        })
+        let handle = unsafe { self.handle.get().read() };
+        match handle {
+            Some(h) => {
+                SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.recv_capacity())
+            }
+            None => {
+                warn!("TCP socket: recv_capacity called on uninitialized socket");
+                0
+            }
+        }
     }
 
     /// Returns the maximum capacity of the send buffer in bytes.
     #[inline]
     pub fn send_capacity(&self) -> usize {
-        info!("TCP socket: send_capacity called");
-        let handle = unsafe { self.handle.get().read() }
-            .unwrap_or_else(|| SOCKET_SET.add(SocketSetWrapper::new_tcp_socket()));
-        SOCKET_SET.with_socket::<tcp::Socket, _, _>(handle, |socket| {
-            info!("TCP socket: send_capacity={}", socket.send_capacity());
-            socket.send_capacity()
-        })
+        let handle = unsafe { self.handle.get().read() };
+        match handle {
+            Some(h) => {
+                SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.send_capacity())
+            }
+            None => {
+                warn!("TCP socket: send_capacity called on uninitialized socket");
+                0
+            }
+        }
     }
 }
 

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -367,15 +367,6 @@ impl TcpSocket {
         });
     }
 
-    /// Gets the Maximum Segment Size (MSS) of the remote peer.
-    /// In the future, if the user sets TCP_MAXSEG via sys_setsockopt,
-    /// it should return the value set by set_remote_mss,
-    /// otherwise it will return DEFAULT_MSS. But it is not used yet.
-    #[inline]
-    pub fn get_remote_mss(&self) -> usize {
-        DEFAULT_MSS
-    }
-
     /// Returns the maximum capacity of the receive buffer in bytes.
     #[inline]
     pub fn recv_capacity(&self) -> usize {


### PR DESCRIPTION
 added several new interfaces to smoltcp_impl, including: nagle_enabled,set_nagle_enabled, get_remote_mss,recv_capacity,send_capacity