### PR TITLE
fix the bindgen error caused by the forward declaration conflicts of `iovec`

### DIFF
--- a/ulib/axlibc/include/sys/socket.h
+++ b/ulib/axlibc/include/sys/socket.h
@@ -4,6 +4,7 @@
 #include <endian.h>
 #include <limits.h>
 #include <stddef.h>
+#include <sys/uio.h>
 
 typedef unsigned socklen_t;
 typedef unsigned short sa_family_t;


### PR DESCRIPTION
The `msghdr` struct in [socket.h](https://github.com/arceos-org/arceos/blob/fix/bindgen/ulib/axlibc/include/sys/socket.h#L15) references struct `iovec` but the header was missing the proper include, causing `bindgen` to generate incorrect bindings due to forward declaration conflicts.

Before this PR, we run the following command on the mainline code[https://github.com/arceos-org/arceos/commit/0c876234ecabb5b9e62e85a06d10ae55e6029594):
```sh
make A=examples/helloworld-c ACCEL=n run
```

And it will report an error like this:
```sh
error[E0609]: no field `iov_len` on type `&iovec`
  --> api/arceos_posix_api/src/imp/io.rs:69:20
   |
69 |             if iov.iov_len == 0 {
   |                    ^^^^^^^ unknown field
   |
   = note: available field is: `_address`

error[E0609]: no field `iov_base` on type `&iovec`
  --> api/arceos_posix_api/src/imp/io.rs:72:45
   |
72 |             let result = write_impl(fd, iov.iov_base, iov.iov_len)?;
   |                                             ^^^^^^^^ unknown field
   |
   = note: available field is: `_address`

error[E0609]: no field `iov_len` on type `&iovec`
  --> api/arceos_posix_api/src/imp/io.rs:72:59
   |
72 |             let result = write_impl(fd, iov.iov_base, iov.iov_len)?;
   |                                                           ^^^^^^^ unknown field
   |
   = note: available field is: `_address`

error[E0609]: no field `iov_len` on type `&iovec`
  --> api/arceos_posix_api/src/imp/io.rs:78:29
   |
78 |             if result < iov.iov_len as isize {
   |                             ^^^^^^^ unknown field
   |
   = note: available field is: `_address`

error[E0080]: evaluation of constant value failed
   --> api/arceos_posix_api/src/./ctypes_gen.rs:812:23
    |
812 |     ["Size of iovec"][::core::mem::size_of::<iovec>() - 16usize];
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `1_usize - 16_usize`, which would overflow

Some errors have detailed explanations: E0080, E0609.
For more information about an error, try `rustc --explain E0080`.
```
And this commit will fix this error.
