### PR TITLE
add: qemu custom arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ GRAPHIC ?= n
 BUS ?= pci
 MEM ?= 128M
 ACCEL ?=
+QEMU_ARGS ?=
 
 DISK_IMG ?= disk.img
 QEMU_LOG ?= n

--- a/scripts/make/qemu.mk
+++ b/scripts/make/qemu.mk
@@ -86,6 +86,8 @@ ifeq ($(QEMU_LOG), y)
   qemu_args-y += -D qemu.log -d in_asm,int,mmu,pcall,cpu_reset,guest_errors
 endif
 
+qemu_args-y += $(QEMU_ARGS)
+
 qemu_args-debug := $(qemu_args-y) -s -S
 
 ifeq ($(ACCEL),)


### PR DESCRIPTION
This pull request introduces a new mechanism for passing custom QEMU arguments through the build system. The main change is the addition of the `QEMU_ARGS` variable, which allows users to specify extra command-line options for QEMU when running the build. This enhances flexibility for debugging, testing, or customizing QEMU behavior without modifying build scripts.

Build system enhancements:

* Added the `QEMU_ARGS` variable to the `Makefile`, allowing users to define additional QEMU command-line arguments.
* Updated `scripts/make/qemu.mk` to append the contents of `QEMU_ARGS` to the QEMU invocation, ensuring custom arguments are included when running QEMU.