### PR TITLE
[CI] add check for build and doc CI tasks under macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,10 @@ jobs:
       run: make clippy ARCH=${{ matrix.arch }}
 
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         arch: [x86_64, riscv64, aarch64, loongarch64]
         rust-toolchain: [nightly, nightly-2025-05-20]
     env:
@@ -86,11 +85,10 @@ jobs:
       run: make ARCH=${{ matrix.arch }} A=examples/httpserver-c
 
   build-for-other-platforms:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         rust-toolchain: [nightly, nightly-2025-05-20]
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
@@ -151,3 +149,53 @@ jobs:
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make PLATFORM=x86_64-pc-oslab A=examples/httpserver-c FEATURES=page-alloc-4g,driver-ixgbe
 
+  # Necessary checks for macOS builds
+  build-for-macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-toolchain: [nightly, nightly-2025-05-20]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+        components: rust-src, clippy
+        targets: x86_64-unknown-none
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: cargo-bin-cache
+        cache-targets: false
+    - name: Clippy for the default target
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make clippy
+
+    - run: cargo install cargo-binutils
+    - name: Build helloworld
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make A=examples/helloworld
+
+    # Test for other platforms
+    - run: make PLATFORM=x86_64-pc-oslab defconfig
+    - name: Build helloworld for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/helloworld
+    - name: Build shell for x86_64-pc-oslab
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=x86_64-pc-oslab A=examples/shell FEATURES=page-alloc-4g,driver-ramdisk
+
+    - run: make PLATFORM=aarch64-raspi4 defconfig
+    - name: Build helloworld for aarch64-raspi4
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=aarch64-raspi4 SMP=4 A=examples/helloworld
+
+    - run: make PLATFORM=aarch64-bsta1000b defconfig
+    - name: Build helloworld for aarch64-bsta1000b
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=aarch64-bsta1000b A=examples/helloworld SMP=8
+
+    - run: make PLATFORM=aarch64-phytium-pi defconfig
+    - name: Build helloworld for aarch64-phytium-pi
+      continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
+      run: make PLATFORM=aarch64-phytium-pi A=examples/helloworld SMP=4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,10 @@ env:
 
 jobs:
   doc:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     permissions:
       contents: write
@@ -24,10 +26,9 @@ jobs:
         shared-key: cargo-bin-cache
         cache-targets: false
     - name: Build docs
-      continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: make doc_check_missing
     - name: Deploy to Github Pages
-      if: ${{ github.ref == env.default-branch }}
+      if: ${{ github.ref == env.default-branch && matrix.os == 'ubuntu-latest' }}
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         single-commit: true

--- a/modules/axhal/src/platform/mod.rs
+++ b/modules/axhal/src/platform/mod.rs
@@ -1,7 +1,7 @@
 //! Platform-specific operations.
 
 cfg_if::cfg_if! {
-    if #[cfg(target_arch = "aarch64")]{
+    if #[cfg(all(target_arch = "aarch64", target_os = "none"))]{
         mod aarch64_common;
     }
 }

--- a/modules/axns/src/lib.rs
+++ b/modules/axns/src/lib.rs
@@ -23,13 +23,9 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use core::{alloc::Layout, fmt, ops::Deref};
-
 use lazyinit::LazyInit;
 
-unsafe extern "C" {
-    fn __start_axns_resource();
-    fn __stop_axns_resource();
-}
+pub mod link;
 
 /// A namespace that contains all user-defined resources.
 ///
@@ -66,13 +62,13 @@ impl AxNamespace {
 
     /// Returns the size of the `axns_resource` section.
     fn section_size() -> usize {
-        __stop_axns_resource as usize - __start_axns_resource as usize
+        link::section_end() as usize - link::section_start() as usize
     }
 
     /// Returns the global namespace.
     pub fn global() -> Self {
         Self {
-            base: __start_axns_resource as *mut u8,
+            base: link::section_start() as *mut u8,
             alloc: false,
         }
     }
@@ -92,7 +88,7 @@ impl AxNamespace {
         } else {
             let layout = Layout::from_size_align(size, 64).unwrap();
             let dst = unsafe { alloc::alloc::alloc(layout) };
-            let src = __start_axns_resource as *const u8;
+            let src = link::section_start();
             unsafe { core::ptr::copy_nonoverlapping(src, dst, size) };
             dst
         };
@@ -233,14 +229,9 @@ macro_rules! def_resource {
 
             impl $name {
                 unsafe fn deref_from_base(&self, ns_base: *mut u8) -> &$ty {
-                    unsafe extern {
-                        fn __start_axns_resource();
-                    }
+                    $crate::def_static_resource!(RES, $ty, $default);
 
-                    #[unsafe(link_section = "axns_resource")]
-                    static RES: $ty = $default;
-
-                    let offset = &RES as *const _ as usize - __start_axns_resource as usize;
+                    let offset = &RES as *const _ as *const u8 as usize - $crate::link::section_start() as usize;
                     let ptr = unsafe{ ns_base.add(offset) } as *const _;
                     unsafe{ &*ptr }
                 }

--- a/modules/axns/src/link.rs
+++ b/modules/axns/src/link.rs
@@ -1,0 +1,103 @@
+//! Module for defining static resources in the `axns_resource` section under
+//! different operating systems.
+//!
+//! The implementation is based on `link_section` attributes and platform-specific
+//! linker support.
+
+#[cfg(any(target_os = "linux", target_os = "none"))]
+#[macro_use]
+pub mod linux {
+    //! Module for defining static resources in the `axns_resource` section under Linux and
+    //! other similar ELF environments.
+
+    unsafe extern "C" {
+        fn __start_axns_resource();
+        fn __stop_axns_resource();
+    }
+
+    /// Defines a static resource of the specified type and default value,
+    /// placing it in the custom linker section `axns_resource`.
+    ///
+    /// # Parameters
+    /// - `$ty`: The type of the static resource.
+    /// - `$default`: The default value to initialize the resource with.
+    ///
+    /// # Generated Items
+    /// - A static variable `RES` of type `$ty`, initialized with `$default`.
+    /// - A function `res_ptr()` that returns a raw pointer to the resource as `*const u8`.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// def_static_resource!(u32, 0);
+    /// ```
+    #[macro_export]
+    macro_rules! def_static_resource {
+        (RES, $ty: ty, $default: expr) => {
+            #[unsafe(link_section = "axns_resource")]
+            static RES: $ty = $default;
+        };
+    }
+
+    /// Returns a raw pointer to the static resource defined in the `axns_resource` section.
+    pub fn section_start() -> *const u8 {
+        __start_axns_resource as *const u8
+    }
+
+    /// Returns a raw pointer to the end of the `axns_resource` section.
+    pub fn section_end() -> *const u8 {
+        __stop_axns_resource as *const u8
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[macro_use]
+pub mod macho {
+    //! Module for defining static resources in the `axns_resource` section under macOS
+    //! and other similar mach-O environments.
+
+    unsafe extern "Rust" {
+        #[link_name = "\u{1}section$start$__AXNS$__axns_resource"]
+        static AXNS_RESOURCE_START: *const u8;
+        #[link_name = "\u{1}section$end$__AXNS$__axns_resource"]
+        static AXNS_RESOURCE_END: *const u8;
+    }
+
+    #[macro_export]
+    /// Defines a static resource of the specified type and default value,
+    /// placing it in the custom linker section `axns_resource`.
+    ///
+    /// # Parameters
+    /// - `$ty`: The type of the static resource.
+    /// - `$default`: The default value to initialize the resource with.
+    ///
+    /// # Generated Items
+    /// - A static variable `RES` of type `$ty`, initialized with `$default`.
+    /// - A function `res_ptr()` that returns a raw pointer to the resource as `*const u8`.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// def_static_resource!(u32, 0);
+    /// ```
+    macro_rules! def_static_resource {
+        (RES, $ty: ty, $default: expr) => {
+            #[unsafe(link_section = "__AXNS,axns_resource")]
+            static RES: $ty = $default;
+        };
+    }
+
+    /// Returns a pointer to the start of `axns_resource` section.
+    pub fn section_start() -> *const u8 {
+        unsafe { AXNS_RESOURCE_START }
+    }
+
+    /// Returns a pointer to the end of `axns_resource` section.
+    pub fn section_end() -> *const u8 {
+        unsafe { AXNS_RESOURCE_END }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "none"))]
+pub use linux::*;
+
+#[cfg(target_os = "macos")]
+pub use macho::*;


### PR DESCRIPTION
This PR adds check for building and checking documentation of ArceOS on the `macOS` environment in CICD.

And it fixes two bugs that caused `ArceOS` to fail to build on `macOS`.

