### PR TITLE
fix: example shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,20 @@ dependencies = [
  "enum_dispatch",
  "log",
  "paste",
+ "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "arm-gic-driver"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dda00d35b3c85f4e994746587c4579e63c0ba350b843fca96d6531b609292ae"
+dependencies = [
+ "aarch64-cpu 11.2.0",
+ "bitflags 2.11.0",
+ "enum_dispatch",
+ "log",
+ "paste",
  "rdif-intc",
  "tock-registers 0.10.1",
 ]
@@ -462,9 +476,10 @@ dependencies = [
  "axklib",
  "cfg-if",
  "crate_interface 0.1.4",
+ "dma-api 0.7.1",
  "log",
  "memory_addr",
- "rdif-block",
+ "rd-block",
  "rdrive",
  "smallvec",
  "spin 0.10.0",
@@ -644,15 +659,15 @@ dependencies = [
 
 [[package]]
 name = "axfs-ng-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0d501c182116576111dc04ba89f48fea639b7080e0455393be5dbc41cfacef"
+checksum = "75b3fc5c71051e9ae0b29700aa6eb676b7dadb91be3415d2b374cc8d2a2d37c6"
 dependencies = [
  "axerrno 0.2.2",
  "axpoll",
  "bitflags 2.11.0",
  "cfg-if",
- "hashbrown 0.15.5",
+ "hashbrown",
  "inherit-methods-macro",
  "log",
  "smallvec",
@@ -857,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f3819d30fa3a4038c0f9ab7e122c8b3ba840b323ee3fc19e4dbabe22b4e56ac"
 dependencies = [
  "aarch64-cpu 11.2.0",
- "arm-gic-driver",
+ "arm-gic-driver 0.16.4",
  "arm_pl011",
  "arm_pl031",
  "axcpu",
@@ -1680,6 +1695,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dma-api"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e9ce2657334f873c12845789d5a4f1b34bef91fe531437284b8387d77bd925"
+dependencies = [
+ "aarch64-cpu-ext",
+ "cfg-if",
+ "derive_more",
+ "log",
+ "mbarrier",
+ "spin 0.10.0",
+ "thiserror",
+]
+
+[[package]]
 name = "dw_apb_uart"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,12 +1871,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1973,24 +1997,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -2056,7 +2069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2323,7 +2336,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2505,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "pcie"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225c81c0f672afbdd95e55abebe56541870e64e350eba9f7eabfb392112229ab"
+checksum = "98b1339d53c73a04833791fa907b60ff074b95cae8db9f94f3173ed2b30b5b6c"
 dependencies = [
  "bare-test-macros",
  "bit_field",
@@ -2675,6 +2688,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rd-block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c20952f27dc5aaf853e8c00026ba7f2633e149ce47f9a58115704b342756307"
+dependencies = [
+ "dma-api 0.7.1",
+ "futures",
+ "rdif-block",
+ "spin_on",
+]
+
+[[package]]
 name = "rdif-base"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,16 +2713,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rdif-block"
-version = "0.6.2"
+name = "rdif-base"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ae1ba6c121eef2653dd2e0c88a209bb1d4d21e75e15cca71f19770ef327f81"
+checksum = "cda8c6ace8e0124ec777028cf86a56049f039c5d6f7a19b307a3f564b01ed858"
 dependencies = [
- "cfg-if",
- "dma-api",
- "futures",
- "rdif-base",
- "spin_on",
+ "as-any",
+ "async-trait",
+ "paste",
+ "rdif-def",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-block"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2a2573c1fb0af5daf596a32b9e10284f1fc018adfd0413e2213f35151ebff1"
+dependencies = [
+ "dma-api 0.7.1",
+ "rdif-base 0.8.0",
  "thiserror",
 ]
 
@@ -2712,22 +2747,22 @@ dependencies = [
 
 [[package]]
 name = "rdif-intc"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b79eba6783fb02dfb2a499a7f9da60b6c16b56c666b546d026e8fffc82c517"
+checksum = "25f3b9bf119dea83dcc7e4f0e2487d7635d373f55500bde982defa934dd17e9c"
 dependencies = [
  "cfg-if",
- "rdif-base",
+ "rdif-base 0.8.0",
 ]
 
 [[package]]
 name = "rdif-pcie"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60c6e8dea6d432b2c03bc3f4238dc59a276aacac6f688a937351e7a313918738"
+checksum = "e4ab8ecf37d86123500a1d99519424b7dcf2489c0df6b62b56af9f436224259f"
 dependencies = [
  "pci_types",
- "rdif-base",
+ "rdif-base 0.8.0",
  "thiserror",
 ]
 
@@ -2740,22 +2775,22 @@ dependencies = [
  "bitflags 2.11.0",
  "futures",
  "heapless 0.9.2",
- "rdif-base",
+ "rdif-base 0.7.0",
  "spin 0.10.0",
  "thiserror",
 ]
 
 [[package]]
 name = "rdrive"
-version = "0.18.11"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28163d9cd26a17d444424168fde0f5f6f8b867cffdc7de617c2d0865eecf156"
+checksum = "ab4f7c92af8670536001b449bf8d27c67c22ff5f2391dd76ca2da9b5c5343f40"
 dependencies = [
  "fdt-parser",
  "log",
  "paste",
  "pcie",
- "rdif-base",
+ "rdif-base 0.8.0",
  "rdif-pcie",
  "rdrive-macros",
  "spin 0.10.0",
@@ -3047,7 +3082,7 @@ checksum = "20ad586f110c679176859fe111f2c3dd176b95bbe731e9b4c3d1c6382cb301c9"
 dependencies = [
  "bare-test-macros",
  "bitflags 2.11.0",
- "dma-api",
+ "dma-api 0.5.2",
  "enum_dispatch",
  "heapless 0.9.2",
  "log",
@@ -3060,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "someboot"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d098355236a04942502f316661e06e8df92ac0e0db1c6c25922bab4b08e8317"
+checksum = "374257b9f5fdd9dadca39c3d1484d58e6760f6894bcb529e460814c30c8738aa"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64-cpu-ext",
@@ -3104,13 +3139,13 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ee11f1025589dfcf334ba3c5ee2094ad212ce614e8c630da559ceaca38e3"
+checksum = "0959f802461a5c3458a5eff143d0622f3710946b3c47129e20be257fb9648bb4"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "anyhow",
- "arm-gic-driver",
+ "arm-gic-driver 0.17.0",
  "kernutil",
  "log",
  "mmio-api",

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -43,9 +43,9 @@ dyn = [
     "dep:axerrno",
     "dep:axhal",
     "dep:axklib",
-    # "dep:dma-api",
     "dep:memory_addr",
-    "dep:rdif-block",
+    "dep:dma-api",
+    "dep:rd-block",
     "dep:rdrive",
     "dep:spin",
 ]
@@ -69,10 +69,10 @@ axhal = { workspace = true, optional = true }
 axklib = { workspace = true, optional = true }
 cfg-if.workspace = true
 crate_interface.workspace = true
-# dma-api = { version = "0.5", features = ["alloc"], optional = true }
+dma-api = { version = "0.7", optional = true }
 log.workspace = true
 memory_addr = { workspace = true, optional = true }
-rdif-block = { version = "0.6.2", optional = true }
-rdrive = { version = "0.18", optional = true }
+rd-block = { version = "0.1", optional = true }
+rdrive = { version = "0.19", optional = true }
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
 spin = { version = "0.10", optional = true }

--- a/modules/axdriver/src/dyn_drivers/blk/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/blk/mod.rs
@@ -1,15 +1,17 @@
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 use axdriver_block::BlockDriverOps;
-use rdif_block::BlkError;
+use rd_block::BlkError;
 use rdrive::Device;
 use spin::Mutex;
+
+use crate::dyn_drivers::DmaImpl;
 
 #[cfg(feature = "virtio-blk")]
 mod virtio;
 
 pub struct Block {
-    dev: Device<rdif_block::Block>,
-    queue: Mutex<rdif_block::CmdQueue>,
+    dev: Device<rd_block::Block>,
+    queue: Mutex<rd_block::CmdQueue>,
 }
 
 impl BaseDriverOps for Block {
@@ -60,8 +62,8 @@ impl BlockDriverOps for Block {
     }
 }
 
-impl From<Device<rdif_block::Block>> for Block {
-    fn from(base: Device<rdif_block::Block>) -> Self {
+impl From<Device<rd_block::Block>> for Block {
+    fn from(base: Device<rd_block::Block>) -> Self {
         let queue = base.lock().unwrap().create_queue().unwrap();
         Self {
             dev: base,
@@ -97,12 +99,12 @@ fn maping_dev_err_to_blk_err(err: DevError) -> BlkError {
 }
 
 pub trait PlatformDeviceBlock {
-    fn register_block<T: rdif_block::Interface>(self, dev: T);
+    fn register_block<T: rd_block::Interface>(self, dev: T);
 }
 
 impl PlatformDeviceBlock for rdrive::PlatformDevice {
-    fn register_block<T: rdif_block::Interface>(self, dev: T) {
-        let dev = rdif_block::Block::new(dev);
+    fn register_block<T: rd_block::Interface>(self, dev: T) {
+        let dev = rd_block::Block::new(dev, &DmaImpl);
         self.register(dev);
     }
 }

--- a/modules/axdriver/src/dyn_drivers/blk/virtio.rs
+++ b/modules/axdriver/src/dyn_drivers/blk/virtio.rs
@@ -73,17 +73,13 @@ struct BlockQueue {
 }
 
 impl DriverGeneric for BlockDivce {
-    fn open(&mut self) -> Result<(), rdrive::KError> {
-        Ok(())
-    }
-
-    fn close(&mut self) -> Result<(), rdrive::KError> {
-        Ok(())
+    fn name(&self) -> &str {
+        "virtio-blk"
     }
 }
 
-impl rdif_block::Interface for BlockDivce {
-    fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rdif_block::IQueue>> {
+impl rd_block::Interface for BlockDivce {
+    fn create_queue(&mut self) -> Option<alloc::boxed::Box<dyn rd_block::IQueue>> {
         self.dev
             .take()
             .map(|dev| alloc::boxed::Box::new(BlockQueue { raw: dev }) as _)
@@ -101,12 +97,12 @@ impl rdif_block::Interface for BlockDivce {
         false
     }
 
-    fn handle_irq(&mut self) -> rdif_block::Event {
-        rdif_block::Event::none()
+    fn handle_irq(&mut self) -> rd_block::Event {
+        rd_block::Event::none()
     }
 }
 
-impl rdif_block::IQueue for BlockQueue {
+impl rd_block::IQueue for BlockQueue {
     fn num_blocks(&self) -> usize {
         self.raw.num_blocks() as _
     }
@@ -119,8 +115,8 @@ impl rdif_block::IQueue for BlockQueue {
         0
     }
 
-    fn buff_config(&self) -> rdif_block::BuffConfig {
-        rdif_block::BuffConfig {
+    fn buff_config(&self) -> rd_block::BuffConfig {
+        rd_block::BuffConfig {
             dma_mask: u64::MAX,
             align: 0x1000,
             size: self.block_size(),
@@ -129,29 +125,26 @@ impl rdif_block::IQueue for BlockQueue {
 
     fn submit_request(
         &mut self,
-        request: rdif_block::Request<'_>,
-    ) -> Result<rdif_block::RequestId, rdif_block::BlkError> {
+        request: rd_block::Request<'_>,
+    ) -> Result<rd_block::RequestId, rd_block::BlkError> {
         let id = request.block_id;
         match request.kind {
-            rdif_block::RequestKind::Read(mut buffer) => {
+            rd_block::RequestKind::Read(mut buffer) => {
                 self.raw
                     .read_block(id as _, &mut buffer)
                     .map_err(maping_dev_err_to_blk_err)?;
-                Ok(rdif_block::RequestId::new(0))
+                Ok(rd_block::RequestId::new(0))
             }
-            rdif_block::RequestKind::Write(items) => {
+            rd_block::RequestKind::Write(items) => {
                 self.raw
                     .write_block(id as _, items)
                     .map_err(maping_dev_err_to_blk_err)?;
-                Ok(rdif_block::RequestId::new(0))
+                Ok(rd_block::RequestId::new(0))
             }
         }
     }
 
-    fn poll_request(
-        &mut self,
-        _request: rdif_block::RequestId,
-    ) -> Result<(), rdif_block::BlkError> {
+    fn poll_request(&mut self, _request: rd_block::RequestId) -> Result<(), rd_block::BlkError> {
         Ok(())
     }
 }

--- a/modules/axdriver/src/dyn_drivers/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/mod.rs
@@ -1,4 +1,7 @@
-use alloc::vec::Vec;
+use alloc::{
+    alloc::{alloc, alloc_zeroed, dealloc},
+    vec::Vec,
+};
 use core::ptr::NonNull;
 
 use axerrno::AxError;
@@ -27,7 +30,7 @@ pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
     let mut devices = Vec::new();
     #[cfg(feature = "block")]
     {
-        let ls = rdrive::get_list::<rdif_block::Block>();
+        let ls = rdrive::get_list::<rd_block::Block>();
         for dev in ls {
             devices.push(super::AxDeviceEnum::from_block(
                 crate::dyn_drivers::blk::Block::from(dev),
@@ -35,4 +38,117 @@ pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
         }
     }
     devices
+}
+
+pub(crate) struct DmaImpl;
+
+#[inline]
+fn dma_addr_from_ptr(ptr: NonNull<u8>) -> u64 {
+    axhal::mem::virt_to_phys((ptr.as_ptr() as usize).into()).as_usize() as u64
+}
+
+#[inline]
+fn dma_range_fits_mask(dma_addr: u64, size: usize, dma_mask: u64) -> bool {
+    if size == 0 {
+        dma_addr <= dma_mask
+    } else {
+        dma_addr
+            .checked_add(size.saturating_sub(1) as u64)
+            .map(|end| end <= dma_mask)
+            .unwrap_or(false)
+    }
+}
+
+#[inline]
+fn dma_addr_is_aligned(dma_addr: u64, align: usize) -> bool {
+    dma_addr.is_multiple_of(align as u64)
+}
+
+impl dma_api::DmaOp for DmaImpl {
+    fn page_size(&self) -> usize {
+        axhal::mem::PAGE_SIZE_4K
+    }
+
+    unsafe fn map_single(
+        &self,
+        dma_mask: u64,
+        addr: NonNull<u8>,
+        size: core::num::NonZeroUsize,
+        align: usize,
+        direction: dma_api::DmaDirection,
+    ) -> Result<dma_api::DmaMapHandle, dma_api::DmaError> {
+        let layout = core::alloc::Layout::from_size_align(size.get(), align)?;
+        let dma_addr = dma_addr_from_ptr(addr);
+
+        if dma_range_fits_mask(dma_addr, size.get(), dma_mask)
+            && dma_addr_is_aligned(dma_addr, align)
+        {
+            return Ok(unsafe { dma_api::DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
+        }
+
+        let map_ptr = unsafe { alloc(layout) };
+        let map_virt = NonNull::new(map_ptr).ok_or(dma_api::DmaError::NoMemory)?;
+
+        if matches!(
+            direction,
+            dma_api::DmaDirection::ToDevice | dma_api::DmaDirection::Bidirectional
+        ) {
+            unsafe {
+                map_virt
+                    .as_ptr()
+                    .copy_from_nonoverlapping(addr.as_ptr(), size.get());
+            }
+        }
+
+        let map_dma_addr = dma_addr_from_ptr(map_virt);
+        if !dma_range_fits_mask(map_dma_addr, size.get(), dma_mask) {
+            unsafe { dealloc(map_virt.as_ptr(), layout) };
+            return Err(dma_api::DmaError::DmaMaskNotMatch {
+                addr: map_dma_addr.into(),
+                mask: dma_mask,
+            });
+        }
+        if !dma_addr_is_aligned(map_dma_addr, align) {
+            unsafe { dealloc(map_virt.as_ptr(), layout) };
+            return Err(dma_api::DmaError::AlignMismatch {
+                required: align,
+                address: map_dma_addr.into(),
+            });
+        }
+
+        Ok(
+            unsafe {
+                dma_api::DmaMapHandle::new(addr, map_dma_addr.into(), layout, Some(map_virt))
+            },
+        )
+    }
+
+    unsafe fn unmap_single(&self, handle: dma_api::DmaMapHandle) {
+        if let Some(map_virt) = handle.alloc_virt() {
+            unsafe { dealloc(map_virt.as_ptr(), handle.layout()) };
+        }
+    }
+
+    unsafe fn alloc_coherent(
+        &self,
+        dma_mask: u64,
+        layout: core::alloc::Layout,
+    ) -> Option<dma_api::DmaHandle> {
+        let ptr = unsafe { alloc_zeroed(layout) };
+        let cpu_addr = NonNull::new(ptr)?;
+
+        let dma_addr = dma_addr_from_ptr(cpu_addr);
+        if !dma_range_fits_mask(dma_addr, layout.size(), dma_mask)
+            || !dma_addr_is_aligned(dma_addr, layout.align())
+        {
+            unsafe { dealloc(cpu_addr.as_ptr(), layout) };
+            return None;
+        }
+
+        Some(unsafe { dma_api::DmaHandle::new(cpu_addr, dma_addr.into(), layout) })
+    }
+
+    unsafe fn dealloc_coherent(&self, handle: dma_api::DmaHandle) {
+        unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+    }
 }

--- a/modules/axplat-dyn/Cargo.toml
+++ b/modules/axplat-dyn/Cargo.toml
@@ -22,7 +22,7 @@ heapless = "0.9"
 spin = "0.10"
 anyhow = { version = "1", default-features = false }
 axplat.workspace = true
-somehal = "0.5"
+somehal = "0.6"
 log.workspace = true
 axconfig-macros = "0.2"
 percpu = { workspace = true, features = ["custom-base"] }

--- a/modules/axplat-dyn/src/console.rs
+++ b/modules/axplat-dyn/src/console.rs
@@ -25,18 +25,17 @@ impl ConsoleIf for ConsoleIfImpl {
     /// Reads bytes from the console into the given mutable slice.
     ///
     /// Returns the number of bytes read.
-    fn read_bytes(_bytes: &mut [u8]) -> usize {
-        todo!()
-        // let mut read_len = 0;
-        // while read_len < bytes.len() {
-        //     if let Some(c) = somehal::console::getchar() {
-        //         bytes[read_len] = c;
-        //     } else {
-        //         break;
-        //     }
-        //     read_len += 1;
-        // }
-        // read_len
+    fn read_bytes(bytes: &mut [u8]) -> usize {
+        let mut read_len = 0;
+        while read_len < bytes.len() {
+            if let Some(c) = somehal::console::read_byte() {
+                bytes[read_len] = c;
+            } else {
+                break;
+            }
+            read_len += 1;
+        }
+        read_len
     }
 
     /// Returns the IRQ number for the console input interrupt.


### PR DESCRIPTION
This pull request introduces several significant updates to the `axdriver` and `axplat-dyn` modules, focusing on updating dependencies, refactoring block device driver code to use new interfaces, and implementing a DMA abstraction. The changes modernize the codebase by adopting newer crate versions and interfaces, and by adding a platform-specific DMA implementation for improved memory operations.

Dependency and Interface Updates:
- Updated dependencies in `modules/axdriver/Cargo.toml` to use `rd-block` (v0.1) and `rdrive` (v0.19) instead of the older `rdif-block` and `rdrive` versions. Also enabled and configured the `dma-api` crate (v0.7). [[1]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L46-R48) [[2]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L72-R76)
- Updated `modules/axplat-dyn/Cargo.toml` to use `somehal` version 0.6.

Block Device Driver Refactor:
- Refactored all usages of `rdif_block` to `rd_block` in `modules/axdriver/src/dyn_drivers/blk/mod.rs` and `virtio.rs`, updating trait bounds, struct fields, and method implementations accordingly. [[1]](diffhunk://#diff-4370a091199e1150b6b11adefa6c7fecc052c95ae1024acb253d042e493e2c01L3-R14) [[2]](diffhunk://#diff-4370a091199e1150b6b11adefa6c7fecc052c95ae1024acb253d042e493e2c01L63-R66) [[3]](diffhunk://#diff-4370a091199e1150b6b11adefa6c7fecc052c95ae1024acb253d042e493e2c01L100-R107) [[4]](diffhunk://#diff-eeb727daf95bc10ecd0a57e5922221cc260f4544e71bb2e8bcea89190ed5d3edL76-R82) [[5]](diffhunk://#diff-eeb727daf95bc10ecd0a57e5922221cc260f4544e71bb2e8bcea89190ed5d3edL104-R105) [[6]](diffhunk://#diff-eeb727daf95bc10ecd0a57e5922221cc260f4544e71bb2e8bcea89190ed5d3edL122-R119) [[7]](diffhunk://#diff-eeb727daf95bc10ecd0a57e5922221cc260f4544e71bb2e8bcea89190ed5d3edL132-R147)
- Updated device probing logic to use the new block interface.

DMA Abstraction Implementation:
- Introduced a new `DmaImpl` struct in `modules/axdriver/src/dyn_drivers/mod.rs` that implements the `dma_api::DmaOp` trait, providing platform-specific DMA memory mapping, allocation, and deallocation logic.

Console Implementation Fix:
- Implemented the `read_bytes` method in `modules/axplat-dyn/src/console.rs`, replacing the previous `todo!()` with working logic using `somehal::console::read_byte()`.