### PR TITLE
fix(axtask): fix IRQ waker race conditions in register_irq_waker and block_on

### DIFF
--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -10,7 +10,7 @@ use crate::{AxDeviceEnum, drivers::DriverProbe};
 
 cfg_if! {
     if #[cfg(bus = "pci")] {
-        use axdriver_pci::{Cam, DeviceFunction, DeviceFunctionInfo, PciConfigAccess, PciRoot};
+        use axdriver_pci::{PciRoot, DeviceFunction, DeviceFunctionInfo};
         type VirtIoTransport = axdriver_virtio::PciTransport;
     } else if #[cfg(bus =  "mmio")] {
         type VirtIoTransport = axdriver_virtio::MmioTransport;
@@ -135,9 +135,6 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         bdf: DeviceFunction,
         dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {
-        let base_vaddr = phys_to_virt(axconfig::devices::PCI_ECAM_BASE.into());
-        let mut config = unsafe { PciConfigAccess::new(base_vaddr.as_mut_ptr(), Cam::Ecam) };
-
         if dev_info.vendor_id != 0x1af4 {
             return None;
         }
@@ -151,7 +148,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         }
 
         if let Some((ty, transport, irq)) =
-            axdriver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info, &mut config)
+            axdriver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info)
             && ty == D::DEVICE_TYPE
         {
             match D::try_new(transport, Some(irq)) {

--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -10,7 +10,7 @@ use crate::{AxDeviceEnum, drivers::DriverProbe};
 
 cfg_if! {
     if #[cfg(bus = "pci")] {
-        use axdriver_pci::{PciRoot, DeviceFunction, DeviceFunctionInfo};
+        use axdriver_pci::{Cam, DeviceFunction, DeviceFunctionInfo, PciConfigAccess, PciRoot};
         type VirtIoTransport = axdriver_virtio::PciTransport;
     } else if #[cfg(bus =  "mmio")] {
         type VirtIoTransport = axdriver_virtio::MmioTransport;
@@ -135,6 +135,9 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         bdf: DeviceFunction,
         dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {
+        let base_vaddr = phys_to_virt(axconfig::devices::PCI_ECAM_BASE.into());
+        let mut config = unsafe { PciConfigAccess::new(base_vaddr.as_mut_ptr(), Cam::Ecam) };
+
         if dev_info.vendor_id != 0x1af4 {
             return None;
         }
@@ -148,7 +151,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         }
 
         if let Some((ty, transport, irq)) =
-            axdriver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info)
+            axdriver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info, &mut config)
             && ty == D::DEVICE_TYPE
         {
             match D::try_new(transport, Some(irq)) {

--- a/modules/axhal/src/irq.rs
+++ b/modules/axhal/src/irq.rs
@@ -21,8 +21,8 @@ pub fn register_irq_hook(hook: fn(usize)) -> bool {
         .compare_exchange(
             0,
             hook as *const () as usize,
-            Ordering::SeqCst,
-            Ordering::SeqCst,
+            Ordering::Release,
+            Ordering::Relaxed,
         )
         .is_ok()
 }
@@ -37,7 +37,7 @@ pub fn irq_handler(vector: usize) -> bool {
     let guard = kernel_guard::NoPreempt::new();
 
     if let Some(irq) = handle(vector) {
-        let hook = IRQ_HOOK.load(Ordering::SeqCst);
+        let hook = IRQ_HOOK.load(Ordering::Acquire);
         if hook != 0 {
             let hook = unsafe { core::mem::transmute::<usize, fn(usize)>(hook) };
             hook(irq);

--- a/modules/axtask/src/future/mod.rs
+++ b/modules/axtask/src/future/mod.rs
@@ -70,11 +70,20 @@ pub fn block_on<F: IntoFuture>(f: F) -> F::Output {
         match fut.as_mut().poll(&mut cx) {
             Poll::Pending => {
                 let mut rq = current_run_queue::<NoPreemptIrqSave>();
-                let woke = woke.lock();
+                let mut woke = axwaker.woke.lock();
                 if !*woke {
+                    // blocked_resched() will set *woke = false and drop
+                    // the guard internally before rescheduling. When this
+                    // task is woken, woke will be set to true by the waker
+                    // and we'll re-enter the loop to poll again.
                     rq.blocked_resched(woke);
                 } else {
-                    // Immediately woken
+                    // ③ woke = true: waker fired between poll() returning
+                    // Pending and us acquiring the lock.
+                    // Clear under the current lock hold, then drop.
+                    // If an interrupt sets woke=true after drop(), the next
+                    // loop iteration will see it correctly.
+                    *woke = false;
                     drop(woke);
                     crate::yield_now();
                 }

--- a/modules/axtask/src/future/mod.rs
+++ b/modules/axtask/src/future/mod.rs
@@ -60,13 +60,11 @@ pub fn block_on<F: IntoFuture>(f: F) -> F::Output {
     // to prevent it from being dropped while blocking.
     let task = curr.clone();
 
-    let waker = AxWaker::new(&task);
-    let woke = &waker.woke;
-    let waker = Waker::from(waker.clone());
+    let axwaker = AxWaker::new(&task);
+    let waker = Waker::from(axwaker.clone());
     let mut cx = Context::from_waker(&waker);
 
     loop {
-        *woke.lock() = false;
         match fut.as_mut().poll(&mut cx) {
             Poll::Pending => {
                 let mut rq = current_run_queue::<NoPreemptIrqSave>();

--- a/modules/axtask/src/future/poll.rs
+++ b/modules/axtask/src/future/poll.rs
@@ -57,9 +57,5 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
 
     POLL_IRQ.lock().entry(irq).or_default().register(waker);
 
-    // With MSI-X (edge-triggered), enabling the IRQ here is safe: an
-    // edge-triggered interrupt fires once per assertion and does not re-fire
-    // while the line is held. There is no risk of a spurious wakeup loop
-    // during the poll phase.
     axhal::irq::set_enable(irq, true);
 }

--- a/modules/axtask/src/future/poll.rs
+++ b/modules/axtask/src/future/poll.rs
@@ -57,10 +57,15 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
     match POLL_IRQ.lock().entry(irq) {
         Entry::Vacant(e) => {
             axhal::irq::register_irq_hook(irq_hook);
-            axhal::irq::set_enable(irq, true);
             e.insert(PollSet::new())
         }
         Entry::Occupied(e) => e.into_mut(),
     }
     .register(waker);
+
+    // With MSI-X (edge-triggered), enabling the IRQ here is safe: an
+    // edge-triggered interrupt fires once per assertion and does not re-fire
+    // while the line is held. There is no risk of a spurious wakeup loop
+    // during the poll phase.
+    axhal::irq::set_enable(irq, true);
 }

--- a/modules/axtask/src/future/poll.rs
+++ b/modules/axtask/src/future/poll.rs
@@ -41,7 +41,7 @@ pub async fn poll_io<P: Pollable, F: FnMut() -> AxResult<T>, T>(
 #[cfg(feature = "irq")]
 /// Registers a waker for the given IRQ number.
 pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
-    use alloc::collections::{BTreeMap, btree_map::Entry};
+    use alloc::collections::BTreeMap;
 
     use axpoll::PollSet;
     use kspin::SpinNoIrq;
@@ -53,15 +53,9 @@ pub fn register_irq_waker(irq: usize, waker: &core::task::Waker) {
             s.wake();
         }
     }
+    axhal::irq::register_irq_hook(irq_hook);
 
-    match POLL_IRQ.lock().entry(irq) {
-        Entry::Vacant(e) => {
-            axhal::irq::register_irq_hook(irq_hook);
-            e.insert(PollSet::new())
-        }
-        Entry::Occupied(e) => e.into_mut(),
-    }
-    .register(waker);
+    POLL_IRQ.lock().entry(irq).or_default().register(waker);
 
     // With MSI-X (edge-triggered), enabling the IRQ here is safe: an
     // edge-triggered interrupt fires once per assertion and does not re-fire


### PR DESCRIPTION
### Related Issue

https://github.com/Starry-OS/StarryOS/issues/129

On x86_64, a host-side TCP client could not complete a TCP echo exchange with a server running inside the system. The server never reported an accepted connection, the client blocked indefinitely, and the server could not be terminated with `Ctrl+C`. See the issue for full reproduction steps.

### Root Cause

Two race conditions in the async IRQ waker infrastructure caused wake signals
to be silently dropped, leaving async tasks permanently blocked on network I/O:

**Race 1 — `register_irq_waker`: IRQ fires before waker is registered**

`enable(irq, true)` was called inside the `Vacant` branch, before
`register(waker)`. If a level-triggered IRQ fired in that window, `irq_hook`
would find an empty `PollSet`, the wake signal would be lost, and `dispatch_irq`
would mask the IRQ line. No further interrupts would arrive, so the waiting task
could never be woken.

**Race 2 — `block_on`: missing woke flag reset causes CPU busy-loop**

In the race path where an IRQ fires between `poll()→Pending` and the `woke`
lock acquisition, the code skipped `blocked_resched` and called `yield_now()`
instead — but without resetting `woke` to `false`. Every subsequent
`poll()→Pending` iteration would again see `woke=true` and keep spinning,
consuming 100% CPU and never allowing the task to sleep and be properly woken.

### Changes

- **`register_irq_waker`**: move `enable(irq, true)` to after `register(waker)`,
  and hoist it outside the `Vacant` branch so every call re-enables (unmasks)
  the IRQ line. This ensures the waker is always registered before any interrupt
  can arrive, and correctly recovers from a masked level-triggered IRQ on
  re-registration.

- **`block_on`**: reset `*kwaker.woke.lock() = false` before `yield_now()` in
  the race path. This consumes the wake signal so that if `poll()` returns
  `Pending` again in the next iteration, the task correctly enters
  `blocked_resched` and sleeps instead of spinning.

### Notes

This PR addresses the IRQ waker race conditions and partially restores correct
async network I/O behavior on x86_64. The TCP echo test issue is not yet fully
resolved — follow-up PRs will address remaining problems.