### PR TITLE
Fix mutex deadlock from spurious weak CAS failure

### DIFF
--- a/modules/axsync/src/mutex.rs
+++ b/modules/axsync/src/mutex.rs
@@ -55,6 +55,11 @@ unsafe impl lock_api::RawMutex for RawMutex {
                         "{} tried to acquire mutex it already owns.",
                         current().id_name()
                     );
+                    // Handle spurious failure: if compare_exchange_weak failed but the lock
+                    // is actually unlocked, skip block_on to avoid deadlock (no one will wake us).
+                    if !self.is_locked() {
+                        continue;
+                    }
                     // Wait until the lock looks unlocked before retrying
                     self.wq.wait_until(|| !self.is_locked());
                 }


### PR DESCRIPTION
Skip block_on when the lock is actually unlocked to avoid waiting forever with no one to wake us. This handles spurious failures from compare_exchange_weak on LL/SC architectures.