### PR TITLE
Fix: `run_cmd` unsoundness and clippy warnings in the example `shell`

### DIFF
--- a/examples/shell/src/cmd.rs
+++ b/examples/shell/src/cmd.rs
@@ -87,16 +87,7 @@ fn do_ls(args: &str) {
         let file_type = metadata.file_type();
         let file_type_char = file_type_to_char(file_type);
         let rwx = file_perm_to_rwx(metadata.permissions().mode());
-        let Ok(rwx) = str::from_utf8(&rwx) else {
-            #[cfg(feature = "axstd")]
-            let err = io::Error::InvalidData;
-            #[cfg(not(feature = "axstd"))]
-            let err = io::Error::new(
-                io::ErrorKind::InvalidData,
-                "The rwx value is not utf8 encoded.",
-            );
-            return Err(err);
-        };
+        let rwx = str::from_utf8(&rwx).unwrap();
         println!("{file_type_char}{rwx} {size:>8} {entry}");
         Ok(())
     }

--- a/examples/shell/src/cmd.rs
+++ b/examples/shell/src/cmd.rs
@@ -84,7 +84,7 @@ fn do_ls(args: &str) {
         let file_type_char = file_type_to_char(file_type);
         let rwx = file_perm_to_rwx(metadata.permissions().mode());
         let rwx = core::str::from_utf8(&rwx).unwrap();
-        println!("{}{} {:>8} {}", file_type_char, rwx, size, entry);
+        println!("{file_type_char}{rwx} {size:>8} {entry}");
         Ok(())
     }
 
@@ -95,7 +95,7 @@ fn do_ls(args: &str) {
         }
 
         if print_name {
-            println!("{}:", name);
+            println!("{name}:");
         }
         let mut entries = fs::read_dir(name)?
             .filter_map(|e| e.ok())
@@ -176,7 +176,7 @@ fn do_echo(args: &str) {
             print_err!("echo", fname, e);
         }
     } else {
-        println!("{}", args)
+        println!("{args}")
     }
 }
 
@@ -257,19 +257,13 @@ fn do_uname(_args: &str) {
     #[cfg(not(feature = "axstd"))]
     let smp = "";
     let version = option_env!("CARGO_PKG_VERSION").unwrap_or("0.1.0");
-    println!(
-        "ArceOS {ver}{smp} {arch} {plat}",
-        ver = version,
-        smp = smp,
-        arch = arch,
-        plat = platform,
-    );
+    println!("ArceOS {version}{smp} {arch} {platform}");
 }
 
 fn do_help(_args: &str) {
     println!("Available commands:");
     for (name, _) in CMD_TABLE {
-        println!("  {}", name);
+        println!("  {name}");
     }
 }
 
@@ -288,7 +282,7 @@ pub fn run_cmd(line: &[u8]) {
                 return;
             }
         }
-        println!("{}: command not found", cmd);
+        println!("{cmd}: command not found");
     }
 }
 

--- a/examples/shell/src/cmd.rs
+++ b/examples/shell/src/cmd.rs
@@ -1,3 +1,4 @@
+use core::str;
 use std::fs::{self, File, FileType};
 use std::io::{self, prelude::*};
 use std::{string::String, vec::Vec};
@@ -69,7 +70,10 @@ const fn file_perm_to_rwx(mode: u32) -> [u8; 9] {
 }
 
 fn do_ls(args: &str) {
-    let current_dir = std::env::current_dir().unwrap();
+    let current_dir = match std::env::current_dir() {
+        Ok(current_dir) => current_dir,
+        Err(err) => return println!("Failed to access the current directory: {err}"),
+    };
     let args = if args.is_empty() {
         path_to_str(&current_dir)
     } else {
@@ -83,7 +87,16 @@ fn do_ls(args: &str) {
         let file_type = metadata.file_type();
         let file_type_char = file_type_to_char(file_type);
         let rwx = file_perm_to_rwx(metadata.permissions().mode());
-        let rwx = core::str::from_utf8(&rwx).unwrap();
+        let Ok(rwx) = str::from_utf8(&rwx) else {
+            #[cfg(feature = "axstd")]
+            let err = io::Error::InvalidData;
+            #[cfg(not(feature = "axstd"))]
+            let err = io::Error::new(
+                io::ErrorKind::InvalidData,
+                "The rwx value is not utf8 encoded.",
+            );
+            return Err(err);
+        };
         println!("{file_type_char}{rwx} {size:>8} {entry}");
         Ok(())
     }
@@ -241,15 +254,20 @@ fn do_cd(mut args: &str) {
 }
 
 fn do_pwd(_args: &str) {
-    let pwd = std::env::current_dir().unwrap();
-    println!("{}", path_to_str(&pwd));
+    match std::env::current_dir() {
+        Ok(pwd) => println!("{}", path_to_str(&pwd)),
+        Err(err) => println!("Failed to access the current directory: {err}"),
+    }
 }
 
 fn do_uname(_args: &str) {
     let arch = option_env!("AX_ARCH").unwrap_or("");
     let platform = option_env!("AX_PLATFORM").unwrap_or("");
     #[cfg(feature = "axstd")]
-    let smp = if std::thread::available_parallelism().unwrap().get() == 1 {
+    let smp = if std::thread::available_parallelism()
+        .map(|n| n.get() == 1)
+        .unwrap_or(true)
+    {
         ""
     } else {
         " SMP"
@@ -273,7 +291,10 @@ fn do_exit(_args: &str) {
 }
 
 pub fn run_cmd(line: &[u8]) {
-    let line_str = core::str::from_utf8(line).unwrap();
+    let Ok(line_str) = str::from_utf8(line) else {
+        println!("Please enter a valid utf-8 string as the command.");
+        return;
+    };
     let (cmd, args) = split_whitespace(line_str);
     if !cmd.is_empty() {
         for (name, func) in CMD_TABLE {

--- a/examples/shell/src/cmd.rs
+++ b/examples/shell/src/cmd.rs
@@ -83,7 +83,7 @@ fn do_ls(args: &str) {
         let file_type = metadata.file_type();
         let file_type_char = file_type_to_char(file_type);
         let rwx = file_perm_to_rwx(metadata.permissions().mode());
-        let rwx = unsafe { core::str::from_utf8_unchecked(&rwx) };
+        let rwx = core::str::from_utf8(&rwx).unwrap();
         println!("{}{} {:>8} {}", file_type_char, rwx, size, entry);
         Ok(())
     }
@@ -279,7 +279,7 @@ fn do_exit(_args: &str) {
 }
 
 pub fn run_cmd(line: &[u8]) {
-    let line_str = unsafe { core::str::from_utf8_unchecked(line) };
+    let line_str = core::str::from_utf8(line).unwrap();
     let (cmd, args) = split_whitespace(line_str);
     if !cmd.is_empty() {
         for (name, func) in CMD_TABLE {


### PR DESCRIPTION
This PR focuses on the shell example:
* closes https://github.com/arceos-org/arceos/issues/204
* fixes clippy warnings
* handles `.unwrap()` calls