### PR TITLE
Release v0.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ulib/axlibc/include/**/*.h linguist-vendored

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ jobs:
         toolchain: ${{ matrix.rust-toolchain }}
         components: rust-src, clippy, rustfmt
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
-    - uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: cargo-bin-cache
-        cache-targets: false
     - name: Check rust version
       run: rustc --version --verbose
     - name: Check code format
@@ -55,7 +51,7 @@ jobs:
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
       with:
-        shared-key: cargo-bin-cache
+        shared-key: cargo-bin-cache-${{ matrix.rust-toolchain }}
         cache-targets: false
     - name: Build helloworld
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
@@ -100,10 +96,10 @@ jobs:
         targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
       with:
-        shared-key: cargo-bin-cache
+        shared-key: cargo-bin-cache-${{ matrix.rust-toolchain }}
         cache-targets: false
 
-    # Test various config files
+    # Test custom config file
     - name: Build helloworld for x86_64-pc-oslab
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make PLAT_CONFIG=$(pwd)/configs/custom/x86_64-pc-oslab.toml A=examples/helloworld
@@ -140,27 +136,23 @@ jobs:
       run: |
         make MYPLAT=axplat-aarch64-bsta1000b defconfig
         make MYPLAT=axplat-aarch64-bsta1000b A=examples/helloworld-myplat APP_FEATURES=aarch64-bsta1000b
-      
     - name: Build helloworld-myplat for aarch64-phytium-pi
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: |
         make MYPLAT=axplat-aarch64-phytium-pi defconfig
         make MYPLAT=axplat-aarch64-phytium-pi A=examples/helloworld-myplat APP_FEATURES=aarch64-phytium-pi
-
     - name: Build helloworld-myplat for loongarch64-qemu-virt
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: |
         make ARCH=loongarch64 defconfig
         make ARCH=loongarch64 A=examples/helloworld-myplat SMP=4 APP_FEATURES=loongarch64-qemu-virt
         make MYPLAT=axplat-loongarch64-qemu-virt A=examples/helloworld-myplat SMP=4 APP_FEATURES=loongarch64-qemu-virt
-      
     - name: Build helloworld-myplat for riscv64-qemu-virt
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: |
         make ARCH=riscv64 defconfig
         make ARCH=riscv64 A=examples/helloworld-myplat SMP=4 APP_FEATURES=riscv64-qemu-virt
         make MYPLAT=axplat-riscv64-qemu-virt A=examples/helloworld-myplat SMP=4 APP_FEATURES=riscv64-qemu-virt
-      
 
     # Test platform `aarch64-raspi4` for various apps
     - name: Setup aarch64-raspi4
@@ -210,7 +202,7 @@ jobs:
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make MYPLAT=axplat-aarch64-phytium-pi A=examples/shell FEATURES=page-alloc-4g,driver-ramdisk BUS=mmio
 
-    # Test various config files for C apps
+    # Test custom config file for C apps
     - uses: arceos-org/setup-musl@v1
       with:
         arch: x86_64
@@ -233,22 +225,23 @@ jobs:
       fail-fast: false
       matrix:
         rust-toolchain: [nightly, nightly-2025-05-20]
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust-toolchain }}
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ matrix.rust-toolchain }}
-        components: rust-src, clippy
+        components: rust-src, clippy, llvm-tools
         targets: x86_64-unknown-none
     - uses: Swatinem/rust-cache@v2
       with:
-        shared-key: cargo-bin-cache
+        shared-key: cargo-bin-cache-${{ matrix.rust-toolchain }}
         cache-targets: false
     - name: Clippy for the default target
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make clippy
 
-    - run: cargo install cargo-binutils
     - name: Build helloworld
       continue-on-error: ${{ matrix.rust-toolchain == 'nightly' }}
       run: make A=examples/helloworld

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}
-    - uses: Swatinem/rust-cache@v2
-      with:
-        shared-key: cargo-bin-cache
-        cache-targets: false
     - name: Build docs
       run: make doc_check_missing ARCH=${{ matrix.os == 'macos-latest' && 'aarch64' || 'x86_64' }}
     - name: Deploy to Github Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}
-        components: rust-src
     - name: Run unit tests
       run: make unittest_no_fail_fast
 
@@ -26,15 +25,18 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [x86_64, riscv64, aarch64, loongarch64]
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2025-05-20
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ env.rust-toolchain }}
-        components: rust-src
+        components: rust-src, llvm-tools
+        targets: x86_64-unknown-none, riscv64gc-unknown-none-elf, aarch64-unknown-none-softfloat, loongarch64-unknown-none-softfloat
     - uses: Swatinem/rust-cache@v2
       with:
-        shared-key: cargo-bin-cache
+        shared-key: cargo-bin-cache-${{ env.rust-toolchain }}
         cache-targets: false
     - uses: arceos-org/setup-qemu@v1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "ctor_bare",
  "flatten_objects",
  "lazy_static",
- "spin",
+ "spin 0.10.0",
  "static_assertions",
 ]
 
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "axcpu"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835db849dcf67c2e67fd8efb70351365d4268c37b12970ef4cf25bb1d4c12187"
+checksum = "e09bc1235e3da45e942b50f47812f8397ad84cb490264bf914c65ac44e6f8b1d"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "cfg-if",
@@ -302,7 +302,7 @@ dependencies = [
  "static_assertions",
  "tock-registers 0.9.0",
  "x86",
- "x86_64 0.15.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "fxmac_rs",
  "ixgbe-driver",
  "log",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ checksum = "81b87ae981272ca8d5d8f106a4452c63f4b5ac36e17ee8f848ee1b250538b9f8"
 dependencies = [
  "axfs_vfs",
  "log",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ checksum = "9f50c26614485d837a3fc09a92f24a226caddc25a30df7e6aaf4bd19b304c399"
 dependencies = [
  "axfs_vfs",
  "log",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "lazyinit",
  "log",
  "smoltcp 0.12.0",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-x86-pc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5cd7aa6fbc9d3be3733cb5df6d800375a288e634036bf6c2d3ac08b64fc5283"
+checksum = "05b1b3bee47e2965347b943c86adb1a65555d90e4d5e6271fe99489957520590"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -743,7 +743,7 @@ dependencies = [
  "uart_16550",
  "x2apic",
  "x86",
- "x86_64 0.15.2",
+ "x86_64",
  "x86_rtc",
 ]
 
@@ -766,6 +766,15 @@ dependencies = [
  "crate_interface",
  "ctor_bare",
  "percpu",
+]
+
+[[package]]
+name = "axsched"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de469da35f912194e4104cc2f51bff63d6c184b65b6ebf8e90e2cd162b7f3c"
+dependencies = [
+ "linked_list_r4l",
 ]
 
 [[package]]
@@ -797,6 +806,7 @@ version = "0.1.0"
 dependencies = [
  "axconfig",
  "axhal",
+ "axsched",
  "axtask",
  "cfg-if",
  "cpumask",
@@ -808,7 +818,6 @@ dependencies = [
  "memory_addr",
  "percpu",
  "rand",
- "scheduler",
  "timer_list",
 ]
 
@@ -831,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
@@ -917,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.28"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -1151,7 +1160,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "fatfs"
 version = "0.4.0"
-source = "git+https://github.com/rafalh/rust-fatfs?rev=85f06e0#85f06e08edbd3368e1b0562f2fc1b6d178bf7b8a"
+source = "git+https://github.com/rafalh/rust-fatfs?rev=4eccb50#4eccb50d011146fbed20e133d33b22f3c27292e7"
 dependencies = [
  "bitflags 2.9.1",
  "log",
@@ -1233,7 +1242,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1356,7 +1365,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1382,9 +1391,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked_list"
-version = "0.1.0"
-source = "git+https://github.com/arceos-org/linked_list.git?tag=v0.1.0#34c8db301882cecfeb56df0f7c89978dbc62f49a"
+name = "linked_list_r4l"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c6e48d7df84e6414be8e53976ead35ba4d47a4ba561eaad5d1e2b1447b4c0a"
 
 [[package]]
 name = "linkme"
@@ -1520,7 +1530,7 @@ dependencies = [
  "aarch64-cpu 10.0.0",
  "bitflags 2.9.1",
  "memory_addr",
- "x86_64 0.15.2",
+ "x86_64",
 ]
 
 [[package]]
@@ -1552,7 +1562,7 @@ dependencies = [
  "cfg-if",
  "kernel_guard",
  "percpu_macros",
- "spin",
+ "spin 0.9.8",
  "x86",
 ]
 
@@ -1793,14 +1803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
-name = "scheduler"
-version = "0.1.0"
-source = "git+https://github.com/arceos-org/scheduler.git?tag=v0.1.0#c8d25d9aed146dca28dc8987afd229b52c20361a"
-dependencies = [
- "linked_list",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +1861,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -2319,15 +2330,15 @@ dependencies = [
 
 [[package]]
 name = "x2apic"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbcd582541cbb8ef1dfc24a3c849a64ff074b1b512af723ad90056558d424602"
+checksum = "db5cbcb7faedfa15f90376004ffc0cb42e427623ab56629f0073d275ee8e7043"
 dependencies = [
  "bit",
  "bitflags 1.3.2",
  "paste",
  "raw-cpuid 10.7.0",
- "x86_64 0.14.13",
+ "x86_64",
 ]
 
 [[package]]
@@ -2339,18 +2350,6 @@ dependencies = [
  "bit_field",
  "bitflags 1.3.2",
  "raw-cpuid 10.7.0",
-]
-
-[[package]]
-name = "x86_64"
-version = "0.14.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c101112411baafbb4bf8d33e4c4a80ab5b02d74d2612331c61e8192fc9710491"
-dependencies = [
- "bit_field",
- "bitflags 2.9.1",
- "rustversion",
- "volatile 0.4.6",
 ]
 
 [[package]]
@@ -2372,7 +2371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1a42420da20c01d82e5d42231570efa3b9e16a5515eaaf9ee4e964f49cc1313"
 dependencies = [
  "cfg-if",
- "x86_64 0.15.2",
+ "x86_64",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "arceos_api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "arceos_posix_api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -243,7 +243,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axalloc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "allocator",
  "axerrno",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "axconfig"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axconfig-macros",
 ]
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "axdisplay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axdriver",
  "axdriver_display",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "axdma"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "allocator",
  "axalloc",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "axdriver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "axfeat"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axdisplay",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "axfs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axdriver",
  "axdriver_block",
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "axhal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "axalloc",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "axlibc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arceos_posix_api",
  "axerrno",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "axlog"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axlog",
  "cfg-if",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "axmm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "axnet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axdriver",
  "axdriver_net",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "axns"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axns",
  "crate_interface",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "axruntime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "axstd"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arceos_api",
  "axerrno",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "axsync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axsync",
  "axtask",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "axtask"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axconfig",
  "axhal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
         pkg-config libglib2.0-dev git libslirp-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install cargo-binutils axconfig-gen
+RUN cargo install cargo-binutils axconfig-gen cargo-axplat
 
 COPY rust-toolchain.toml /rust-toolchain.toml
 
@@ -25,15 +25,15 @@ RUN wget https://musl.cc/aarch64-linux-musl-cross.tgz \
     && tar zxf loongarch64-linux-musl-cross.tgz \
     && rm -f *.tgz
 
-RUN wget https://download.qemu.org/qemu-9.2.1.tar.xz \
-    && tar xf qemu-9.2.1.tar.xz \
-    && cd qemu-9.2.1 \
-    && ./configure --prefix=/qemu-bin-9.2.1 \
+RUN wget https://download.qemu.org/qemu-9.2.4.tar.xz \
+    && tar xf qemu-9.2.4.tar.xz \
+    && cd qemu-9.2.4 \
+    && ./configure --prefix=/qemu-bin-9.2.4 \
         --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
         --enable-gcov --enable-debug --enable-slirp \
     && make -j$(nproc) \
     && make install
-RUN rm -rf qemu-9.2.1 qemu-9.2.1.tar.xz
+RUN rm -rf qemu-9.2.4 qemu-9.2.4.tar.xz
 
 ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:$PATH"
-ENV PATH="/qemu-bin-9.2.1/bin:$PATH"
+ENV PATH="/qemu-bin-9.2.4/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ endif
 
 .DEFAULT_GOAL := all
 
-ifneq ($(filter $(or $(MAKECMDGOALS), $(.DEFAULT_GOAL)), all build run justrun debug defconfig oldconfig),)
+ifneq ($(filter $(or $(MAKECMDGOALS), $(.DEFAULT_GOAL)), all build disasm run justrun debug defconfig oldconfig),)
 # Install dependencies
 include scripts/make/deps.mk
 # Platform resolving

--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ make PLAT_CONFIG=$(pwd)/configs/custom/x86_64-pc-oslab.toml A=examples/httpserve
 ```toml
 # In Cargo.toml
 [dependencies]
-axalloc = { git = "https://github.com/arceos-org/arceos.git", tag = "v0.1.0" } # modules/axalloc
-axhal = { git = "https://github.com/arceos-org/arceos.git", tag = "v0.1.0" } # modules/axhal
+axalloc = { git = "https://github.com/arceos-org/arceos.git", tag = "v0.2.0" } # modules/axalloc
+axhal = { git = "https://github.com/arceos-org/arceos.git", tag = "v0.2.0" } # modules/axhal
 ```
 
 ## Design

--- a/README.md
+++ b/README.md
@@ -180,7 +180,14 @@ Examples are given below and in the [app-helloworld](https://github.com/arceos-o
 
 ## How to build ArceOS for specific platforms and devices
 
-Set the `MYPLAT` variable when run `make`:
+You need to manually link your application with the appropriate platform packages:
+
+```rs
+// Add this line to your application (for raspi4 platform)
+extern crate axplat_aarch64_raspi;
+```
+
+Then set the `MYPLAT` variable when run `make`:
 
 ```bash
 # Build helloworld for raspi4

--- a/api/arceos_posix_api/Cargo.toml
+++ b/api/arceos_posix_api/Cargo.toml
@@ -50,9 +50,9 @@ axio = "0.1"
 axerrno = "0.1"
 flatten_objects = "0.2"
 static_assertions = "1.1.0"
-spin = { version = "0.9" }
+spin = { version = "0.10" }
 lazy_static = { version = "1.5", features = ["spin_no_std"] }
 ctor_bare = "0.2"
 
 [build-dependencies]
-bindgen ={ version = "0.71" }
+bindgen ={ version = "0.72" }

--- a/configs/custom/x86_64-pc-oslab.toml
+++ b/configs/custom/x86_64-pc-oslab.toml
@@ -55,3 +55,5 @@ pci-ranges = []                 # [(uint, uint)]
 
 # Timer interrupt frequencyin Hz. (4.0GHz)
 timer-frequency = 4_000_000_000     # uint
+# Timer interrupt num.
+timer-irq = 0xf0                    # uint

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -38,7 +38,7 @@ axns = { workspace = true }
 
 [dependencies.fatfs]
 git = "https://github.com/rafalh/rust-fatfs"
-rev = "85f06e0"
+rev = "4eccb50"
 optional = true
 default-features = false
 features = [ # no std

--- a/modules/axfs/src/api/mod.rs
+++ b/modules/axfs/src/api/mod.rs
@@ -10,7 +10,7 @@ use alloc::{string::String, vec::Vec};
 use axio::{self as io, prelude::*};
 
 /// Returns an iterator over the entries within a directory.
-pub fn read_dir(path: &str) -> io::Result<ReadDir> {
+pub fn read_dir(path: &str) -> io::Result<ReadDir<'_>> {
     ReadDir::new(path)
 }
 

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -104,6 +104,7 @@ pub mod context {
 
 pub use axcpu::asm;
 pub use axplat::init::{init_early, init_later};
+
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
 
@@ -119,6 +120,7 @@ pub fn init_percpu(cpu_id: usize) {
 ///
 /// This function should be called as early as possible, as other initializations
 /// may acess the CPU-local data.
+#[cfg(feature = "smp")]
 pub fn init_percpu_secondary(cpu_id: usize) {
     self::percpu::init_secondary(cpu_id);
 }

--- a/modules/axnet/Cargo.toml
+++ b/modules/axnet/Cargo.toml
@@ -16,7 +16,7 @@ default = ["smoltcp"]
 [dependencies]
 log = "=0.4.21"
 cfg-if = "1.0"
-spin = "0.9"
+spin = "0.10"
 lazyinit = "0.2"
 axerrno = "0.1"
 axio = "0.1"

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -74,7 +74,6 @@ impl TcpSocket {
 
     /// Returns the local address and port, or
     /// [`Err(NotConnected)`](AxError::NotConnected) if not connected.
-    #[inline]
     pub fn local_addr(&self) -> AxResult<SocketAddr> {
         match self.get_state() {
             STATE_CONNECTED | STATE_LISTENING => {
@@ -86,7 +85,6 @@ impl TcpSocket {
 
     /// Returns the remote address and port, or
     /// [`Err(NotConnected)`](AxError::NotConnected) if not connected.
-    #[inline]
     pub fn peer_addr(&self) -> AxResult<SocketAddr> {
         match self.get_state() {
             STATE_CONNECTED | STATE_LISTENING => {
@@ -345,7 +343,6 @@ impl TcpSocket {
     }
 
     /// Checks if Nagle's algorithm is enabled for this TCP socket.
-    #[inline]
     pub fn nodelay(&self) -> AxResult<bool> {
         if let Some(h) = unsafe { self.handle.get().read() } {
             Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.nagle_enabled()))
@@ -355,7 +352,6 @@ impl TcpSocket {
     }
 
     /// Enables or disables Nagle's algorithm for this TCP socket.
-    #[inline]
     pub fn set_nodelay(&self, enabled: bool) -> AxResult<()> {
         if let Some(h) = unsafe { self.handle.get().read() } {
             SOCKET_SET.with_socket_mut::<tcp::Socket, _, _>(h, |socket| {
@@ -368,7 +364,6 @@ impl TcpSocket {
     }
 
     /// Returns the maximum capacity of the receive buffer in bytes.
-    #[inline]
     pub fn recv_capacity(&self) -> AxResult<usize> {
         if let Some(h) = unsafe { self.handle.get().read() } {
             Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.recv_capacity()))
@@ -378,7 +373,6 @@ impl TcpSocket {
     }
 
     /// Returns the maximum capacity of the send buffer in bytes.
-    #[inline]
     pub fn send_capacity(&self) -> AxResult<usize> {
         if let Some(h) = unsafe { self.handle.get().read() } {
             Ok(SOCKET_SET.with_socket::<tcp::Socket, _, _>(h, |socket| socket.send_capacity()))

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -18,7 +18,7 @@ multitask = [
     "dep:kspin",
     "dep:lazyinit",
     "dep:memory_addr",
-    "dep:scheduler",
+    "dep:axsched",
     "dep:timer_list",
     "kernel_guard",
     "dep:crate_interface",
@@ -48,7 +48,7 @@ timer_list = { version = "0.1", optional = true }
 kernel_guard = { version = "0.1", optional = true }
 crate_interface = { version = "0.1", optional = true }
 cpumask = { version = "0.1", optional = true }
-scheduler = { git = "https://github.com/arceos-org/scheduler.git", tag = "v0.1.0", optional = true }
+axsched = { version = "0.3", optional = true }
 
 [dev-dependencies]
 rand = "0.9"

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -22,15 +22,15 @@ pub type AxCpuMask = cpumask::CpuMask<{ axconfig::plat::CPU_NUM }>;
 cfg_if::cfg_if! {
     if #[cfg(feature = "sched-rr")] {
         const MAX_TIME_SLICE: usize = 5;
-        pub(crate) type AxTask = scheduler::RRTask<TaskInner, MAX_TIME_SLICE>;
-        pub(crate) type Scheduler = scheduler::RRScheduler<TaskInner, MAX_TIME_SLICE>;
+        pub(crate) type AxTask = axsched::RRTask<TaskInner, MAX_TIME_SLICE>;
+        pub(crate) type Scheduler = axsched::RRScheduler<TaskInner, MAX_TIME_SLICE>;
     } else if #[cfg(feature = "sched-cfs")] {
-        pub(crate) type AxTask = scheduler::CFSTask<TaskInner>;
-        pub(crate) type Scheduler = scheduler::CFScheduler<TaskInner>;
+        pub(crate) type AxTask = axsched::CFSTask<TaskInner>;
+        pub(crate) type Scheduler = axsched::CFScheduler<TaskInner>;
     } else {
         // If no scheduler features are set, use FIFO as the default.
-        pub(crate) type AxTask = scheduler::FifoTask<TaskInner>;
-        pub(crate) type Scheduler = scheduler::FifoScheduler<TaskInner>;
+        pub(crate) type AxTask = axsched::FifoTask<TaskInner>;
+        pub(crate) type Scheduler = axsched::FifoScheduler<TaskInner>;
     }
 }
 

--- a/modules/axtask/src/lib.rs
+++ b/modules/axtask/src/lib.rs
@@ -21,9 +21,9 @@
 //! - `sched-cfs`: Use the [Completely Fair Scheduler][3]. It also enables the
 //!   the `multitask` and `preempt` features if it is enabled.
 //!
-//! [1]: scheduler::FifoScheduler
-//! [2]: scheduler::RRScheduler
-//! [3]: scheduler::CFScheduler
+//! [1]: axsched::FifoScheduler
+//! [2]: axsched::RRScheduler
+//! [3]: axsched::CFScheduler
 
 #![cfg_attr(not(test), no_std)]
 #![feature(doc_cfg)]

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -5,10 +5,10 @@ use core::mem::MaybeUninit;
 #[cfg(feature = "smp")]
 use alloc::sync::Weak;
 
+use axsched::BaseScheduler;
 use kernel_guard::BaseGuard;
 use kspin::SpinRaw;
 use lazyinit::LazyInit;
-use scheduler::BaseScheduler;
 
 use axhal::percpu::this_cpu_id;
 

--- a/scripts/make/deps.mk
+++ b/scripts/make/deps.mk
@@ -2,18 +2,18 @@
 
 # Tool to parse information about the target package
 ifeq ($(shell cargo axplat --version 2>/dev/null),)
-  $(info "Installing cargo-axplat...")
+  $(info Installing cargo-axplat...)
   $(shell cargo install cargo-axplat)
 endif
 
 # Tool to generate platform configuration files
 ifeq ($(shell axconfig-gen --version 2>/dev/null),)
-  $(info "Installing cargo-axconfig-gen...")
+  $(info Installing axconfig-gen...)
   $(shell cargo install axconfig-gen)
 endif
 
 # Cargo binutils
 ifeq ($(shell cargo install --list | grep cargo-binutils),)
-  $(info "Installing cargo-binutils...")
+  $(info Installing cargo-binutils...)
   $(shell cargo install cargo-binutils)
 endif

--- a/ulib/axlibc/Cargo.toml
+++ b/ulib/axlibc/Cargo.toml
@@ -61,4 +61,4 @@ axio = "0.1"
 axerrno = "0.1"
 
 [build-dependencies]
-bindgen = { version = "0.71" }
+bindgen = { version = "0.72" }

--- a/ulib/axstd/src/fs/mod.rs
+++ b/ulib/axstd/src/fs/mod.rs
@@ -43,7 +43,7 @@ pub fn metadata(path: &str) -> io::Result<Metadata> {
 }
 
 /// Returns an iterator over the entries within a directory.
-pub fn read_dir(path: &str) -> io::Result<ReadDir> {
+pub fn read_dir(path: &str) -> io::Result<ReadDir<'_>> {
     ReadDir::new(path)
 }
 


### PR DESCRIPTION
## New Features

### Main architecture

- [Refactor config system with axconfig-gen](https://github.com/arceos-org/arceos/pull/214)
- [Add support for Monolithic kernel](https://github.com/arceos-org/arceos/pull/224)
- [Split platform-specific contents from the main repository](https://github.com/arceos-org/arceos/pull/249)

### Memory management

- [Add DMA alloc support](https://github.com/arceos-org/arceos/pull/162)
- [Introduce module `axmm` for virtual memory management](https://github.com/arceos-org/arceos/pull/163)
- [Add functions to read and write data in `AddrSpace`](https://github.com/arceos-org/arceos/pull/178)

### Task management

- [Introduce user-defined task extended data](https://github.com/arceos-org/arceos/pull/173)
- [Support percpu run-queue and cpu affinity for `axtask`](https://github.com/arceos-org/arceos/pull/176)
- [Replace `Mutex` with `lock_api`](https://github.com/arceos-org/arceos/pull/238)
- [Support `requeue`, `len`, `is_empty` in `WaitQueue`](https://github.com/arceos-org/arceos/pull/241)

### Filesystem

- [Enhance truncate, add urandom](https://github.com/arceos-org/arceos/pull/275)

### Networking

- [Upgrade `smoltcp` to 0.12.0](https://github.com/arceos-org/arceos/pull/258)
- [Add Nagle and capacity interfaces](https://github.com/arceos-org/arceos/pull/276)

### Hardware abstraction layer

- [Export trap handlers from `axhal` using `linkme::distributed_slice`](https://github.com/arceos-org/arceos/pull/164)
- [Replace `axhal::arch` with crate `axcpu`](https://github.com/arceos-org/arceos/pull/257)
- [Allow custom linkerscript](https://github.com/arceos-org/arceos/pull/256)

### Platform support

- [Add Phytium Pi support](https://github.com/arceos-org/arceos/pull/207)
- [Add ethernet driver `fxmac` for Phytium Pi](https://github.com/arceos-org/arceos/pull/222)
- [Add loongarch64 support](https://github.com/arceos-org/arceos/pull/225)

### Rust toolchain

- [Migrate to Rust Edition 2024](https://github.com/arceos-org/arceos/pull/212)
- [Upgrade toolchain to nightly-2025-05-20](https://github.com/arceos-org/arceos/pull/228)

### Miscellaneous

- [Use setup-musl & setup-qemu actions from Marketplace](https://github.com/arceos-org/arceos/pull/235)
- [Always use `-softfloat` target for aarch64 and loongarch64](https://github.com/arceos-org/arceos/pull/255)
- [Add check for build and doc CI tasks under macOS](https://github.com/arceos-org/arceos/pull/277)

## New Crates & Modules

### New crates published

- [axconfig-gen](https://crates.io/crates/axconfig-gen)
- [axconfig-macros](https://crates.io/crates/axconfig-macros)
- [axcpu](https://crates.io/crates/axcpu)
- [axplat](https://crates.io/crates/axplat) and related [platform crates](https://github.com/arceos-org/axplat_crates/tree/main/platforms)
- [axsched](https://crates.io/crates/axsched)
- [cpumask](https://crates.io/crates/cpumask)
- [ctor_bare](https://crates.io/crates/ctor_bare)
- [memory_set](https://crates.io/crates/memory_set)

### New modules

- [axdma](https://github.com/arceos-org/arceos/tree/main/modules/axdma)
- [axmm](https://github.com/arceos-org/arceos/tree/main/modules/axmm)
- [axns](https://github.com/arceos-org/arceos/tree/main/modules/axns)
