### PR TITLE
Refactor dockerfile and workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Docker Build Test
+
+on:
+  push:
+    paths:
+      - 'Dockerfile'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and Export
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          outputs: type=docker,dest=/tmp/arceos.tar
+          tags: arceos:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: docker-image
+          path: /tmp/arceos.tar
+          retention-days: 1
+  docker-build-and-run:
+    needs: build-base
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, riscv64, aarch64, loongarch64]
+        app: 
+          - examples/helloworld
+          - examples/httpclient
+          - examples/httpserver
+          - examples/shell
+          - examples/helloworld-c
+          - examples/httpclient-c
+          - examples/httpserver-c
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          name: docker-image
+          path: /tmp
+      - name: Load Image
+        run: docker load --input /tmp/arceos.tar
+      - name: Test Docker Image
+        run: |
+          docker run --rm \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          arceos:latest \
+          make ARCH=${{ matrix.arch }} A=${{ matrix.app }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,27 @@
-FROM rust:slim
+FROM rust:alpine
 
-RUN echo /etc/apt/sources.list << deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main
-RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libclang-19-dev wget make python3 \
-        xz-utils python3-venv ninja-build bzip2 meson \
-        pkg-config libglib2.0-dev git libslirp-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache \
+    build-base qemu-system-x86_64 qemu-system-loongarch64 \
+    qemu-system-riscv64 qemu-system-aarch64 \
+    clang-dev bash coreutils wget python3 xz \
+    py3-pip samurai bzip2 meson make \
+    git pkgconf glib-dev libslirp \
+    ca-certificates openssl diffutils findutils vim cmake
 
 RUN cargo install cargo-binutils axconfig-gen cargo-axplat
 
-COPY rust-toolchain.toml /rust-toolchain.toml
-
-RUN rustc --version
-
-RUN wget https://musl.cc/aarch64-linux-musl-cross.tgz \
-    && wget https://musl.cc/riscv64-linux-musl-cross.tgz \
-    && wget https://musl.cc/x86_64-linux-musl-cross.tgz \
-    && wget https://github.com/LoongsonLab/oscomp-toolchains-for-oskernel/releases/download/loongarch64-linux-musl-cross-gcc-13.2.0/loongarch64-linux-musl-cross.tgz \
-    && tar zxf aarch64-linux-musl-cross.tgz \
-    && tar zxf riscv64-linux-musl-cross.tgz \
-    && tar zxf x86_64-linux-musl-cross.tgz \
-    && tar zxf loongarch64-linux-musl-cross.tgz \
-    && rm -f *.tgz
-
-RUN wget https://download.qemu.org/qemu-9.2.4.tar.xz \
-    && tar xf qemu-9.2.4.tar.xz \
-    && cd qemu-9.2.4 \
-    && ./configure --prefix=/qemu-bin-9.2.4 \
-        --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
-        --enable-gcov --enable-debug --enable-slirp \
-    && make -j$(nproc) \
-    && make install
-RUN rm -rf qemu-9.2.4 qemu-9.2.4.tar.xz
+RUN wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/aarch64-linux-musl-cross.tgz \
+&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/riscv64-linux-musl-cross.tgz \
+&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/x86_64-linux-musl-cross.tgz \
+&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/loongarch64-linux-musl-cross.tgz \
+&& tar zxf aarch64-linux-musl-cross.tgz \
+&& tar zxf riscv64-linux-musl-cross.tgz \
+&& tar zxf x86_64-linux-musl-cross.tgz \
+&& tar zxf loongarch64-linux-musl-cross.tgz \
+&& rm -f *.tgz
 
 ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:$PATH"
-ENV PATH="/qemu-bin-9.2.4/bin:$PATH"
+
+COPY ./rust-toolchain.toml /workspace/rust-toolchain.toml
+
+RUN rustup target list --installed

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:slim-trixie
 RUN apt-get update \
     && apt-get install -y --no-install-recommends libclang-19-dev wget make python3 \
         xz-utils python3-venv ninja-build bzip2 meson \
-        pkg-config libglib2.0-dev git libslirp-dev \
+        pkg-config libglib2.0-dev git libslirp-dev qemu-system \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-binutils axconfig-gen cargo-axplat
@@ -25,17 +25,6 @@ RUN wget -q https://github.com/arceos-org/setup-musl/releases/download/prebuilt/
     && tar zxf loongarch64-linux-musl-cross.tgz -C / \
     && rm -f *.tgz
 
-RUN wget -q https://download.qemu.org/qemu-10.1.2.tar.xz \
-    && tar xJf qemu-10.1.2.tar.xz \
-    && cd qemu-10.1.2 \
-    && ./configure --prefix=/qemu-bin-10.1.2 \
-        --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
-        --enable-slirp \
-    && make -j$(nproc) \
-    && make install
-RUN rm -rf qemu-10.1.2 qemu-10.1.2.tar.xz
-
 ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:$PATH"
-ENV PATH="/qemu-bin-10.1.2/bin:$PATH"
 
 CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,41 @@
-FROM rust:alpine
+FROM rust:slim-trixie
 
-RUN apk add --no-cache \
-    build-base qemu-system-x86_64 qemu-system-loongarch64 \
-    qemu-system-riscv64 qemu-system-aarch64 \
-    clang-dev bash coreutils wget python3 xz \
-    py3-pip samurai bzip2 meson make \
-    git pkgconf glib-dev libslirp \
-    ca-certificates openssl diffutils findutils vim cmake
+# 有需要可以取消注释
+# RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libclang-20-dev wget make python3 \
+        xz-utils python3-venv ninja-build bzip2 meson \
+        pkg-config libglib2.0-dev git libslirp-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install cargo-binutils axconfig-gen cargo-axplat
 
-RUN wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/aarch64-linux-musl-cross.tgz \
-&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/riscv64-linux-musl-cross.tgz \
-&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/x86_64-linux-musl-cross.tgz \
-&& wget https://github.com/arceos-org/setup-musl/releases/download/prebuilt/loongarch64-linux-musl-cross.tgz \
-&& tar zxf aarch64-linux-musl-cross.tgz \
-&& tar zxf riscv64-linux-musl-cross.tgz \
-&& tar zxf x86_64-linux-musl-cross.tgz \
-&& tar zxf loongarch64-linux-musl-cross.tgz \
-&& rm -f *.tgz
+COPY rust-toolchain.toml /workspace/rust-toolchain.toml
+WORKDIR /workspace
+RUN rustup show
+
+RUN wget -q https://github.com/arceos-org/setup-musl/releases/download/prebuilt/aarch64-linux-musl-cross.tgz \
+    && wget -q https://github.com/arceos-org/setup-musl/releases/download/prebuilt/riscv64-linux-musl-cross.tgz \
+    && wget -q https://github.com/arceos-org/setup-musl/releases/download/prebuilt/x86_64-linux-musl-cross.tgz \
+    && wget -q https://github.com/arceos-org/setup-musl/releases/download/prebuilt/loongarch64-linux-musl-cross.tgz \
+    && tar zxf aarch64-linux-musl-cross.tgz -C / \
+    && tar zxf riscv64-linux-musl-cross.tgz -C / \
+    && tar zxf x86_64-linux-musl-cross.tgz -C / \
+    && tar zxf loongarch64-linux-musl-cross.tgz -C / \
+    && rm -f *.tgz
+
+RUN wget -q https://download.qemu.org/qemu-10.1.2.tar.xz \
+    && tar xJf qemu-10.1.2.tar.xz \
+    && cd qemu-10.1.2 \
+    && ./configure --prefix=/qemu-bin-10.1.2 \
+        --target-list=loongarch64-softmmu,riscv64-softmmu,aarch64-softmmu,x86_64-softmmu \
+        --enable-slirp \
+    && make -j$(nproc) \
+    && make install
+RUN rm -rf qemu-10.1.2 qemu-10.1.2.tar.xz
 
 ENV PATH="/x86_64-linux-musl-cross/bin:/aarch64-linux-musl-cross/bin:/riscv64-linux-musl-cross/bin:/loongarch64-linux-musl-cross/bin:$PATH"
+ENV PATH="/qemu-bin-10.1.2/bin:$PATH"
 
-COPY ./rust-toolchain.toml /workspace/rust-toolchain.toml
-
-RUN rustup target list --installed
+CMD [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:slim-trixie
 # RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libclang-20-dev wget make python3 \
+    && apt-get install -y --no-install-recommends libclang-19-dev wget make python3 \
         xz-utils python3-venv ninja-build bzip2 meson \
         pkg-config libglib2.0-dev git libslirp-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Alpine下的musl的链接有些问题，编译c程序时bindgen会报错
"the `libclang` shared library at /usr/lib/llvm20/lib/libclang.so.20.1.8 could not be opened: Dynamic loading not supported"

修复问题需要改动其他内容，先回退继续使用Debian

可能可以参考的资料：
https://users.rust-lang.org/t/dynamic-linking-in-alpine/105608/2
https://github.com/tikv/grpc-rs/issues/477
https://github.com/immunant/c2rust/issues/724
https://github.com/rust-lang/rust-bindgen/issues/2360

由于Debian packages的qemu-system为ds版本，没有opensbi等，所以仍旧自行编译
编译配置取消了仅对调试qemu本身有用的选项，影响速度