### PR TITLE
Introduce `max-cpu-num` config item, remove all direct usages of `axconfig::plat::CPU_NUM`, use `axplat` to get cpu num.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -728,7 +728,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-bsta1000b"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-peripherals"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "arm-gic-driver",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-phytium-pi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-raspi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "axconfig-macros",
@@ -802,7 +802,7 @@ dependencies = [
 [[package]]
 name = "axplat-loongarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -819,7 +819,7 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "axplat-riscv64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -847,7 +847,7 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#cfa48ef4e049346605a0ed83e96ab06978aacdf8"
 dependencies = [
  "axconfig-macros",
  "axcpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "axlog",
  "axmm",
  "axnet",
- "axplat",
  "axruntime",
  "axsync",
  "axtask",
@@ -714,7 +713,7 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -729,7 +728,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-bsta1000b"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -744,7 +743,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-peripherals"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "arm-gic-driver",
@@ -763,7 +762,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-phytium-pi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -776,7 +775,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -789,7 +788,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-raspi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "axconfig-macros",
@@ -803,7 +802,7 @@ dependencies = [
 [[package]]
 name = "axplat-loongarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -820,7 +819,7 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -830,7 +829,7 @@ dependencies = [
 [[package]]
 name = "axplat-riscv64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -848,7 +847,7 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#ab7ec0d05b9800e61722459a3309a3674fce1b39"
 dependencies = [
  "axconfig-macros",
  "axcpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -728,7 +729,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-bsta1000b"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -743,7 +744,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-peripherals"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "arm-gic-driver",
@@ -762,7 +763,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-phytium-pi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -775,7 +776,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -788,7 +789,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-raspi"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "aarch64-cpu 10.0.0",
  "axconfig-macros",
@@ -802,7 +803,7 @@ dependencies = [
 [[package]]
 name = "axplat-loongarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -819,6 +820,7 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -828,7 +830,7 @@ dependencies = [
 [[package]]
 name = "axplat-riscv64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -846,6 +848,7 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.3.0"
+source = "git+https://github.com/arceos-org/axplat_crates.git?branch=feat%2Fcpu_num#c2f79999d9d4fb1a94f43019cfe7f1ee6bf05260"
 dependencies = [
  "axconfig-macros",
  "axcpu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "axlog",
  "axmm",
  "axnet",
+ "axplat",
  "axruntime",
  "axsync",
  "axtask",
@@ -713,7 +714,6 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -819,7 +819,6 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -847,7 +846,6 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,7 @@ page_table_multiarch = "0.5"
 percpu = "0.2"
 scope-local = "0.1"
 spin = "0.10"
+
+[patch."https://github.com/arceos-org/axplat_crates.git"]
+axplat = { path = "../axplat_crates/axplat" }
+axplat-x86-pc = { path = "../axplat_crates/platforms/axplat-x86-pc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,13 +108,3 @@ page_table_multiarch = "0.5"
 percpu = "0.2"
 scope-local = "0.1"
 spin = "0.10"
-
-# [patch."https://github.com/arceos-org/axplat_crates.git"]
-# axplat = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-aarch64-bsta1000b = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-aarch64-phytium-pi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-aarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-aarch64-raspi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-loongarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-riscv64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
-# axplat-x86-pc = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,14 +82,14 @@ axdriver_vsock = { git = "https://github.com/arceos-org/axdriver_crates.git", ta
 axerrno = "0.1"
 axio = "0.1"
 axklib = { git = "https://github.com/arceos-hypervisor/axklib.git" } # FIXME: pin to a specific commit or tag
-axplat = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-aarch64-bsta1000b = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-aarch64-phytium-pi = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-aarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-aarch64-raspi = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-loongarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-riscv64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
-axplat-x86-pc = { git = "https://github.com/arceos-org/axplat_crates.git", tag = "dev-v03" }
+axplat = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-aarch64-bsta1000b = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-aarch64-phytium-pi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-aarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-aarch64-raspi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-loongarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-riscv64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+axplat-x86-pc = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
 axpoll = "0.1"
 bindgen = "0.72"
 cfg-if = "1.0"
@@ -109,6 +109,12 @@ percpu = "0.2"
 scope-local = "0.1"
 spin = "0.10"
 
-[patch."https://github.com/arceos-org/axplat_crates.git"]
-axplat = { path = "../axplat_crates/axplat" }
-axplat-x86-pc = { path = "../axplat_crates/platforms/axplat-x86-pc" }
+# [patch."https://github.com/arceos-org/axplat_crates.git"]
+# axplat = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-aarch64-bsta1000b = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-aarch64-phytium-pi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-aarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-aarch64-raspi = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-loongarch64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-riscv64-qemu-virt = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }
+# axplat-x86-pc = { git = "https://github.com/arceos-org/axplat_crates.git", branch = "feat/cpu_num" }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 #     - `ARCH`: Target architecture: x86_64, riscv64, aarch64, loongarch64
 #     - `MYPLAT`: Package name of the target platform crate.
 #     - `PLAT_CONFIG`: Path to the platform configuration file.
-#     - `SMP`: Number of CPUs. If not set, use the default value from platform config.
+#     - `SMP`: Number of CPUs. If not set, use the default value from platform config. Platforms 
+#        that support reading CPU number from hardware (e.g., via DTB) may ignore this option.
 #     - `MODE`: Build mode: release, debug
 #     - `LOG:` Logging level: warn, error, info, debug, trace
 #     - `V`: Verbose level: (empty), 1, 2

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 #     - `ARCH`: Target architecture: x86_64, riscv64, aarch64, loongarch64
 #     - `MYPLAT`: Package name of the target platform crate.
 #     - `PLAT_CONFIG`: Path to the platform configuration file.
-#     - `SMP`: Number of CPUs. If not set, use the default value from platform config. Platforms 
-#        that support reading CPU number from hardware (e.g., via DTB) may ignore this option.
+#     - `SMP`: Override maximum CPU number specified in the platform config. For
+# 		statically configured platforms, this is also the number of CPUs to boot
+#		and for platforms with runtime CPU detection, this is the upper limit of
+#       CPUs.
 #     - `MODE`: Build mode: release, debug
 #     - `LOG:` Logging level: warn, error, info, debug, trace
 #     - `V`: Verbose level: (empty), 1, 2

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -42,6 +42,7 @@ axipi = { workspace = true, optional = true }
 axlog.workspace = true
 axmm = { workspace = true, optional = true }
 axnet = { workspace = true, optional = true }
+axplat = { workspace = true }
 axruntime.workspace = true
 axsync.workspace = true
 axtask = { workspace = true, optional = true }

--- a/api/arceos_api/Cargo.toml
+++ b/api/arceos_api/Cargo.toml
@@ -42,7 +42,6 @@ axipi = { workspace = true, optional = true }
 axlog.workspace = true
 axmm = { workspace = true, optional = true }
 axnet = { workspace = true, optional = true }
-axplat = { workspace = true }
 axruntime.workspace = true
 axsync.workspace = true
 axtask = { workspace = true, optional = true }

--- a/api/arceos_api/src/imp/mod.rs
+++ b/api/arceos_api/src/imp/mod.rs
@@ -39,6 +39,11 @@ mod stdio {
     }
 }
 
+mod sys {
+    pub use axhal::cpu_num as ax_get_cpu_num;
+    pub use axhal::power::system_off as ax_terminate;
+}
+
 mod time {
     pub use axhal::time::{
         TimeValue as AxTimeValue, monotonic_time as ax_monotonic_time, wall_time as ax_wall_time,
@@ -47,8 +52,8 @@ mod time {
 
 pub use self::mem::*;
 pub use self::stdio::*;
+pub use self::sys::*;
 pub use self::task::*;
 pub use self::time::*;
 
-pub use axhal::power::system_off as ax_terminate;
 pub use axio::PollState as AxPollState;

--- a/api/arceos_api/src/lib.rs
+++ b/api/arceos_api/src/lib.rs
@@ -32,6 +32,9 @@ pub mod sys {
     define_api! {
         /// Shutdown the whole system and all CPUs.
         pub fn ax_terminate() -> !;
+
+        /// Returns the number of CPUs in the system.
+        pub fn ax_get_cpu_num() -> usize;
     }
 }
 

--- a/api/arceos_posix_api/src/imp/sys.rs
+++ b/api/arceos_posix_api/src/imp/sys.rs
@@ -15,7 +15,7 @@ pub fn sys_sysconf(name: c_int) -> c_long {
             // Page size
             ctypes::_SC_PAGE_SIZE => Ok(PAGE_SIZE_4K),
             // Number of processors in use
-            ctypes::_SC_NPROCESSORS_ONLN => Ok(axhal::cpu_num() as usize),
+            ctypes::_SC_NPROCESSORS_ONLN => Ok(axhal::cpu_num()),
             // Total physical pages
             ctypes::_SC_PHYS_PAGES => Ok(axhal::mem::total_ram_size() / PAGE_SIZE_4K),
             // Avaliable physical pages

--- a/api/arceos_posix_api/src/imp/sys.rs
+++ b/api/arceos_posix_api/src/imp/sys.rs
@@ -15,7 +15,7 @@ pub fn sys_sysconf(name: c_int) -> c_long {
             // Page size
             ctypes::_SC_PAGE_SIZE => Ok(PAGE_SIZE_4K),
             // Number of processors in use
-            ctypes::_SC_NPROCESSORS_ONLN => Ok(axconfig::plat::CPU_NUM),
+            ctypes::_SC_NPROCESSORS_ONLN => Ok(axhal::cpu_num() as usize),
             // Total physical pages
             ctypes::_SC_PHYS_PAGES => Ok(axhal::mem::total_ram_size() / PAGE_SIZE_4K),
             // Avaliable physical pages

--- a/configs/custom/x86_64-pc-oslab.toml
+++ b/configs/custom/x86_64-pc-oslab.toml
@@ -9,8 +9,9 @@ package = "axplat-x86-pc"       # str
 # Platform configs
 #
 [plat]
-# Number of CPUs.
-cpu-num = 8                     # uint
+# Maximum number of CPUs. For platforms that does not support runtime CPU
+# detection, it's also the number of CPUs to boot (like this platform).
+max-cpu-num = 8                 # uint
 # Base address of the whole physical memory.
 phys-memory-base = 0            # uint
 # Size of the whole physical memory. (2G)

--- a/configs/custom/x86_64-pc-oslab.toml
+++ b/configs/custom/x86_64-pc-oslab.toml
@@ -9,7 +9,7 @@ package = "axplat-x86-pc"       # str
 # Platform configs
 #
 [plat]
-# Maximum number of CPUs. For platforms that does not support runtime CPU
+# Maximum number of CPUs. For platforms that do not support runtime CPU number
 # detection, it's also the number of CPUs to boot (like this platform).
 max-cpu-num = 8                 # uint
 # Base address of the whole physical memory.

--- a/configs/defconfig.toml
+++ b/configs/defconfig.toml
@@ -1,3 +1,6 @@
+# Maximum CPU number supported.
+max-cpu-num = 8             # uint
+
 # Stack size of each task.
 task-stack-size = 0x40000   # uint
 

--- a/configs/defconfig.toml
+++ b/configs/defconfig.toml
@@ -1,6 +1,3 @@
-# Maximum CPU number supported.
-max-cpu-num = 8             # uint
-
 # Stack size of each task.
 task-stack-size = 0x40000   # uint
 

--- a/configs/dummy.toml
+++ b/configs/dummy.toml
@@ -15,7 +15,7 @@ ticks-per-sec = 100         # uint
 #
 [plat]
 # Platform family.
-# Maximum number of CPUs. For platforms that does not support runtime CPU
+# Maximum number of CPUs. For platforms that do not support runtime CPU number
 # detection, it's also the number of CPUs to boot.
 max-cpu-num = 1             # uint
 # Base address of the whole physical memory.

--- a/configs/dummy.toml
+++ b/configs/dummy.toml
@@ -4,8 +4,6 @@ arch = "unknown"            # str
 platform = "dummy"          # str
 # Platform package.
 package = "dummy"           # str
-# Maximum CPU number supported.
-max-cpu-num = 8             # uint
 # Stack size of each task.
 task-stack-size = 0x40000   # uint
 # Number of timer ticks per second (Hz). A timer tick may contain several timer
@@ -17,8 +15,9 @@ ticks-per-sec = 100         # uint
 #
 [plat]
 # Platform family.
-# Number of CPUs
-cpu-num = 1                 # uint
+# Maximum number of CPUs. For platforms that does not support runtime CPU
+# detection, it's also the number of CPUs to boot.
+max-cpu-num = 1             # uint
 # Base address of the whole physical memory.
 phys-memory-base = 0        # uint
 # Size of the whole physical memory.

--- a/configs/dummy.toml
+++ b/configs/dummy.toml
@@ -4,6 +4,8 @@ arch = "unknown"            # str
 platform = "dummy"          # str
 # Platform package.
 package = "dummy"           # str
+# Maximum CPU number supported.
+max-cpu-num = 8             # uint
 # Stack size of each task.
 task-stack-size = 0x40000   # uint
 # Number of timer ticks per second (Hz). A timer tick may contain several timer

--- a/modules/axhal/build.rs
+++ b/modules/axhal/build.rs
@@ -24,7 +24,7 @@ fn gen_linker_script(arch: &str, platform: &str) -> Result<()> {
         "%KERNEL_BASE%",
         &format!("{:#x}", axconfig::plat::KERNEL_BASE_VADDR),
     );
-    let ld_content = ld_content.replace("%CPU_NUM%", &format!("{}", axconfig::MAX_CPU_NUM));
+    let ld_content = ld_content.replace("%CPU_NUM%", &format!("{}", axconfig::plat::MAX_CPU_NUM));
     let ld_content = ld_content.replace(
         "%DWARF%",
         if std::env::var("DWARF").is_ok_and(|v| v == "y") {

--- a/modules/axhal/build.rs
+++ b/modules/axhal/build.rs
@@ -24,7 +24,7 @@ fn gen_linker_script(arch: &str, platform: &str) -> Result<()> {
         "%KERNEL_BASE%",
         &format!("{:#x}", axconfig::plat::KERNEL_BASE_VADDR),
     );
-    let ld_content = ld_content.replace("%CPU_NUM%", &format!("{}", axconfig::plat::CPU_NUM));
+    let ld_content = ld_content.replace("%CPU_NUM%", &format!("{}", axconfig::MAX_CPU_NUM));
     let ld_content = ld_content.replace(
         "%DWARF%",
         if std::env::var("DWARF").is_ok_and(|v| v == "y") {

--- a/modules/axhal/src/dummy.rs
+++ b/modules/axhal/src/dummy.rs
@@ -111,7 +111,6 @@ impl PowerIf for DummyPower {
         unimplemented!()
     }
 
-    #[cfg(feature = "smp")]
     fn cpu_num() -> usize {
         1
     }

--- a/modules/axhal/src/dummy.rs
+++ b/modules/axhal/src/dummy.rs
@@ -110,6 +110,11 @@ impl PowerIf for DummyPower {
     fn system_off() -> ! {
         unimplemented!()
     }
+
+    #[cfg(feature = "smp")]
+    fn cpu_num() -> usize {
+        1
+    }
 }
 
 #[cfg(feature = "irq")]

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -108,7 +108,7 @@ pub use axplat::init::init_later;
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
 #[cfg(feature = "smp")]
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering, fence};
 
 use lazyinit::LazyInit;
 
@@ -129,8 +129,6 @@ pub fn get_bootarg() -> usize {
 
 /// The number of CPUs in the system. Based on the number declared by the
 /// platform crate and limited by the configured maximum CPU number.
-///
-/// Defaults to 1 for non-SMP builds.
 #[cfg(feature = "smp")]
 static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
 
@@ -152,9 +150,9 @@ pub fn cpu_num() -> usize {
         // The BSP will always see the correct value because `CPU_NUM` is set by
         // itself.
         //
-        // All APs will read `CPU_NUM` with `Acquire` once they are started,
-        // ensuring they see the correct value. Then they can use `Relaxed` for
-        // subsequent reads.
+        // All APs will see the correct value because `init_cpu_num_secondary`
+        // is called during their initialization, which contains a fence to
+        // ensure visibility of the correct value.
         CPU_NUM.load(Ordering::Relaxed)
     }
     #[cfg(not(feature = "smp"))]
@@ -183,12 +181,10 @@ pub fn init_cpu_num() {
             );
         }
 
-        CPU_NUM.store(cpu_num, Ordering::Release);
+        fence(Ordering::SeqCst);
+        CPU_NUM.store(cpu_num, Ordering::Relaxed);
     }
-    #[cfg(not(feature = "smp"))]
-    {
-        // No-op for non-SMP builds.
-    }
+    // No-op for non-SMP builds.
 }
 
 /// Initializes the CPU number information for secondary CPUs.
@@ -196,6 +192,6 @@ pub fn init_cpu_num() {
 /// Used to ensure the correct value of `CPU_NUM` is visible to secondary CPUs.
 #[cfg(feature = "smp")]
 pub fn init_cpu_num_secondary() {
-    // Ensure the correct value of CPU_NUM is visible to secondary CPUs.
-    let _ = CPU_NUM.load(Ordering::Acquire);
+    CPU_NUM.load(Ordering::Relaxed);
+    fence(Ordering::SeqCst)
 }

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -168,7 +168,7 @@ pub fn init_cpu_num() {
     #[cfg(feature = "smp")]
     {
         let plat_cpu_num = axplat::power::cpu_num();
-        let max_cpu_num = axconfig::MAX_CPU_NUM;
+        let max_cpu_num = axconfig::plat::MAX_CPU_NUM;
         let cpu_num = plat_cpu_num.min(max_cpu_num);
 
         info!(

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -132,10 +132,6 @@ pub fn get_bootarg() -> usize {
 #[cfg(feature = "smp")]
 static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
 
-/// Indicates whether the CPU number has been initialized.
-#[cfg(feature = "smp")]
-static CPU_NUM_OK: AtomicBool = AtomicBool::new(false);
-
 /// Gets the number of CPUs running in the system.
 ///
 /// When SMP is disabled, this function always returns 1.
@@ -154,8 +150,10 @@ pub fn cpu_num() -> usize {
         // The BSP will always see the correct value because `CPU_NUM` is set by
         // itself.
         //
-        // All APs will see the correct value because of `CPU_NUM_OK`.
-        CPU_NUM.load(Ordering::Relaxed)
+        // All APs will see the correct value because it is written with
+        // `Ordering::Release` and read with `Ordering::Acquire`, ensuring
+        // memory visibility.
+        CPU_NUM.load(Ordering::Acquire)
     }
     #[cfg(not(feature = "smp"))]
     {
@@ -180,18 +178,7 @@ pub fn init_cpu_num() {
             );
         }
 
-        CPU_NUM.store(cpu_num, Ordering::Relaxed);
-        CPU_NUM_OK.store(true, Ordering::Release);
+        CPU_NUM.store(cpu_num, Ordering::Release);
     }
     // No-op for non-SMP builds.
-}
-
-/// Initializes the CPU number information for secondary CPUs.
-///
-/// Used to ensure the correct value of `CPU_NUM` is visible to secondary CPUs.
-#[cfg(feature = "smp")]
-pub fn init_cpu_num_secondary() {
-    while !CPU_NUM_OK.load(Ordering::Acquire) {
-        core::hint::spin_loop();
-    }
 }

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -108,7 +108,7 @@ pub use axplat::init::init_later;
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
 #[cfg(feature = "smp")]
-use core::sync::atomic::{AtomicUsize, Ordering, fence};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use lazyinit::LazyInit;
 
@@ -132,6 +132,10 @@ pub fn get_bootarg() -> usize {
 #[cfg(feature = "smp")]
 static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
 
+/// Indicates whether the CPU number has been initialized.
+#[cfg(feature = "smp")]
+static CPU_NUM_OK: AtomicBool = AtomicBool::new(false);
+
 /// Gets the number of CPUs running in the system.
 ///
 /// When SMP is disabled, this function always returns 1.
@@ -150,9 +154,7 @@ pub fn cpu_num() -> usize {
         // The BSP will always see the correct value because `CPU_NUM` is set by
         // itself.
         //
-        // All APs will see the correct value because `init_cpu_num_secondary`
-        // is called during their initialization, which contains a fence to
-        // ensure visibility of the correct value.
+        // All APs will see the correct value because of `CPU_NUM_OK`.
         CPU_NUM.load(Ordering::Relaxed)
     }
     #[cfg(not(feature = "smp"))]
@@ -178,8 +180,8 @@ pub fn init_cpu_num() {
             );
         }
 
-        fence(Ordering::SeqCst);
         CPU_NUM.store(cpu_num, Ordering::Relaxed);
+        CPU_NUM_OK.store(true, Ordering::Release);
     }
     // No-op for non-SMP builds.
 }
@@ -189,6 +191,7 @@ pub fn init_cpu_num() {
 /// Used to ensure the correct value of `CPU_NUM` is visible to secondary CPUs.
 #[cfg(feature = "smp")]
 pub fn init_cpu_num_secondary() {
-    CPU_NUM.load(Ordering::Relaxed);
-    fence(Ordering::SeqCst)
+    while !CPU_NUM_OK.load(Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
 }

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -107,7 +107,7 @@ pub use axplat::init::init_later;
 
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
-
+#[cfg(feature = "smp")]
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use lazyinit::LazyInit;
@@ -131,45 +131,64 @@ pub fn get_bootarg() -> usize {
 /// platform crate and limited by the configured maximum CPU number.
 ///
 /// Defaults to 1 for non-SMP builds.
+#[cfg(feature = "smp")]
 static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
 
-/// Gets the number of CPUs running in the system. It's the smaller one between
-/// the platform-declared CPU number [`axplat::power::cpu_num`] and the
-/// configured maximum CPU number `axconfig::plat::MAX_CPU_NUM`.
+/// Gets the number of CPUs running in the system.
+///
+/// When SMP is disabled, this function always returns 1.
+///
+/// When SMP is enabled, It's the smaller one between the platform-declared CPU
+/// number [`axplat::power::cpu_num`] and the configured maximum CPU number
+/// `axconfig::plat::MAX_CPU_NUM`.
 ///
 /// This value is determined during the BSP initialization phase.
 pub fn cpu_num() -> usize {
-    // Relaxed is used here for best performance, as this value is only set
-    // once during initialization and never changed afterwards.
-    //
-    // The BSP will always see the correct value because `CPU_NUM` is set by
-    // itself.
-    //
-    // All APs will read `CPU_NUM` with `Acquire` once they are started,
-    // ensuring they see the correct value. Then they can use `Relaxed` for
-    // subsequent reads.
-    CPU_NUM.load(Ordering::Relaxed)
+    #[cfg(feature = "smp")]
+    {
+        // Relaxed is used here for best performance, as this value is only set
+        // once during initialization and never changed afterwards.
+        //
+        // The BSP will always see the correct value because `CPU_NUM` is set by
+        // itself.
+        //
+        // All APs will read `CPU_NUM` with `Acquire` once they are started,
+        // ensuring they see the correct value. Then they can use `Relaxed` for
+        // subsequent reads.
+        CPU_NUM.load(Ordering::Relaxed)
+    }
+    #[cfg(not(feature = "smp"))]
+    {
+        1
+    }
 }
 
 /// Initializes the CPU number information.
 pub fn init_cpu_num() {
-    let plat_cpu_num = axplat::power::cpu_num();
-    let max_cpu_num = axconfig::MAX_CPU_NUM;
-    let cpu_num = plat_cpu_num.min(max_cpu_num);
+    #[cfg(feature = "smp")]
+    {
+        let plat_cpu_num = axplat::power::cpu_num();
+        let max_cpu_num = axconfig::MAX_CPU_NUM;
+        let cpu_num = plat_cpu_num.min(max_cpu_num);
 
-    info!(
-        "{} CPUs detected by platform, max supported is {}. {} will be used.",
-        plat_cpu_num, max_cpu_num, cpu_num
-    );
-
-    if plat_cpu_num > max_cpu_num {
-        warn!(
-            "platform declares more CPUs ({plat_cpu_num}) than supported max ({max_cpu_num}), only \
-            the first {max_cpu_num} CPUs will be used."
+        info!(
+            "{} CPUs detected by platform, max supported is {}. {} will be used.",
+            plat_cpu_num, max_cpu_num, cpu_num
         );
-    }
 
-    CPU_NUM.store(cpu_num, Ordering::Release);
+        if plat_cpu_num > max_cpu_num {
+            warn!(
+                "platform declares more CPUs ({plat_cpu_num}) than supported max ({max_cpu_num}), only \
+                the first {max_cpu_num} CPUs will be used."
+            );
+        }
+
+        CPU_NUM.store(cpu_num, Ordering::Release);
+    }
+    #[cfg(not(feature = "smp"))]
+    {
+        // No-op for non-SMP builds.
+    }
 }
 
 /// Initializes the CPU number information for secondary CPUs.

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -108,6 +108,8 @@ pub use axplat::init::init_later;
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
 
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 use lazyinit::LazyInit;
 
 static BOOT_ARG: LazyInit<usize> = LazyInit::new();
@@ -123,4 +125,58 @@ pub fn init_early(cpu_id: usize, arg: usize) {
 /// This is typically the device tree blob address passed from the bootloader.
 pub fn get_bootarg() -> usize {
     *BOOT_ARG
+}
+
+/// The number of CPUs in the system. Based on the number declared by the
+/// platform crate and limited by the configured maximum CPU number.
+///
+/// Defaults to 1 for non-SMP builds.
+static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
+
+/// Gets the number of CPUs running in the system. It's the smaller one between
+/// the platform-declared CPU number [`axplat::power::cpu_num`] and the
+/// configured maximum CPU number `axconfig::plat::MAX_CPU_NUM`.
+///
+/// This value is determined during the BSP initialization phase.
+pub fn cpu_num() -> usize {
+    // Relaxed is used here for best performance, as this value is only set
+    // once during initialization and never changed afterwards.
+    //
+    // The BSP will always see the correct value because `CPU_NUM` is set by
+    // itself.
+    //
+    // All APs will read `CPU_NUM` with `Acquire` once they are started,
+    // ensuring they see the correct value. Then they can use `Relaxed` for
+    // subsequent reads.
+    CPU_NUM.load(Ordering::Relaxed)
+}
+
+/// Initializes the CPU number information.
+pub fn init_cpu_num() {
+    let plat_cpu_num = axplat::power::cpu_num();
+    let max_cpu_num = axconfig::MAX_CPU_NUM;
+    let cpu_num = plat_cpu_num.min(max_cpu_num);
+
+    info!(
+        "{} CPUs detected by platform, max supported is {}. {} will be used.",
+        plat_cpu_num, max_cpu_num, cpu_num
+    );
+
+    if plat_cpu_num > max_cpu_num {
+        warn!(
+            "platform declares more CPUs ({plat_cpu_num}) than supported max ({max_cpu_num}), only \
+            the first {max_cpu_num} CPUs will be used."
+        );
+    }
+
+    CPU_NUM.store(cpu_num, Ordering::Release);
+}
+
+/// Initializes the CPU number information for secondary CPUs.
+///
+/// Used to ensure the correct value of `CPU_NUM` is visible to secondary CPUs.
+#[cfg(feature = "smp")]
+pub fn init_cpu_num_secondary() {
+    // Ensure the correct value of CPU_NUM is visible to secondary CPUs.
+    let _ = CPU_NUM.load(Ordering::Acquire);
 }

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -169,15 +169,12 @@ pub fn init_cpu_num() {
         let max_cpu_num = axconfig::plat::MAX_CPU_NUM;
         let cpu_num = plat_cpu_num.min(max_cpu_num);
 
-        info!(
-            "{} CPUs detected by platform, max supported is {}. {} will be used.",
-            plat_cpu_num, max_cpu_num, cpu_num
-        );
+        info!("CPU number: max = {max_cpu_num}, platform = {plat_cpu_num}, use = {cpu_num}",);
 
         if plat_cpu_num > max_cpu_num {
             warn!(
-                "platform declares more CPUs ({plat_cpu_num}) than supported max ({max_cpu_num}), only \
-                the first {max_cpu_num} CPUs will be used."
+                "platform declares more CPUs ({plat_cpu_num}) than configured max ({max_cpu_num}), \
+                only the first {max_cpu_num} CPUs will be used."
             );
         }
 

--- a/modules/axipi/src/lib.rs
+++ b/modules/axipi/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run_on_cpu<T: Into<Callback>>(dest_cpu: usize, callback: T) {
 pub fn run_on_each_cpu<T: Into<MulticastCallback>>(callback: T) {
     info!("Send IPI event to all other CPUs");
     let current_cpu_id = this_cpu_id();
-    let cpu_num = axconfig::plat::CPU_NUM;
+    let cpu_num = axhal::cpu_num();
     let callback = callback.into();
 
     // Execute callback on current CPU immediately

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -86,10 +86,11 @@ impl axlog::LogIf for LogIfImpl {
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+/// Number of CPUs that have completed initialization.
 static INITED_CPUS: AtomicUsize = AtomicUsize::new(0);
 
 fn is_init_ok() -> bool {
-    INITED_CPUS.load(Ordering::Acquire) == axconfig::plat::CPU_NUM
+    INITED_CPUS.load(Ordering::Acquire) == axhal::cpu_num()
 }
 
 /// The main entry point of the ArceOS runtime.
@@ -117,7 +118,6 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
             build_mode = {}
             log_level = {}
             backtrace = {}
-            smp = {}
         "},
         axconfig::ARCH,
         axconfig::PLATFORM,
@@ -125,7 +125,6 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
         option_env!("AX_MODE").unwrap_or(""),
         option_env!("AX_LOG").unwrap_or(""),
         axbacktrace::is_enabled(),
-        axconfig::plat::CPU_NUM,
     );
     #[cfg(feature = "rtc")]
     ax_println!(
@@ -183,6 +182,8 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
 
     info!("Initialize platform devices...");
     axhal::init_later(cpu_id, arg);
+
+    axhal::init_cpu_num();
 
     #[cfg(feature = "multitask")]
     axtask::init_scheduler();

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,19 +1,20 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use axconfig::{TASK_STACK_SIZE, plat::CPU_NUM};
+use axconfig::{MAX_CPU_NUM, TASK_STACK_SIZE};
 use axhal::mem::{VirtAddr, virt_to_phys};
 
 #[unsafe(link_section = ".bss.stack")]
-static mut SECONDARY_BOOT_STACK: [[u8; TASK_STACK_SIZE]; CPU_NUM - 1] =
-    [[0; TASK_STACK_SIZE]; CPU_NUM - 1];
+static mut SECONDARY_BOOT_STACK: [[u8; TASK_STACK_SIZE]; MAX_CPU_NUM - 1] =
+    [[0; TASK_STACK_SIZE]; MAX_CPU_NUM - 1];
 
 static ENTERED_CPUS: AtomicUsize = AtomicUsize::new(1);
 
 #[allow(clippy::absurd_extreme_comparisons)]
 pub fn start_secondary_cpus(primary_cpu_id: usize) {
     let mut logic_cpu_id = 0;
-    for i in 0..CPU_NUM {
-        if i != primary_cpu_id && logic_cpu_id < CPU_NUM - 1 {
+    let cpu_num = axhal::cpu_num();
+    for i in 0..cpu_num {
+        if i != primary_cpu_id && logic_cpu_id < cpu_num - 1 {
             let stack_top = virt_to_phys(VirtAddr::from(unsafe {
                 SECONDARY_BOOT_STACK[logic_cpu_id].as_ptr_range().end as usize
             }));
@@ -36,6 +37,8 @@ pub fn start_secondary_cpus(primary_cpu_id: usize) {
 pub fn rust_main_secondary(cpu_id: usize) -> ! {
     axhal::percpu::init_secondary(cpu_id);
     axhal::init_early_secondary(cpu_id);
+
+    axhal::init_cpu_num_secondary();
 
     ENTERED_CPUS.fetch_add(1, Ordering::Release);
     info!("Secondary CPU {cpu_id} started.");

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use axconfig::{MAX_CPU_NUM, TASK_STACK_SIZE};
+use axconfig::{TASK_STACK_SIZE, plat::MAX_CPU_NUM};
 use axhal::mem::{VirtAddr, virt_to_phys};
 
 #[unsafe(link_section = ".bss.stack")]

--- a/modules/axruntime/src/mp.rs
+++ b/modules/axruntime/src/mp.rs
@@ -38,8 +38,6 @@ pub fn rust_main_secondary(cpu_id: usize) -> ! {
     axhal::percpu::init_secondary(cpu_id);
     axhal::init_early_secondary(cpu_id);
 
-    axhal::init_cpu_num_secondary();
-
     ENTERED_CPUS.fetch_add(1, Ordering::Release);
     info!("Secondary CPU {cpu_id} started.");
 

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -22,7 +22,6 @@ multitask = [
     "dep:futures-util",
     "dep:kernel_guard",
     "dep:kspin",
-    "dep:lazyinit",
     "dep:memory_addr",
     "dep:percpu",
 ]

--- a/modules/axtask/Cargo.toml
+++ b/modules/axtask/Cargo.toml
@@ -55,7 +55,7 @@ futures-util = { version = "0.3", default-features = false, optional = true, fea
 ] }
 kernel_guard = { workspace = true, optional = true }
 kspin = { workspace = true, optional = true }
-lazyinit = { workspace = true, optional = true }
+lazyinit = { workspace = true }
 log.workspace = true
 memory_addr = { workspace = true, optional = true }
 percpu = { workspace = true, optional = true }

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -32,9 +32,7 @@ pub type AxTaskRef = Arc<AxTask>;
 pub type WeakAxTaskRef = Weak<AxTask>;
 
 /// The wrapper type for [`cpumask::CpuMask`] with SMP configuration.
-pub type AxCpuMask = cpumask::CpuMask<{ axconfig::plat::CPU_NUM }>;
-
-static CPU_NUM: AtomicUsize = AtomicUsize::new(1);
+pub type AxCpuMask = cpumask::CpuMask<{ axconfig::MAX_CPU_NUM }>;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "sched-rr")] {
@@ -87,21 +85,36 @@ pub fn current() -> CurrentTask {
 
 /// Initializes the task scheduler (for the primary CPU).
 pub fn init_scheduler() {
-    init_scheduler_with_cpu_num(axconfig::plat::CPU_NUM);
-}
-
-/// Initializes the task scheduler with cpu_num (for the primary CPU).
-pub fn init_scheduler_with_cpu_num(cpu_num: usize) {
     info!("Initialize scheduling...");
-    CPU_NUM.store(cpu_num, core::sync::atomic::Ordering::Relaxed);
 
+    // Initialize the cpu count information.
+    init_cpu_mask_full();
+
+    // Initialize the run queue.
     crate::run_queue::init();
 
     info!("  use {} scheduler.", Scheduler::scheduler_name());
 }
 
-pub(crate) fn active_cpu_num() -> usize {
-    CPU_NUM.load(core::sync::atomic::Ordering::Relaxed)
+/// The full CPU mask of the system.
+static CPU_MASK_FULL: lazy_init::Lazy<AxCpuMask> = lazy_init::Lazy::new();
+
+/// Gets the cpu count information and initializes related data structures.
+fn init_cpu_mask_full() {
+    let cpu_num = axhal::cpu_num();
+    let mut cpumask = AxCpuMask::new();
+    for cpu_id in 0..cpu_num {
+        cpumask.set(cpu_id, true);
+    }
+
+    CPU_MASK_FULL.get_or_init(|| cpumask);
+}
+
+pub(crate) fn cpu_mask_full() -> AxCpuMask {
+    CPU_MASK_FULL
+        .get()
+        .expect("CPU mask not initialized")
+        .clone()
 }
 
 /// Initializes the task scheduler for secondary CPUs.

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -30,7 +30,7 @@ pub type AxTaskRef = Arc<AxTask>;
 pub type WeakAxTaskRef = Weak<AxTask>;
 
 /// The wrapper type for [`cpumask::CpuMask`] with SMP configuration.
-pub type AxCpuMask = cpumask::CpuMask<{ axconfig::MAX_CPU_NUM }>;
+pub type AxCpuMask = cpumask::CpuMask<{ axconfig::plat::MAX_CPU_NUM }>;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "sched-rr")] {

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -95,7 +95,7 @@ pub fn init_scheduler() {
 }
 
 /// The full CPU mask of the system.
-static CPU_MASK_FULL: lazy_init::Lazy<AxCpuMask> = lazy_init::Lazy::new();
+static CPU_MASK_FULL: lazyinit::Lazy<AxCpuMask> = lazyinit::Lazy::new();
 
 /// Gets the cpu count information and initializes related data structures.
 fn init_cpu_mask_full() {

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -95,7 +95,7 @@ pub fn init_scheduler() {
 }
 
 /// The full CPU mask of the system.
-static CPU_MASK_FULL: lazyinit::Lazy<AxCpuMask> = lazyinit::Lazy::new();
+static CPU_MASK_FULL: lazyinit::LazyInit<AxCpuMask> = lazyinit::LazyInit::new();
 
 /// Gets the cpu count information and initializes related data structures.
 fn init_cpu_mask_full() {
@@ -105,7 +105,7 @@ fn init_cpu_mask_full() {
         cpumask.set(cpu_id, true);
     }
 
-    CPU_MASK_FULL.get_or_init(|| cpumask);
+    CPU_MASK_FULL.call_once(|| cpumask);
 }
 
 pub(crate) fn cpu_mask_full() -> AxCpuMask {

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -1,7 +1,5 @@
 //! Task APIs for multi-task configuration.
 
-use core::sync::atomic::AtomicUsize;
-
 use alloc::{
     string::String,
     sync::{Arc, Weak},

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -54,8 +54,8 @@ percpu_static! {
 /// Access to this variable is marked as `unsafe` because it contains `MaybeUninit` references,
 /// which require careful handling to avoid undefined behavior. The array should be fully
 /// initialized before being accessed to ensure safe usage.
-static mut RUN_QUEUES: [MaybeUninit<&'static mut AxRunQueue>; axconfig::plat::CPU_NUM] =
-    [ARRAY_REPEAT_VALUE; axconfig::plat::CPU_NUM];
+static mut RUN_QUEUES: [MaybeUninit<&'static mut AxRunQueue>; axconfig::MAX_CPU_NUM] =
+    [ARRAY_REPEAT_VALUE; axconfig::MAX_CPU_NUM];
 #[allow(clippy::declare_interior_mutable_const)] // It's ok because it's used only for initialization `RUN_QUEUES`.
 const ARRAY_REPEAT_VALUE: MaybeUninit<&'static mut AxRunQueue> = MaybeUninit::uninit();
 
@@ -100,7 +100,7 @@ pub(crate) fn current_run_queue<G: BaseGuard>() -> CurrentRunQueueRef<'static, G
 /// This function will panic if `cpu_mask` is empty, indicating that there are no available CPUs for task execution.
 ///
 #[cfg(feature = "smp")]
-// The modulo operation is safe here because `axconfig::plat::CPU_NUM` is always greater than 1 with "smp" enabled.
+// The modulo operation is safe here because `axconfig::MAX_CPU_NUM` is always greater than 1 with "smp" enabled.
 #[allow(clippy::modulo_one)]
 #[inline]
 fn select_run_queue_index(cpumask: AxCpuMask) -> usize {
@@ -111,7 +111,7 @@ fn select_run_queue_index(cpumask: AxCpuMask) -> usize {
 
     // Round-robin selection of the run queue index.
     loop {
-        let index = RUN_QUEUE_INDEX.fetch_add(1, Ordering::SeqCst) % axconfig::plat::CPU_NUM;
+        let index = RUN_QUEUE_INDEX.fetch_add(1, Ordering::SeqCst) % axhal::cpu_num();
         if cpumask.get(index) {
             return index;
         }

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -100,7 +100,8 @@ pub(crate) fn current_run_queue<G: BaseGuard>() -> CurrentRunQueueRef<'static, G
 /// This function will panic if `cpu_mask` is empty, indicating that there are no available CPUs for task execution.
 ///
 #[cfg(feature = "smp")]
-// The modulo operation is safe here because `axconfig::MAX_CPU_NUM` is always greater than 1 with "smp" enabled.
+// The modulo operation is safe here because `axhal::cpu_num()` is expected to be greater than 1 in SMP mode.
+// If not, index selection logic would not be meaningful.
 #[allow(clippy::modulo_one)]
 #[inline]
 fn select_run_queue_index(cpumask: AxCpuMask) -> usize {

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -54,8 +54,8 @@ percpu_static! {
 /// Access to this variable is marked as `unsafe` because it contains `MaybeUninit` references,
 /// which require careful handling to avoid undefined behavior. The array should be fully
 /// initialized before being accessed to ensure safe usage.
-static mut RUN_QUEUES: [MaybeUninit<&'static mut AxRunQueue>; axconfig::MAX_CPU_NUM] =
-    [ARRAY_REPEAT_VALUE; axconfig::MAX_CPU_NUM];
+static mut RUN_QUEUES: [MaybeUninit<&'static mut AxRunQueue>; axconfig::plat::MAX_CPU_NUM] =
+    [ARRAY_REPEAT_VALUE; axconfig::plat::MAX_CPU_NUM];
 #[allow(clippy::declare_interior_mutable_const)] // It's ok because it's used only for initialization `RUN_QUEUES`.
 const ARRAY_REPEAT_VALUE: MaybeUninit<&'static mut AxRunQueue> = MaybeUninit::uninit();
 

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -257,10 +257,7 @@ impl TaskInner {
 // private methods
 impl TaskInner {
     fn new_common(id: TaskId, name: String) -> Self {
-        let mut cpumask = AxCpuMask::new();
-        for cpu_id in 0..crate::api::active_cpu_num() {
-            cpumask.set(cpu_id, true);
-        }
+        let cpumask = crate::api::cpu_mask_full();
 
         Self {
             id,

--- a/scripts/make/config.mk
+++ b/scripts/make/config.mk
@@ -17,8 +17,12 @@ ifneq ($(SMP),)
 else
   SMP := $(shell axconfig-gen $(PLAT_CONFIG) -r plat.max-cpu-num 2>/dev/null)
   ifeq ($(SMP),)
-    $(error "`plat.max-cpu-num` is not defined in the platform configuration file, \
-        this option must be specified even for platforms with runtime CPU detection.")
+  # default to 1
+    SMP := 1 
+    config_args += -w 'plat.max-cpu-num=1'
+  # or keep this check to enforce explicit specification
+  #     $(error "`plat.max-cpu-num` is not defined in the platform configuration file, \
+  #         this option must be specified even for platforms with runtime CPU detection.")
   endif
 endif
 

--- a/scripts/make/config.mk
+++ b/scripts/make/config.mk
@@ -17,7 +17,9 @@ ifneq ($(SMP),)
 else
   SMP := $(shell axconfig-gen $(PLAT_CONFIG) -r plat.cpu-num 2>/dev/null)
   ifeq ($(SMP),)
-    $(error "`plat.cpu-num` is not defined in the platform configuration file")
+    $(error "`plat.cpu-num` is not defined in the platform configuration file, \
+        if the platform supports runtime CPU number detection, please set a \
+        dummy value (>1) in the platform config file")
   endif
 endif
 

--- a/scripts/make/config.mk
+++ b/scripts/make/config.mk
@@ -13,13 +13,12 @@ else
 endif
 
 ifneq ($(SMP),)
-  config_args += -w 'plat.cpu-num=$(SMP)'
+  config_args += -w 'plat.max-cpu-num=$(SMP)'
 else
-  SMP := $(shell axconfig-gen $(PLAT_CONFIG) -r plat.cpu-num 2>/dev/null)
+  SMP := $(shell axconfig-gen $(PLAT_CONFIG) -r plat.max-cpu-num 2>/dev/null)
   ifeq ($(SMP),)
-    $(error "`plat.cpu-num` is not defined in the platform configuration file, \
-        if the platform supports runtime CPU number detection, please set a \
-        dummy value (>1) in the platform config file")
+    $(error "`plat.max-cpu-num` is not defined in the platform configuration file, \
+        this option must be specified even for platforms with runtime CPU detection.")
   endif
 endif
 

--- a/scripts/make/config.mk
+++ b/scripts/make/config.mk
@@ -17,12 +17,8 @@ ifneq ($(SMP),)
 else
   SMP := $(shell axconfig-gen $(PLAT_CONFIG) -r plat.max-cpu-num 2>/dev/null)
   ifeq ($(SMP),)
-  # default to 1
-    SMP := 1 
-    config_args += -w 'plat.max-cpu-num=1'
-  # or keep this check to enforce explicit specification
-  #     $(error "`plat.max-cpu-num` is not defined in the platform configuration file, \
-  #         this option must be specified even for platforms with runtime CPU detection.")
+    $(error "`plat.max-cpu-num` is not defined in the platform configuration file, \
+      this option must be specified even for platforms with runtime CPU detection.")
   endif
 endif
 

--- a/ulib/axstd/src/thread/mod.rs
+++ b/ulib/axstd/src/thread/mod.rs
@@ -46,6 +46,6 @@ pub fn sleep_until(deadline: arceos_api::time::AxTimeValue) {
 /// Here we directly return the number of available logical CPUs, representing
 /// the theoretical maximum parallelism.
 pub fn available_parallelism() -> crate::io::Result<NonZero<usize>> {
-    NonZero::new(arceos_api::modules::axconfig::plat::CPU_NUM)
+    NonZero::new(arceos_api::sys::ax_get_cpu_num())
         .ok_or_else(|| panic!("No available CPUs found, cannot determine parallelism"))
 }


### PR DESCRIPTION
Currently ArceOS uses `axconfig::plat::CPU_NUM` to determine the number of CPUs in the target system statically, which is straightforward but quite inflexible. The number of CPUs should be detected and reported by platform crates during initialization. And another platform-independent constant, specifying the maximum number of CPUs supported by ArceOS binary, should be used to determine the size of the bootstack section, the percpu section, etc.

In this PR:

1. A new config item `max-cpu-num` is introduced, which is translated into `axconfig::MAX_CPU_NUM`.
2. Methods and static variables are added to `axhal` to read the number of CPUs during initialization, using `axplat::power::cpu_num()` introduced in https://github.com/arceos-org/axplat_crates/pull/29 . They also handle the abnormal scenarios where platform provided `cpu_num` is larger than `axconfig::MAX_CPU_NUM`.
3. All direct usages of `axconfig::plat::CPU_NUM` are removed and replaced with `axhal::cpu_num()` or `axconfig::MAX_CPU_NUM`.
4. The way to determine and build a full `AxCpuMask` is updated.

Possible issues:

1. `cpu-num` should no longer be a required config item. However, dynamic platforms must still include a dummy greater-than-one `cpu-num` in the config to tell the ArceOS build system that the feature `smp` should be enabled.