### PR TITLE
style: enforce rustfmt.toml and fix clippy issues

### DIFF
--- a/api/arceos_posix_api/build.rs
+++ b/api/arceos_posix_api/build.rs
@@ -117,8 +117,7 @@ typedef struct {{
         // During `cargo publish` verification, the external headers are not
         // available. Use the pre-generated ctypes_gen.rs shipped in the crate.
         eprintln!(
-            "cargo:warning=axlibc include directory not found, \
-             skipping ctypes_gen.rs regeneration"
+            "cargo:warning=axlibc include directory not found, skipping ctypes_gen.rs regeneration"
         );
     }
 }

--- a/examples/httpserver/src/main.rs
+++ b/examples/httpserver/src/main.rs
@@ -22,11 +22,16 @@ use std::{
 const LOCAL_IP: &str = "0.0.0.0";
 const LOCAL_PORT: u16 = 5555;
 
+#[rustfmt::skip]
 macro_rules! header {
     () => {
         "\
-                        HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: \
-         {}\r\nConnection: close\r\n\r\n{}"
+HTTP/1.1 200 OK\r\n\
+Content-Type: text/html\r\n\
+Content-Length: {}\r\n\
+Connection: close\r\n\
+\r\n\
+{}"
     };
 }
 

--- a/modules/axalloc/src/axvisor_impl.rs
+++ b/modules/axalloc/src/axvisor_impl.rs
@@ -3,13 +3,15 @@
 //! This implementation is designed for virtualization scenarios and provides
 //! address translation support.
 
-use super::{UsageKind, Usages};
-use buddy_slab_allocator::{AllocResult, PageAllocator, SlabByteAllocator};
 use core::{
     alloc::{GlobalAlloc, Layout},
     ptr::NonNull,
 };
+
+use buddy_slab_allocator::{AllocResult, PageAllocator, SlabByteAllocator};
 use kspin::SpinNoIrq;
+
+use super::{UsageKind, Usages};
 
 /// The global allocator instance for axvisor mode.
 #[cfg_attr(all(target_os = "none", not(test)), global_allocator)]

--- a/modules/axalloc/src/default_impl.rs
+++ b/modules/axalloc/src/default_impl.rs
@@ -6,13 +6,15 @@
 
 #![allow(dead_code)]
 
-use super::{UsageKind, Usages};
-use axallocator::{AllocResult, BaseAllocator, BitmapPageAllocator, ByteAllocator, PageAllocator};
 use core::{
     alloc::{GlobalAlloc, Layout},
     ptr::NonNull,
 };
+
+use axallocator::{AllocResult, BaseAllocator, BitmapPageAllocator, ByteAllocator, PageAllocator};
 use kspin::SpinNoIrq;
+
+use super::{UsageKind, Usages};
 
 /// The global allocator instance for standard mode.
 #[cfg_attr(all(target_os = "none", not(test)), global_allocator)]

--- a/modules/axalloc/src/lib.rs
+++ b/modules/axalloc/src/lib.rs
@@ -12,6 +12,7 @@ extern crate log;
 extern crate alloc;
 
 use core::fmt;
+
 use strum::{IntoStaticStr, VariantArray};
 
 const PAGE_SIZE: usize = 0x1000;
@@ -86,16 +87,13 @@ use axvisor_impl as imp;
 mod default_impl;
 #[cfg(not(feature = "hv"))]
 use default_impl as imp;
-
-// Re-export types and functions from the implementation
-pub use imp::{GlobalAllocator, global_add_memory, global_init};
-
-// Re-export DefaultByteAllocator from both implementations
-pub use imp::DefaultByteAllocator;
-
 // Re-export AddrTranslator when using hv implementation
 #[cfg(feature = "hv")]
 pub use imp::AddrTranslator;
+// Re-export DefaultByteAllocator from both implementations
+pub use imp::DefaultByteAllocator;
+// Re-export types and functions from the implementation
+pub use imp::{GlobalAllocator, global_add_memory, global_init};
 
 /// Returns the reference to the global allocator.
 pub fn global_allocator() -> &'static GlobalAllocator {

--- a/modules/axdma/src/dma.rs
+++ b/modules/axdma/src/dma.rs
@@ -1,13 +1,11 @@
 use core::{alloc::Layout, ptr::NonNull};
 
-#[cfg(feature = "hv")]
-use buddy_slab_allocator::{AllocError, AllocResult, ByteAllocator};
-
+use axalloc::{DefaultByteAllocator, UsageKind, global_allocator};
 #[cfg(not(feature = "hv"))]
 use axallocator::{AllocError, AllocResult, BaseAllocator, ByteAllocator};
-
-use axalloc::{DefaultByteAllocator, UsageKind, global_allocator};
 use axhal::{mem::virt_to_phys, paging::MappingFlags};
+#[cfg(feature = "hv")]
+use buddy_slab_allocator::{AllocError, AllocResult, ByteAllocator};
 use kspin::SpinNoIrq;
 use log::{debug, error};
 use memory_addr::{PAGE_SIZE_4K, VirtAddr, va};

--- a/modules/axdma/src/lib.rs
+++ b/modules/axdma/src/lib.rs
@@ -8,12 +8,10 @@ mod dma;
 
 use core::{alloc::Layout, ptr::NonNull};
 
-#[cfg(feature = "hv")]
-use buddy_slab_allocator::AllocResult;
-
 #[cfg(not(feature = "hv"))]
 use axallocator::AllocResult;
-
+#[cfg(feature = "hv")]
+use buddy_slab_allocator::AllocResult;
 use memory_addr::PhysAddr;
 
 use self::dma::ALLOCATOR;

--- a/modules/axfs/src/api/dir.rs
+++ b/modules/axfs/src/api/dir.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use alloc::string::String;
-use axio::Result;
 use core::fmt;
+
+use axio::Result;
 
 use super::FileType;
 use crate::fops;

--- a/modules/axfs/src/api/dir.rs
+++ b/modules/axfs/src/api/dir.rs
@@ -157,6 +157,6 @@ impl DirBuilder {
     }
 
     fn create_dir_all(&self, _path: &str) -> Result<()> {
-        Err(axerrno::AxError::Unsupported.into())
+        Err(axerrno::AxError::Unsupported)
     }
 }

--- a/modules/axfs/src/api/file.rs
+++ b/modules/axfs/src/api/file.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axio::{Result, SeekFrom, prelude::*};
 use core::fmt;
+
+use axio::{Result, SeekFrom, prelude::*};
 
 use crate::fops;
 

--- a/modules/axfs/src/api/mod.rs
+++ b/modules/axfs/src/api/mod.rs
@@ -17,11 +17,14 @@
 mod dir;
 mod file;
 
-pub use self::dir::{DirBuilder, DirEntry, ReadDir};
-pub use self::file::{File, FileType, Metadata, OpenOptions, Permissions};
-
 use alloc::{string::String, vec::Vec};
+
 use axio::{self as io, prelude::*};
+
+pub use self::{
+    dir::{DirBuilder, DirEntry, ReadDir},
+    file::{File, FileType, Metadata, OpenOptions, Permissions},
+};
 
 /// Returns an iterator over the entries within a directory.
 pub fn read_dir(path: &str) -> io::Result<ReadDir<'_>> {

--- a/modules/axfs/src/dev.rs
+++ b/modules/axfs/src/dev.rs
@@ -15,6 +15,7 @@
 //! Block device abstraction for disk operations
 
 use alloc::sync::Arc;
+
 use axdriver::prelude::*;
 use spin::Mutex;
 

--- a/modules/axfs/src/fops.rs
+++ b/modules/axfs/src/fops.rs
@@ -260,10 +260,9 @@ impl File {
 
     /// Gets the file attributes.
     pub fn get_attr(&self) -> AxResult<FileAttr> {
-        Ok(self
-            .access_node(Cap::empty())?
+        self.access_node(Cap::empty())?
             .get_attr()
-            .map_err(AxError::from)?)
+            .map_err(AxError::from)
     }
 }
 

--- a/modules/axfs/src/fops.rs
+++ b/modules/axfs/src/fops.rs
@@ -14,11 +14,12 @@
 
 //! Low-level filesystem operations.
 
+use core::fmt;
+
 use axerrno::{AxError, AxResult, ax_err_type};
 use axfs_vfs::VfsNodeRef;
 use axio::SeekFrom;
 use cap_access::{Cap, WithCap};
-use core::fmt;
 
 /// Alias of [`axfs_vfs::VfsNodeType`].
 pub type FileType = axfs_vfs::VfsNodeType;
@@ -382,7 +383,7 @@ impl fmt::Debug for OpenOptions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut written = false;
         macro_rules! fmt_opt {
-            ($field: ident, $label: literal) => {
+            ($field:ident, $label:literal) => {
                 if self.$field {
                     if written {
                         write!(f, " | ")?;

--- a/modules/axfs/src/fs/ext4fs.rs
+++ b/modules/axfs/src/fs/ext4fs.rs
@@ -19,6 +19,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
+
 use axfs_vfs::{
     VfsDirEntry, VfsError, VfsNodeAttr, VfsNodeOps, VfsNodePerm, VfsNodeRef, VfsNodeType, VfsOps,
     VfsResult,
@@ -156,7 +157,7 @@ impl FileWrapper {
         }
 
         if let Some(rest) = trim_path.strip_prefix("./") {
-            //if starts with "./"
+            // if starts with "./"
             return self.path_deal_with(rest);
         }
         let rest_p = trim_path.replace("//", "/");

--- a/modules/axfs/src/fs/ext4fs.rs
+++ b/modules/axfs/src/fs/ext4fs.rs
@@ -182,13 +182,13 @@ impl VfsNodeOps for FileWrapper {
         let (_inode_num, inode) = match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &self.path)
+                get_inode_with_num(&mut fs, &mut inner, &self.path)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &self.path)
+                get_inode_with_num(&mut fs, &mut inner, &self.path)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
@@ -198,8 +198,8 @@ impl VfsNodeOps for FileWrapper {
         } else {
             VfsNodeType::File
         };
-        let size = inode.size() as u64;
-        let blocks = inode.blocks_count() as u64;
+        let size = inode.size();
+        let blocks = inode.blocks_count();
 
         trace!(
             "get_attr of {:?}, size: {}, blocks: {}",
@@ -222,10 +222,10 @@ impl VfsNodeOps for FileWrapper {
                 let mut inner = inner.lock();
                 match ty {
                     VfsNodeType::Dir => {
-                        mkdir(&mut *inner, &mut *fs, &fpath);
+                        mkdir(&mut inner, &mut fs, &fpath);
                     }
                     _ => {
-                        mkfile(&mut *inner, &mut *fs, &fpath, None, None);
+                        mkfile(&mut inner, &mut fs, &fpath, None, None);
                     }
                 }
             }
@@ -233,10 +233,10 @@ impl VfsNodeOps for FileWrapper {
                 let mut inner = inner.lock();
                 match ty {
                     VfsNodeType::Dir => {
-                        mkdir(&mut *inner, &mut *fs, &fpath);
+                        mkdir(&mut inner, &mut fs, &fpath);
                     }
                     _ => {
-                        mkfile(&mut *inner, &mut *fs, &fpath, None, None);
+                        mkfile(&mut inner, &mut fs, &fpath, None, None);
                     }
                 }
             }
@@ -253,13 +253,13 @@ impl VfsNodeOps for FileWrapper {
         let (_inode_num, inode) = match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &fpath)
+                get_inode_with_num(&mut fs, &mut inner, &fpath)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &fpath)
+                get_inode_with_num(&mut fs, &mut inner, &fpath)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
@@ -269,17 +269,17 @@ impl VfsNodeOps for FileWrapper {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
                 if inode.is_dir() {
-                    delete_dir(&mut *fs, &mut *inner, &fpath);
+                    delete_dir(&mut fs, &mut inner, &fpath);
                 } else {
-                    unlink(&mut *fs, &mut *inner, &fpath);
+                    unlink(&mut fs, &mut inner, &fpath);
                 }
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
                 if inode.is_dir() {
-                    delete_dir(&mut *fs, &mut *inner, &fpath);
+                    delete_dir(&mut fs, &mut inner, &fpath);
                 } else {
-                    unlink(&mut *fs, &mut *inner, &fpath);
+                    unlink(&mut fs, &mut inner, &fpath);
                 }
             }
         }
@@ -308,13 +308,13 @@ impl VfsNodeOps for FileWrapper {
         let (_inode_num, mut inode) = match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &self.path)
+                get_inode_with_num(&mut fs, &mut inner, &self.path)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &self.path)
+                get_inode_with_num(&mut fs, &mut inner, &self.path)
                     .map_err(|_| VfsError::Io)?
                     .ok_or(VfsError::NotFound)?
             }
@@ -327,12 +327,12 @@ impl VfsNodeOps for FileWrapper {
         let blocks = match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                resolve_inode_block_allextend(&mut *fs, &mut *inner, &mut inode)
+                resolve_inode_block_allextend(&mut fs, &mut inner, &mut inode)
                     .map_err(|_| VfsError::Io)?
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                resolve_inode_block_allextend(&mut *fs, &mut *inner, &mut inode)
+                resolve_inode_block_allextend(&mut fs, &mut inner, &mut inode)
                     .map_err(|_| VfsError::Io)?
             }
         };
@@ -343,13 +343,13 @@ impl VfsNodeOps for FileWrapper {
                 Ext4Inner::Disk(ref inner) => {
                     let mut inner = inner.lock();
                     fs.datablock_cache
-                        .get_or_load(&mut *inner, phys_block)
+                        .get_or_load(&mut inner, phys_block)
                         .map_err(|_| VfsError::Io)?
                 }
                 Ext4Inner::Partition(ref inner) => {
                     let mut inner = inner.lock();
                     fs.datablock_cache
-                        .get_or_load(&mut *inner, phys_block)
+                        .get_or_load(&mut inner, phys_block)
                         .map_err(|_| VfsError::Io)?
                 }
             };
@@ -359,10 +359,11 @@ impl VfsNodeOps for FileWrapper {
         let entries = list_entries(&data);
         let mut unique = BTreeMap::new();
         for entry in entries {
-            if let Some(name) = entry.name_str() {
-                if name != "." && name != ".." {
-                    unique.insert(name.to_string(), entry.file_type);
-                }
+            if let Some(name) = entry.name_str()
+                && name != "."
+                && name != ".."
+            {
+                unique.insert(name.to_string(), entry.file_type);
             }
         }
         let unique_vec: Vec<_> = unique.into_iter().collect();
@@ -394,13 +395,13 @@ impl VfsNodeOps for FileWrapper {
         let exists = match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &fpath)
+                get_inode_with_num(&mut fs, &mut inner, &fpath)
                     .map_err(|_| VfsError::Io)?
                     .is_some()
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                get_inode_with_num(&mut *fs, &mut *inner, &fpath)
+                get_inode_with_num(&mut fs, &mut inner, &fpath)
                     .map_err(|_| VfsError::Io)?
                     .is_some()
             }
@@ -424,11 +425,11 @@ impl VfsNodeOps for FileWrapper {
             *file_guard = match self.inner {
                 Ext4Inner::Disk(ref inner) => {
                     let mut inner = inner.lock();
-                    open(&mut *inner, &mut *fs, &self.path, false).ok()
+                    open(&mut inner, &mut fs, &self.path, false).ok()
                 }
                 Ext4Inner::Partition(ref inner) => {
                     let mut inner = inner.lock();
-                    open(&mut *inner, &mut *fs, &self.path, false).ok()
+                    open(&mut inner, &mut fs, &self.path, false).ok()
                 }
             };
         }
@@ -439,11 +440,11 @@ impl VfsNodeOps for FileWrapper {
             let data = match self.inner {
                 Ext4Inner::Disk(ref inner) => {
                     let mut inner = inner.lock();
-                    read_at(&mut *inner, &mut *fs, file, buf.len()).map_err(|_| VfsError::Io)?
+                    read_at(&mut inner, &mut fs, file, buf.len()).map_err(|_| VfsError::Io)?
                 }
                 Ext4Inner::Partition(ref inner) => {
                     let mut inner = inner.lock();
-                    read_at(&mut *inner, &mut *fs, file, buf.len()).map_err(|_| VfsError::Io)?
+                    read_at(&mut inner, &mut fs, file, buf.len()).map_err(|_| VfsError::Io)?
                 }
             };
             let len = data.len().min(buf.len());
@@ -459,12 +460,12 @@ impl VfsNodeOps for FileWrapper {
         match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                write_file(&mut *inner, &mut *fs, &self.path, offset, buf)
+                write_file(&mut inner, &mut fs, &self.path, offset, buf)
                     .map_err(|_| VfsError::Io)?;
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                write_file(&mut *inner, &mut *fs, &self.path, offset, buf)
+                write_file(&mut inner, &mut fs, &self.path, offset, buf)
                     .map_err(|_| VfsError::Io)?;
             }
         };
@@ -476,11 +477,11 @@ impl VfsNodeOps for FileWrapper {
         match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                let _ = truncate(&mut *inner, &mut *fs, &self.path, size);
+                let _ = truncate(&mut inner, &mut fs, &self.path, size);
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                let _ = truncate(&mut *inner, &mut *fs, &self.path, size);
+                let _ = truncate(&mut inner, &mut fs, &self.path, size);
             }
         }
         Ok(())
@@ -496,11 +497,11 @@ impl VfsNodeOps for FileWrapper {
         match self.inner {
             Ext4Inner::Disk(ref inner) => {
                 let mut inner = inner.lock();
-                let _ = mv(&mut *fs, &mut *inner, &src_fpath, &dst_fpath);
+                let _ = mv(&mut fs, &mut inner, &src_fpath, &dst_fpath);
             }
             Ext4Inner::Partition(ref inner) => {
                 let mut inner = inner.lock();
-                let _ = mv(&mut *fs, &mut *inner, &src_fpath, &dst_fpath);
+                let _ = mv(&mut fs, &mut inner, &src_fpath, &dst_fpath);
             }
         }
         Ok(())

--- a/modules/axfs/src/fs/fatfs.rs
+++ b/modules/axfs/src/fs/fatfs.rs
@@ -14,13 +14,14 @@
 
 //! FAT filesystem implementation
 
-use alloc::boxed::Box;
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use core::cell::OnceCell;
 
 use axfatfs::{Dir, File, LossyOemCpConverter, NullTimeProvider, Read, Seek, SeekFrom, Write};
-use axfs_vfs::{VfsDirEntry, VfsError, VfsNodePerm, VfsResult};
-use axfs_vfs::{VfsNodeAttr, VfsNodeOps, VfsNodeRef, VfsNodeType, VfsOps};
+use axfs_vfs::{
+    VfsDirEntry, VfsError, VfsNodeAttr, VfsNodeOps, VfsNodePerm, VfsNodeRef, VfsNodeType, VfsOps,
+    VfsResult,
+};
 use spin::Mutex;
 
 use crate::dev::{Disk, Partition};

--- a/modules/axfs/src/fs/mod.rs
+++ b/modules/axfs/src/fs/mod.rs
@@ -20,5 +20,4 @@ pub mod ext4fs;
 pub mod fatfs;
 
 pub use axfs_devfs as devfs;
-
 pub use axfs_ramfs as ramfs;

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -34,16 +34,17 @@ mod disk;
 mod highlevel;
 #[cfg(feature = "monolitic")]
 mod monofs;
-#[cfg(feature = "monolitic")]
-pub use highlevel::*;
-
-use crate::partition::PartitionInfo;
 use alloc::{
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
 };
+
 use axdriver::{AxBlockDevice, AxDeviceContainer, prelude::*};
+#[cfg(feature = "monolitic")]
+pub use highlevel::*;
+
+use crate::partition::PartitionInfo;
 
 #[cfg(not(feature = "monolitic"))]
 /// Initializes filesystems by block devices.
@@ -120,7 +121,8 @@ fn format_guid_as_partuuid(guid: &[u8; 16]) -> alloc::string::String {
     // Linux PARTUUID format is little-endian for first 3 fields,
     // and big-endian for the rest
     alloc::format!(
-        "{:02X}{:02X}{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
+        "{:02X}{:02X}{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:\
+         02X}{:02X}{:02X}",
         guid[3],
         guid[2],
         guid[1],

--- a/modules/axfs/src/lib.rs
+++ b/modules/axfs/src/lib.rs
@@ -155,43 +155,42 @@ struct RootSpec {
 fn parse_root_spec(bootargs: Option<&str>) -> RootSpec {
     let mut spec = RootSpec::default();
 
-    if let Some(bootargs) = bootargs {
-        if let Some(root_arg) = bootargs
+    if let Some(bootargs) = bootargs
+        && let Some(root_arg) = bootargs
             .split_whitespace()
             .find(|arg| arg.starts_with("root="))
-        {
-            let root_value = root_arg.strip_prefix("root=").unwrap_or("");
+    {
+        let root_value = root_arg.strip_prefix("root=").unwrap_or("");
 
-            spec = match root_value {
-                v if v.starts_with("/dev/sda") => parse_device_path(v, "/dev/sda"),
-                v if v.starts_with("/dev/mmcblk") => parse_mmcblk_path(v),
-                v if v.starts_with("PARTUUID=") => {
-                    let partuuid = v.strip_prefix("PARTUUID=").unwrap_or("").to_uppercase();
-                    info!("Looking for partition with PARTUUID: {}", partuuid);
-                    RootSpec {
-                        partuuid: Some(partuuid),
-                        ..Default::default()
-                    }
+        spec = match root_value {
+            v if v.starts_with("/dev/sda") => parse_device_path(v, "/dev/sda"),
+            v if v.starts_with("/dev/mmcblk") => parse_mmcblk_path(v),
+            v if v.starts_with("PARTUUID=") => {
+                let partuuid = v.strip_prefix("PARTUUID=").unwrap_or("").to_uppercase();
+                info!("Looking for partition with PARTUUID: {}", partuuid);
+                RootSpec {
+                    partuuid: Some(partuuid),
+                    ..Default::default()
                 }
-                v if v.starts_with("UUID=") => {
-                    let uuid = v.strip_prefix("UUID=").unwrap_or("").to_uppercase();
-                    info!("Looking for filesystem with UUID: {}", uuid);
-                    RootSpec {
-                        uuid: Some(uuid),
-                        ..Default::default()
-                    }
+            }
+            v if v.starts_with("UUID=") => {
+                let uuid = v.strip_prefix("UUID=").unwrap_or("").to_uppercase();
+                info!("Looking for filesystem with UUID: {}", uuid);
+                RootSpec {
+                    uuid: Some(uuid),
+                    ..Default::default()
                 }
-                v if v.starts_with("PARTLABEL=") => {
-                    let partlabel = v.strip_prefix("PARTLABEL=").unwrap_or("").to_string();
-                    info!("Looking for partition with PARTLABEL: {}", partlabel);
-                    RootSpec {
-                        partlabel: Some(partlabel),
-                        ..Default::default()
-                    }
+            }
+            v if v.starts_with("PARTLABEL=") => {
+                let partlabel = v.strip_prefix("PARTLABEL=").unwrap_or("").to_string();
+                info!("Looking for partition with PARTLABEL: {}", partlabel);
+                RootSpec {
+                    partlabel: Some(partlabel),
+                    ..Default::default()
                 }
-                _ => spec,
-            };
-        }
+            }
+            _ => spec,
+        };
     }
 
     spec
@@ -199,32 +198,31 @@ fn parse_root_spec(bootargs: Option<&str>) -> RootSpec {
 
 /// Parse device path like /dev/sdaX
 fn parse_device_path(path: &str, prefix: &str) -> RootSpec {
-    if let Some(part_num) = path.strip_prefix(prefix) {
-        if let Ok(num) = part_num.parse::<usize>() {
-            if num > 0 {
-                return RootSpec {
-                    partition_index: Some(num - 1),
-                    ..Default::default()
-                };
-            }
-        }
+    if let Some(part_num) = path.strip_prefix(prefix)
+        && let Ok(num) = part_num.parse::<usize>()
+        && num > 0
+    {
+        return RootSpec {
+            partition_index: Some(num - 1),
+            ..Default::default()
+        };
     }
     RootSpec::default()
 }
 
 /// Parse mmcblk path like /dev/mmcblkXpY
 fn parse_mmcblk_path(path: &str) -> RootSpec {
-    if let Some(remaining) = path.strip_prefix("/dev/mmcblk") {
-        if let Some(p_pos) = remaining.find('p') {
-            let part_str = &remaining[p_pos + 1..];
-            if let Ok(num) = part_str.parse::<usize>() {
-                if num > 0 {
-                    return RootSpec {
-                        partition_index: Some(num - 1),
-                        ..Default::default()
-                    };
-                }
-            }
+    if let Some(remaining) = path.strip_prefix("/dev/mmcblk")
+        && let Some(p_pos) = remaining.find('p')
+    {
+        let part_str = &remaining[p_pos + 1..];
+        if let Ok(num) = part_str.parse::<usize>()
+            && num > 0
+        {
+            return RootSpec {
+                partition_index: Some(num - 1),
+                ..Default::default()
+            };
         }
     }
     RootSpec::default()
@@ -258,23 +256,22 @@ fn find_root_partition(partitions: &[PartitionInfo], root_spec: &RootSpec) -> Op
         }
 
         // Check UUID match
-        if let Some(ref uuid) = root_spec.uuid {
-            if let Some(ref partition_uuid) = partition.filesystem_uuid {
-                if partition_uuid.to_uppercase() == *uuid {
-                    info!("UUID matches partition {} ({})", i, partition.name);
-                    return Some(i);
-                }
-            }
+        if let Some(ref uuid) = root_spec.uuid
+            && let Some(ref partition_uuid) = partition.filesystem_uuid
+            && partition_uuid.to_uppercase() == *uuid
+        {
+            info!("UUID matches partition {} ({})", i, partition.name);
+            return Some(i);
         }
 
         // Check PARTLABEL match
-        if let Some(ref partlabel) = root_spec.partlabel {
-            if partition.name == *partlabel {
-                info!("PARTLABEL matches partition {} ({})", i, partition.name);
-                return Some(i);
-            }
+        if let Some(ref partlabel) = root_spec.partlabel
+            && partition.name == *partlabel
+        {
+            info!("PARTLABEL matches partition {} ({})", i, partition.name);
+            return Some(i);
         }
     }
 
-    return None;
+    None
 }

--- a/modules/axfs/src/mounts.rs
+++ b/modules/axfs/src/mounts.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use alloc::sync::Arc;
+
 use axfs_vfs::{VfsNodeType, VfsOps, VfsResult};
 
 use crate::fs;

--- a/modules/axfs/src/partition.rs
+++ b/modules/axfs/src/partition.rs
@@ -276,7 +276,7 @@ fn parse_gpt_partitions(disk: &mut Disk) -> AxResult<Vec<PartitionInfo>> {
         };
 
         let partition = PartitionInfo {
-            index: i as u32,
+            index: i,
             name: name_str,
             partition_type_guid: entry.partition_type_guid,
             unique_partition_guid: entry.unique_partition_guid,
@@ -308,7 +308,7 @@ fn detect_filesystem_type(disk: &mut Disk, start_lba: u64) -> Option<FilesystemT
     // Set position to read from the specific LBA
     disk.set_position(start_lba * 512);
 
-    if let Err(_) = read_exact(disk, &mut boot_sector) {
+    if read_exact(disk, &mut boot_sector).is_err() {
         warn!("Failed to read boot sector at LBA {}", start_lba);
         // Restore position
         disk.set_position(original_position);
@@ -378,7 +378,7 @@ fn is_ext4_filesystem(disk: &mut Disk, start_lba: u64) -> bool {
     // Set position to read the superblock
     disk.set_position(superblock_offset);
 
-    let result = if let Err(_) = read_exact(disk, &mut superblock) {
+    let result = if read_exact(disk, &mut superblock).is_err() {
         warn!(
             "Failed to read ext4 superblock at offset {}",
             superblock_offset

--- a/modules/axfs/src/partition.rs
+++ b/modules/axfs/src/partition.rs
@@ -18,6 +18,7 @@
 //! filesystem types on each partition.
 
 use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+
 use axerrno::{AxError, AxResult};
 use axfs_vfs::VfsOps;
 use log::{debug, info, warn};
@@ -474,7 +475,8 @@ fn read_ext4_uuid(disk: &mut Disk, starting_lba: u64) -> Option<String> {
         // Convert UUID bytes to string format (8-4-4-4-12)
         // ext4 stores UUID as little-endian for the first 3 fields and big-endian for the last 2 fields
         let uuid_str = format!(
-            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+            "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:\
+             02x}{:02x}{:02x}",
             uuid_bytes[0],
             uuid_bytes[1],
             uuid_bytes[2],

--- a/modules/axfs/src/root.rs
+++ b/modules/axfs/src/root.rs
@@ -149,36 +149,36 @@ impl VfsNodeOps for RootDirectory {
 
     fn lookup(self: Arc<Self>, path: &str) -> VfsResult<VfsNodeRef> {
         let normalized_path = self.normalize_path(path);
-        if let Some((mount_fs, rest_path)) = self.find_best_mount(&normalized_path) {
+        if let Some((mount_fs, rest_path)) = self.find_best_mount(normalized_path) {
             mount_fs.root_dir().lookup(rest_path)
         } else {
-            self.main_fs.root_dir().lookup(&normalized_path)
+            self.main_fs.root_dir().lookup(normalized_path)
         }
     }
 
     fn create(&self, path: &str, ty: VfsNodeType) -> VfsResult {
         let normalized_path = self.normalize_path(path);
-        if let Some((mount_fs, rest_path)) = self.find_best_mount(&normalized_path) {
+        if let Some((mount_fs, rest_path)) = self.find_best_mount(normalized_path) {
             if rest_path.is_empty() {
                 Ok(())
             } else {
                 mount_fs.root_dir().create(rest_path, ty)
             }
         } else {
-            self.main_fs.root_dir().create(&normalized_path, ty)
+            self.main_fs.root_dir().create(normalized_path, ty)
         }
     }
 
     fn remove(&self, path: &str) -> VfsResult {
         let normalized_path = self.normalize_path(path);
-        if let Some((mount_fs, rest_path)) = self.find_best_mount(&normalized_path) {
+        if let Some((mount_fs, rest_path)) = self.find_best_mount(normalized_path) {
             if rest_path.is_empty() {
                 Err(axfs_vfs::VfsError::PermissionDenied)
             } else {
                 mount_fs.root_dir().remove(rest_path)
             }
         } else {
-            self.main_fs.root_dir().remove(&normalized_path)
+            self.main_fs.root_dir().remove(normalized_path)
         }
     }
 
@@ -197,13 +197,13 @@ impl VfsNodeOps for RootDirectory {
             main_dirents.push(VfsDirEntry::default());
         }
         let main_count = self.main_fs.root_dir().read_dir(0, &mut main_dirents)?;
-        for i in 0..main_count {
-            let name_bytes = main_dirents[i].name_as_bytes();
-            if let Ok(name_str) = core::str::from_utf8(name_bytes) {
-                if !name_str.is_empty() {
-                    let ty = main_dirents[i].entry_type();
-                    all_entries.push((name_str.to_string(), ty));
-                }
+        for dirent in main_dirents.iter().take(main_count) {
+            let name_bytes = dirent.name_as_bytes();
+            if let Ok(name_str) = core::str::from_utf8(name_bytes)
+                && !name_str.is_empty()
+            {
+                let ty = dirent.entry_type();
+                all_entries.push((name_str.to_string(), ty));
             }
         }
 
@@ -240,10 +240,10 @@ fn find_root_filesystem(
     root_partition_index: Option<usize>,
 ) -> (Option<Arc<dyn VfsOps>>, Option<usize>) {
     // Try to use the specified partition index first
-    if let Some(index) = root_partition_index {
-        if let Some((fs, idx)) = try_use_specified_partition(disk, partitions, index) {
-            return (Some(fs), Some(idx));
-        }
+    if let Some(index) = root_partition_index
+        && let Some((fs, idx)) = try_use_specified_partition(disk, partitions, index)
+    {
+        return (Some(fs), Some(idx));
     }
 
     // Fall back to first partition with supported filesystem
@@ -493,7 +493,7 @@ pub(crate) fn create_file(dir: Option<&VfsNodeRef>, path: &str) -> AxResult<VfsN
     parent
         .create(path, VfsNodeType::File)
         .map_err(AxError::from)?;
-    Ok(parent.lookup(path).map_err(AxError::from)?)
+    parent.lookup(path).map_err(AxError::from)
 }
 
 pub(crate) fn create_dir(dir: Option<&VfsNodeRef>, path: &str) -> AxResult {
@@ -584,7 +584,7 @@ pub(crate) fn rename(old: &str, new: &str) -> AxResult {
         warn!("dst file already exist, now remove it");
         remove_file(None, new)?;
     }
-    Ok(parent_node_of(None, old)
+    parent_node_of(None, old)
         .rename(old, new)
-        .map_err(AxError::from)?)
+        .map_err(AxError::from)
 }

--- a/modules/axfs/src/root.rs
+++ b/modules/axfs/src/root.rs
@@ -24,6 +24,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
+
 use axerrno::{AxError, AxResult};
 use axfs_vfs::{VfsDirEntry, VfsNodeAttr, VfsNodeOps, VfsNodeRef, VfsNodeType, VfsOps, VfsResult};
 use lazyinit::LazyInit;

--- a/modules/axhal/build.rs
+++ b/modules/axhal/build.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-use std::path::Path;
+use std::{io::Result, path::Path};
 
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(plat_dyn)");

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -104,12 +104,9 @@ pub mod context {
 }
 
 pub use axcpu::asm;
-
 #[cfg(feature = "uspace")]
 pub use axcpu::uspace;
-
 pub use axplat::init::init_later;
-
 #[cfg(feature = "smp")]
 pub use axplat::init::{init_early_secondary, init_later_secondary};
 

--- a/modules/axhal/src/paging.rs
+++ b/modules/axhal/src/paging.rs
@@ -3,11 +3,10 @@
 use axalloc::{UsageKind, global_allocator};
 use memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
 use page_table_multiarch::PagingHandler;
-
-use crate::mem::{phys_to_virt, virt_to_phys};
-
 #[doc(no_inline)]
 pub use page_table_multiarch::{MappingFlags, PageSize, PagingError, PagingResult};
+
+use crate::mem::{phys_to_virt, virt_to_phys};
 
 /// Implementation of [`PagingHandler`], to provide physical memory manipulation to
 /// the [page_table_multiarch] crate.

--- a/modules/axlog/src/lib.rs
+++ b/modules/axlog/src/lib.rs
@@ -82,22 +82,22 @@ macro_rules! with_color {
 #[repr(u8)]
 #[allow(dead_code)]
 enum ColorCode {
-    Black = 30,
-    Red = 31,
-    Green = 32,
-    Yellow = 33,
-    Blue = 34,
-    Magenta = 35,
-    Cyan = 36,
-    White = 37,
-    BrightBlack = 90,
-    BrightRed = 91,
-    BrightGreen = 92,
-    BrightYellow = 93,
-    BrightBlue = 94,
+    Black         = 30,
+    Red           = 31,
+    Green         = 32,
+    Yellow        = 33,
+    Blue          = 34,
+    Magenta       = 35,
+    Cyan          = 36,
+    White         = 37,
+    BrightBlack   = 90,
+    BrightRed     = 91,
+    BrightGreen   = 92,
+    BrightYellow  = 93,
+    BrightBlue    = 94,
     BrightMagenta = 95,
-    BrightCyan = 96,
-    BrightWhite = 97,
+    BrightCyan    = 96,
+    BrightWhite   = 97,
 }
 
 /// Extern interfaces that must be implemented in other crates.

--- a/modules/axmm/src/aspace.rs
+++ b/modules/axmm/src/aspace.rs
@@ -1,9 +1,11 @@
 use core::fmt;
 
 use axerrno::{AxError, AxResult, ax_err};
-use axhal::mem::phys_to_virt;
-use axhal::paging::{MappingFlags, PageTable};
-use axhal::trap::PageFaultFlags;
+use axhal::{
+    mem::phys_to_virt,
+    paging::{MappingFlags, PageTable},
+    trap::PageFaultFlags,
+};
 use memory_addr::{
     MemoryAddr, PAGE_SIZE_4K, PageIter4K, PhysAddr, VirtAddr, VirtAddrRange, is_aligned_4k,
 };
@@ -178,7 +180,7 @@ impl AddrSpace {
         for vaddr in PageIter4K::new(start.align_down_4k(), end_align_up)
             .expect("Failed to create page iterator")
         {
-            let (mut paddr, _, _) = self.pt.query(vaddr).map_err(|_| AxError::BadAddress)?;
+            let (mut paddr, ..) = self.pt.query(vaddr).map_err(|_| AxError::BadAddress)?;
 
             let mut copy_size = (size - cnt).min(PAGE_SIZE_4K);
 

--- a/modules/axmm/src/backend/alloc.rs
+++ b/modules/axmm/src/backend/alloc.rs
@@ -1,6 +1,8 @@
 use axalloc::{UsageKind, global_allocator};
-use axhal::mem::{phys_to_virt, virt_to_phys};
-use axhal::paging::{MappingFlags, PageSize, PageTable};
+use axhal::{
+    mem::{phys_to_virt, virt_to_phys},
+    paging::{MappingFlags, PageSize, PageTable},
+};
 use memory_addr::{PAGE_SIZE_4K, PageIter4K, PhysAddr, VirtAddr};
 
 use super::Backend;

--- a/modules/axmm/src/lib.rs
+++ b/modules/axmm/src/lib.rs
@@ -9,15 +9,16 @@ extern crate alloc;
 mod aspace;
 mod backend;
 
-pub use self::aspace::AddrSpace;
-pub use self::backend::Backend;
-
 use axerrno::{AxError, AxResult};
-use axhal::mem::{MemRegionFlags, phys_to_virt};
-use axhal::paging::MappingFlags;
+use axhal::{
+    mem::{MemRegionFlags, phys_to_virt},
+    paging::MappingFlags,
+};
 use kspin::SpinNoIrq;
 use lazyinit::LazyInit;
 use memory_addr::{MemoryAddr, PhysAddr, VirtAddr};
+
+pub use self::{aspace::AddrSpace, backend::Backend};
 
 static KERNEL_ASPACE: LazyInit<SpinNoIrq<AddrSpace>> = LazyInit::new();
 

--- a/modules/axnet/src/lib.rs
+++ b/modules/axnet/src/lib.rs
@@ -30,12 +30,11 @@ cfg_if::cfg_if! {
     }
 }
 
-pub use self::net_impl::TcpSocket;
-pub use self::net_impl::UdpSocket;
-pub use self::net_impl::{bench_receive, bench_transmit};
-pub use self::net_impl::{dns_query, poll_interfaces};
-
 use axdriver::{AxDeviceContainer, prelude::*};
+
+pub use self::net_impl::{
+    TcpSocket, UdpSocket, bench_receive, bench_transmit, dns_query, poll_interfaces,
+};
 
 /// Initializes the network subsystem by NIC devices.
 pub fn init_network(mut net_devs: AxDeviceContainer<AxNetDevice>) {

--- a/modules/axnet/src/smoltcp_impl/bench.rs
+++ b/modules/axnet/src/smoltcp_impl/bench.rs
@@ -1,6 +1,6 @@
-use super::{AxNetRxToken, AxNetTxToken, STANDARD_MTU};
-use super::{DeviceWrapper, InterfaceWrapper};
 use smoltcp::phy::{Device, RxToken, TxToken};
+
+use super::{AxNetRxToken, AxNetTxToken, DeviceWrapper, InterfaceWrapper, STANDARD_MTU};
 
 const GB: usize = 1000 * MB;
 const MB: usize = 1000 * KB;

--- a/modules/axnet/src/smoltcp_impl/dns.rs
+++ b/modules/axnet/src/smoltcp_impl/dns.rs
@@ -1,10 +1,12 @@
 use alloc::vec::Vec;
-use axerrno::{AxError, AxResult, ax_err_type};
 use core::net::IpAddr;
 
-use smoltcp::iface::SocketHandle;
-use smoltcp::socket::dns::{self, GetQueryResultError, StartQueryError};
-use smoltcp::wire::DnsQueryType;
+use axerrno::{AxError, AxResult, ax_err_type};
+use smoltcp::{
+    iface::SocketHandle,
+    socket::dns::{self, GetQueryResultError, StartQueryError},
+    wire::DnsQueryType,
+};
 
 use super::{ETH0, SOCKET_SET, SocketSetWrapper};
 

--- a/modules/axnet/src/smoltcp_impl/listen_table.rs
+++ b/modules/axnet/src/smoltcp_impl/listen_table.rs
@@ -3,9 +3,11 @@ use core::ops::{Deref, DerefMut};
 
 use axerrno::{AxError, AxResult, ax_err};
 use axsync::Mutex;
-use smoltcp::iface::{SocketHandle, SocketSet};
-use smoltcp::socket::tcp::{self, State};
-use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
+use smoltcp::{
+    iface::{SocketHandle, SocketSet},
+    socket::tcp::{self, State},
+    wire::{IpAddress, IpEndpoint, IpListenEndpoint},
+};
 
 use super::{LISTEN_QUEUE_SIZE, SOCKET_SET, SocketSetWrapper};
 

--- a/modules/axnet/src/smoltcp_impl/mod.rs
+++ b/modules/axnet/src/smoltcp_impl/mod.rs
@@ -6,24 +6,22 @@ mod tcp;
 mod udp;
 
 use alloc::vec;
-use core::cell::RefCell;
-use core::ops::DerefMut;
+use core::{cell::RefCell, ops::DerefMut};
 
 use axdriver::prelude::*;
 use axhal::time::{NANOS_PER_MICROS, wall_time_nanos};
 use axsync::Mutex;
 use lazyinit::LazyInit;
-use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
-use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
-use smoltcp::socket::{self, AnySocket};
-use smoltcp::time::Instant;
-use smoltcp::wire::{EthernetAddress, HardwareAddress, IpAddress, IpCidr};
+use smoltcp::{
+    iface::{Config, Interface, SocketHandle, SocketSet},
+    phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken},
+    socket::{self, AnySocket},
+    time::Instant,
+    wire::{EthernetAddress, HardwareAddress, IpAddress, IpCidr},
+};
 
 use self::listen_table::ListenTable;
-
-pub use self::dns::dns_query;
-pub use self::tcp::TcpSocket;
-pub use self::udp::UdpSocket;
+pub use self::{dns::dns_query, tcp::TcpSocket, udp::UdpSocket};
 
 macro_rules! env_or_default {
     ($key:literal) => {
@@ -56,7 +54,7 @@ static ETH0: LazyInit<InterfaceWrapper> = LazyInit::new();
 struct SocketSetWrapper<'a>(Mutex<SocketSet<'a>>);
 
 struct DeviceWrapper {
-    inner: RefCell<AxNetDevice>, // use `RefCell` is enough since it's wrapped in `Mutex` in `InterfaceWrapper`.
+    inner: RefCell<AxNetDevice>, /* use `RefCell` is enough since it's wrapped in `Mutex` in `InterfaceWrapper`. */
 }
 
 struct InterfaceWrapper {

--- a/modules/axnet/src/smoltcp_impl/tcp.rs
+++ b/modules/axnet/src/smoltcp_impl/tcp.rs
@@ -1,17 +1,19 @@
-use core::cell::UnsafeCell;
-use core::net::SocketAddr;
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::{
+    cell::UnsafeCell,
+    net::SocketAddr,
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+};
 
 use axerrno::{AxError, AxResult, ax_err, ax_err_type};
 use axio::PollState;
 use axsync::Mutex;
+use smoltcp::{
+    iface::SocketHandle,
+    socket::tcp::{self, ConnectError, State},
+    wire::{IpEndpoint, IpListenEndpoint},
+};
 
-use smoltcp::iface::SocketHandle;
-use smoltcp::socket::tcp::{self, ConnectError, State};
-use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
-
-use super::addr::UNSPECIFIED_ENDPOINT;
-use super::{ETH0, LISTEN_TABLE, SOCKET_SET, SocketSetWrapper};
+use super::{ETH0, LISTEN_TABLE, SOCKET_SET, SocketSetWrapper, addr::UNSPECIFIED_ENDPOINT};
 
 // State transitions:
 // CLOSED -(connect)-> BUSY -> CONNECTING -> CONNECTED -(shutdown)-> BUSY -> CLOSED

--- a/modules/axnet/src/smoltcp_impl/udp.rs
+++ b/modules/axnet/src/smoltcp_impl/udp.rs
@@ -1,17 +1,19 @@
-use core::net::SocketAddr;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::{
+    net::SocketAddr,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use axerrno::{AxError, AxResult, ax_err, ax_err_type};
 use axio::PollState;
 use axsync::Mutex;
+use smoltcp::{
+    iface::SocketHandle,
+    socket::udp::{self, BindError, SendError},
+    wire::{IpEndpoint, IpListenEndpoint},
+};
 use spin::RwLock;
 
-use smoltcp::iface::SocketHandle;
-use smoltcp::socket::udp::{self, BindError, SendError};
-use smoltcp::wire::{IpEndpoint, IpListenEndpoint};
-
-use super::addr::UNSPECIFIED_ENDPOINT;
-use super::{SOCKET_SET, SocketSetWrapper};
+use super::{SOCKET_SET, SocketSetWrapper, addr::UNSPECIFIED_ENDPOINT};
 
 /// A UDP socket that provides POSIX-like APIs.
 pub struct UdpSocket {

--- a/modules/axplat-dyn/src/init.rs
+++ b/modules/axplat-dyn/src/init.rs
@@ -16,7 +16,7 @@ impl InitIf for InitIfImpl {
 
     /// Initializes the platform at the early stage for secondary cores.
     #[cfg(feature = "smp")]
-    fn init_early_secondary(cpu_id: usize) {
+    fn init_early_secondary(_cpu_id: usize) {
         axcpu::init::init_trap();
         somehal::timer::enable();
     }

--- a/modules/axplat-dyn/src/irq.rs
+++ b/modules/axplat-dyn/src/irq.rs
@@ -45,7 +45,7 @@ impl IrqIf for IrqIfImpl {
     /// It is called by the common interrupt handler. It should look up in the
     /// IRQ handler table and calls the corresponding handler. If necessary, it
     /// also acknowledges the interrupt controller after handling.
-    fn handle(irq_num: usize) -> Option<usize> {
+    fn handle(_irq_num: usize) -> Option<usize> {
         let irq = somehal::irq::irq_handler_raw();
         Some(irq.raw())
     }

--- a/modules/axtask/src/api.rs
+++ b/modules/axtask/src/api.rs
@@ -8,20 +8,17 @@ use alloc::{
 use kernel_guard::NoPreemptIrqSave;
 
 pub(crate) use crate::run_queue::{current_run_queue, select_run_queue};
-
+#[doc(cfg(all(feature = "multitask", feature = "task-ext")))]
+#[cfg(feature = "task-ext")]
+pub use crate::task::{AxTaskExt, TaskExt};
+#[doc(cfg(all(feature = "multitask", feature = "irq")))]
+#[cfg(feature = "irq")]
+pub use crate::timers::register_timer_callback;
 #[doc(cfg(feature = "multitask"))]
 pub use crate::{
     task::{CurrentTask, TaskId, TaskInner, TaskState},
     wait_queue::WaitQueue,
 };
-
-#[doc(cfg(all(feature = "multitask", feature = "irq")))]
-#[cfg(feature = "irq")]
-pub use crate::timers::register_timer_callback;
-
-#[doc(cfg(all(feature = "multitask", feature = "task-ext")))]
-#[cfg(feature = "task-ext")]
-pub use crate::task::{AxTaskExt, TaskExt};
 
 /// The reference type of a task.
 pub type AxTaskRef = Arc<AxTask>;

--- a/modules/axtask/src/future/mod.rs
+++ b/modules/axtask/src/future/mod.rs
@@ -1,7 +1,6 @@
 //! Future support.
 
 use alloc::{sync::Arc, task::Wake};
-use axerrno::AxError;
 use core::{
     fmt,
     future::poll_fn,
@@ -10,6 +9,7 @@ use core::{
     task::{Context, Poll, Waker},
 };
 
+use axerrno::AxError;
 use kernel_guard::NoPreemptIrqSave;
 
 use crate::{AxTaskRef, WeakAxTaskRef, current, current_run_queue, select_run_queue};

--- a/modules/axtask/src/run_queue.rs
+++ b/modules/axtask/src/run_queue.rs
@@ -1,20 +1,18 @@
+#[cfg(feature = "smp")]
+use alloc::sync::Weak;
 use alloc::{collections::VecDeque, sync::Arc};
 use core::{
     future::poll_fn,
     mem::MaybeUninit,
     task::{Context, Poll},
 };
-use futures_util::task::AtomicWaker;
 
-#[cfg(feature = "smp")]
-use alloc::sync::Weak;
-
+use axhal::percpu::this_cpu_id;
 use axsched::BaseScheduler;
+use futures_util::task::AtomicWaker;
 use kernel_guard::BaseGuard;
 use kspin::SpinRaw;
 use lazyinit::LazyInit;
-
-use axhal::percpu::this_cpu_id;
 
 use crate::{
     AxCpuMask, AxTaskRef, Scheduler, TaskInner,
@@ -98,7 +96,6 @@ pub(crate) fn current_run_queue<G: BaseGuard>() -> CurrentRunQueueRef<'static, G
 /// ## Panics
 ///
 /// This function will panic if `cpu_mask` is empty, indicating that there are no available CPUs for task execution.
-///
 #[cfg(feature = "smp")]
 // The modulo operation is safe here because `axconfig::plat::MAX_CPU_NUM` is always greater than 1 with "smp" enabled.
 #[allow(clippy::modulo_one)]
@@ -134,7 +131,6 @@ fn select_run_queue_index(cpumask: AxCpuMask) -> usize {
 /// ## Panics
 ///
 /// This function will panic if the index is out of bounds.
-///
 #[cfg(feature = "smp")]
 #[inline]
 fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
@@ -158,7 +154,6 @@ fn get_run_queue(index: usize) -> &'static mut AxRunQueue {
 ///
 /// 1. Implement better load balancing across CPUs for more efficient task distribution.
 /// 2. Use a more generic load balancing algorithm that can be customized or replaced.
-///
 #[inline]
 pub(crate) fn select_run_queue<G: BaseGuard>(task: &AxTaskRef) -> AxRunQueueRef<'static, G> {
     let irq_state = G::acquire();

--- a/modules/axtask/src/task.rs
+++ b/modules/axtask/src/task.rs
@@ -33,12 +33,12 @@ pub enum TaskState {
     /// Task is running on some CPU.
     Running = 1,
     /// Task is ready to run on some scheduler's ready queue.
-    Ready = 2,
+    Ready   = 2,
     /// Task is blocked (in the wait queue or timer list),
     /// and it has finished its scheduling process, it can be wake up by `notify()` on any run queue safely.
     Blocked = 3,
     /// Task is exited and waiting for being dropped.
-    Exited = 4,
+    Exited  = 4,
 }
 
 /// User-defined task extended data.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,16 @@
+unstable_features = true
+
+style_edition = "2024"
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+
+normalize_comments = true
+
+condense_wildcard_suffixes = true
+enum_discrim_align_threshold = 20
+use_field_init_shorthand = true
+
+format_strings = true
+format_code_in_doc_comments = true
+format_macro_matchers = true

--- a/ulib/axstd/src/io/stdio.rs
+++ b/ulib/axstd/src/io/stdio.rs
@@ -1,9 +1,12 @@
-use crate::io::{self, BufReader, prelude::*};
-use crate::sync::{Mutex, MutexGuard};
-use lazyinit::LazyInit;
-
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
+
+use lazyinit::LazyInit;
+
+use crate::{
+    io::{self, BufReader, prelude::*},
+    sync::{Mutex, MutexGuard},
+};
 
 struct StdinRaw;
 struct StdoutRaw;


### PR DESCRIPTION
In the first commit a rustfmt.toml is added to enforce code style. References:
- https://github.com/Starry-OS/StarryOS/blob/main/rustfmt.toml
- https://github.com/arceos-org/page_table_multiarch/blob/main/rustfmt.toml

In the second commit some clippy issues (not all) in axfs are fixed.