### PR TITLE
Fix: clean a workspace member and clarify edition in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ members = [
     "examples/helloworld-myplat",
     "examples/httpclient",
     "examples/httpserver",
-    "examples/httpserver",
     "examples/shell",
 ]
 

--- a/tools/bwbench_client/Cargo.toml
+++ b/tools/bwbench_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bwbench-client"
 version = "0.1.0"
-edition.workspace = true
+edition = "2024"
 authors = ["ChengXiang Qi <kuangjux@outlook.com>"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tools/deptool/Cargo.toml
+++ b/tools/deptool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deptool"
 version = "0.1.0"
-edition.workspace = true
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Some minor fixes:
* deduplicate root workspace member
* clarify 2024 edition in tools crates that are respective workspaces

<details><summary>OS-checker fails to know ArceOS crates</summary>
<p>

<img width="1909" height="621" alt="" src="https://github.com/user-attachments/assets/8d99bd16-5203-4d2f-9e7d-af23e98b33ee" />


</p>
</details> 

