### PR TITLE
some bug fix

### DIFF
--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -102,10 +102,10 @@ SECTIONS
 }
 
 SECTIONS {
-    linkme_IRQ : { *(linkme_IRQ) }
-    linkm2_IRQ : { *(linkm2_IRQ) }
-    linkme_PAGE_FAULT : { *(linkme_PAGE_FAULT) }
-    linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
-    scope_local : { *(scope_local) }
+    linkme_IRQ : { KEEP(*(linkme_IRQ)) }
+    linkm2_IRQ : { KEEP(*(linkm2_IRQ)) }
+    linkme_PAGE_FAULT : { KEEP(*(linkme_PAGE_FAULT)) }
+    linkm2_PAGE_FAULT : { KEEP(*(linkm2_PAGE_FAULT)) }
+    scope_local : { KEEP(*(scope_local)) }
 }
 INSERT AFTER .tbss;

--- a/modules/axhal/src/tls.rs
+++ b/modules/axhal/src/tls.rs
@@ -108,7 +108,7 @@ impl TlsArea {
         let area_base = unsafe { alloc::alloc::alloc_zeroed(layout) };
 
         let tls_load_base = _stdata as *mut u8;
-        let tls_load_size = _etbss as usize - _stdata as usize;
+        let tls_load_size = _etdata as usize - _stdata as usize;
         unsafe {
             // copy data from .tbdata section
             core::ptr::copy_nonoverlapping(

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -642,7 +642,10 @@ pub(crate) fn init() {
     let cpu_id = this_cpu_id();
 
     // Create the `idle` task (not current task).
-    const IDLE_TASK_STACK_SIZE: usize = 4096;
+    // The idle task will run when there is no other runnable task.
+    // Stack size of idle task should be large because traps/interrupts may happen in idle task,
+    // which need more stack space.
+    const IDLE_TASK_STACK_SIZE: usize = 16384;
     let idle_task = TaskInner::new(|| crate::run_idle(), "idle".into(), IDLE_TASK_STACK_SIZE);
     // idle task should be pinned to the current CPU.
     idle_task.set_cpumask(AxCpuMask::one_shot(cpu_id));

--- a/modules/axtask/src/wait_queue.rs
+++ b/modules/axtask/src/wait_queue.rs
@@ -111,25 +111,28 @@ impl WaitQueue {
     }
 
     /// Wakes up one task in the wait queue, usually the first one.
+    /// This function should not be called in a loop, use `notify_many` instead.
     ///
-    /// If `resched` is true, the current task will be preempted when the
-    /// preemption is enabled.
+    /// If `resched` is true, the current task will yield.
     pub fn notify_one(&self, resched: bool) -> bool {
-        let n = self.event.notify(1);
+        self.notify_many(1, resched) == 1
+    }
+
+    /// Wakes up to `count` tasks in the wait queue.
+    ///
+    /// If `resched` is true, the current task will yield.
+    pub fn notify_many(&self, count: usize, resched: bool) -> usize {
+        let n = self.event.notify(count);
         if resched {
             crate::yield_now();
         }
-        n > 0
+        n
     }
 
     /// Wakes all tasks in the wait queue.
     ///
-    /// If `resched` is true, the current task will be preempted when the
-    /// preemption is enabled.
+    /// If `resched` is true, the current task will yield.
     pub fn notify_all(&self, resched: bool) {
-        self.event.notify(usize::MAX);
-        if resched {
-            crate::yield_now();
-        }
+        self.notify_many(usize::MAX, resched);
     }
 }


### PR DESCRIPTION
- fix[tls]: fix TLS area init range: TLS area has been set to zero before the copy, but we still copy dirty data to `.tbss` area.
- fix[axhal]: add KEEP directive to preserve linkme sections in linker script: Otherwise, once the artifact is linked to other ELFs as a static library (.a), the symbols in the linkme sections will not survive in `--gc-sections`
- fix[axtask]: increase idle task stack size: The idle task requires sufficient stack space to handle traps and interrupts safely.
- fix[axtask]: add extra `notify_many` function to avoid calling `notify_one` in a loop: Underlying structure `EventListener` will return zero if `notify` is called multiple times. It's a misuse that call the function in a loop.