### PR TITLE
Fix: Add direct optional axhal dependency to axdisplay, axfs, and axsync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.2.0"
 dependencies = [
  "axdriver",
  "axdriver_display",
+ "axhal",
  "axsync",
  "lazyinit",
  "log",
@@ -448,6 +449,7 @@ dependencies = [
  "axfs_devfs",
  "axfs_ramfs",
  "axfs_vfs",
+ "axhal",
  "axio",
  "axns",
  "axsync",
@@ -814,6 +816,7 @@ dependencies = [
 name = "axsync"
 version = "0.2.0"
 dependencies = [
+ "axhal",
  "axsync",
  "axtask",
  "kspin",

--- a/modules/axdisplay/Cargo.toml
+++ b/modules/axdisplay/Cargo.toml
@@ -13,5 +13,6 @@ documentation = "https://arceos-org.github.io/arceos/axdisplay/index.html"
 log = "=0.4.21"
 lazyinit = "0.2"
 axdriver = { workspace = true, features = ["display"] }
+axhal = { workspace = true, optional = true }
 axsync = { workspace = true }
 axdriver_display = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.2" }

--- a/modules/axfs/Cargo.toml
+++ b/modules/axfs/Cargo.toml
@@ -35,6 +35,7 @@ axsync = { workspace = true }
 axdriver = { workspace = true, features = ["block"] }
 axdriver_block = { git = "https://github.com/arceos-org/axdriver_crates.git", tag = "v0.1.2" }
 axns = { workspace = true }
+axhal = { workspace = true, optional = true }
 
 [dependencies.fatfs]
 git = "https://github.com/rafalh/rust-fatfs"

--- a/modules/axsync/Cargo.toml
+++ b/modules/axsync/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 kspin = "0.1"
 lock_api = { version = "0.4", default-features = false }
 axtask = { workspace = true }
+axhal = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = "0.9"


### PR DESCRIPTION
* fixes https://github.com/arceos-org/arceos/issues/300 

These crates didn't directly rely on axhal (or axfeat, or axstd). 
So the fix allows axhal's defplat feature and make them compile on non-host targets respectively.

