### PR TITLE
refactor: all dyn related moves into axplat-dyn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,16 +483,11 @@ dependencies = [
  "axdriver_vsock",
  "axerrno 0.2.2",
  "axhal",
- "axklib",
+ "axplat-dyn",
  "cfg-if",
  "crate_interface 0.1.4",
- "dma-api 0.7.1",
  "log",
- "memory_addr",
- "rd-block",
- "rdrive",
  "smallvec",
- "spin 0.10.0",
 ]
 
 [[package]]
@@ -789,8 +784,6 @@ dependencies = [
 [[package]]
 name = "axklib"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bf328ee0dd583179ce7108584ec69da10e06bd4beb4d6acac7f6cb33754dab"
 dependencies = [
  "axerrno 0.2.2",
  "memory_addr",
@@ -979,14 +972,22 @@ name = "axplat-dyn"
 version = "0.3.0-preview.2"
 dependencies = [
  "anyhow",
+ "axalloc",
  "axconfig-macros",
  "axcpu",
+ "axdriver_base",
+ "axdriver_block",
+ "axdriver_virtio",
  "axerrno 0.2.2",
  "axklib",
  "axplat",
+ "dma-api 0.7.1",
  "heapless 0.9.2",
  "log",
+ "memory_addr",
  "percpu",
+ "rd-block",
+ "rdrive",
  "somehal",
  "spin 0.10.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "acpi"
-version = "6.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccf6d4e668d9babca9103f59f305d3bc55e24355cf166dbddf5a7a5e1243d06"
+checksum = "b763acdc1d85c36d61acf97a59938f23202d0e8efe45e8759de10c02db242744"
 dependencies = [
  "bit_field",
  "bitflags 2.11.0",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
 dependencies = [
  "cpp_demangle",
  "gimli",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "axbacktrace"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9566516f5d799b2f791a6ec5af57eec87d17624346f7c876fa006b922c99e6"
+checksum = "1ed127f24c722b06d19c9c1ff73907905bbc2f9463dfd7440652f3f0d6617a93"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -784,6 +784,8 @@ dependencies = [
 [[package]]
 name = "axklib"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03bf328ee0dd583179ce7108584ec69da10e06bd4beb4d6acac7f6cb33754dab"
 dependencies = [
  "axerrno 0.2.2",
  "memory_addr",
@@ -982,6 +984,7 @@ dependencies = [
  "axklib",
  "axplat",
  "dma-api 0.7.1",
+ "fdt-edit",
  "heapless 0.9.2",
  "log",
  "memory_addr",
@@ -1492,9 +1495,9 @@ checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -1857,12 +1860,12 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdt-edit"
-version = "0.1.5"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0f564fda6b9389cec0b258a98483b974b6ed37cf4e771222fb49cabe1e260f"
+checksum = "bda8ff88f0dd8770b247b17d9e0faf293c52cb5733e2500294ffa93ac1f0b384"
 dependencies = [
  "enum_dispatch",
- "fdt-raw 0.1.5",
+ "fdt-raw",
  "log",
 ]
 
@@ -1874,20 +1877,9 @@ checksum = "1f95f0bda5ff920492f6573294d8e3a99b75ee2e5ef93ab313fc6d517fa46785"
 
 [[package]]
 name = "fdt-raw"
-version = "0.1.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7b19f67663e8368d5a07165a1c348b5a761afe5d130e982a0ed8859aca37c2"
-dependencies = [
- "heapless 0.9.2",
- "log",
- "thiserror",
-]
-
-[[package]]
-name = "fdt-raw"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce2d6b3100c219add1cf704f0996cd45003fee5f1a2567397625c62cb7688f4"
+checksum = "91e6747052012035c3473585be1d706207893d8db73101825d8a3f75effa9843"
 dependencies = [
  "heapless 0.9.2",
  "log",
@@ -2013,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -2281,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -2541,14 +2533,14 @@ dependencies = [
 
 [[package]]
 name = "pcie"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b1339d53c73a04833791fa907b60ff074b95cae8db9f94f3173ed2b30b5b6c"
+checksum = "f8b092a434cb4a9dff1321bc486f0d324ce2425f217eb1fe43d34b1d21b03294"
 dependencies = [
- "bare-test-macros",
  "bit_field",
  "bitflags 2.11.0",
  "log",
+ "mmio-api",
  "pci_types",
  "rdif-pcie",
  "thiserror",
@@ -2761,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "rdif-def"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb161fd5654843a0fc86866f3342f41622a589ecf4ebb33ec313a593fd235b4"
+checksum = "1e44a12e44c2f439be06af72a3e03d4e57f6c79211a68058158a02670e63853c"
 dependencies = [
  "thiserror",
 ]
@@ -2805,12 +2797,14 @@ dependencies = [
 
 [[package]]
 name = "rdrive"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07b25da4361480c3ac22159f6b71ee712c4b6b3c82cb3fd20ad9b2fbe2a1d2e"
+checksum = "e9bdca8365115779b803244844c4db3c8e2ae3355edbdb5ce6547de540b29dd2"
 dependencies = [
- "fdt-parser",
+ "fdt-edit",
+ "fdt-raw",
  "log",
+ "mmio-api",
  "paste",
  "pcie",
  "rdif-base 0.8.0",
@@ -3108,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "someboot"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca7da37e97c79fade1f8ee0ee1a186881cbc2364cb17593ad76cbe68545da9"
+checksum = "9afbf93ac5c9501d93d1496f58ff089ac3aa02648adedad5777a767bcfd448ad"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "aarch64-cpu-ext",
@@ -3126,7 +3120,7 @@ dependencies = [
  "byteorder",
  "derive_more",
  "fdt-edit",
- "fdt-raw 0.2.0",
+ "fdt-raw",
  "heapless 0.9.2",
  "kasm-aarch64",
  "kernutil",
@@ -3152,9 +3146,9 @@ dependencies = [
 
 [[package]]
 name = "somehal"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14ce6607060f05f2b4f1a9bad3bd990169a32daba5a74424f894bef530a6987"
+checksum = "df2e441db2f693b803ee5fdf85b89bcc1830c83ae483406d4f0bb74cf90473a6"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "anyhow",
@@ -3167,15 +3161,16 @@ dependencies = [
  "rdrive",
  "someboot",
  "somehal-macros",
+ "spin 0.10.0",
  "thiserror",
  "tock-registers 0.10.1",
 ]
 
 [[package]]
 name = "somehal-macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cc4ec03fa0bf03efcaf2b829371f3e08862df67be679009ff2ba6e87a3a7b8"
+checksum = "0e26764471ab7fe1c7cafcc1505b61ed59a3e9d55d4aa4a3d42648f0d4638d78"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/modules/axdriver/Cargo.toml
+++ b/modules/axdriver/Cargo.toml
@@ -38,16 +38,7 @@ fxmac = ["net", "axdriver_net/fxmac", "dep:axalloc", "dep:axhal", "dep:axdma"]
 # more devices example: e1000 = ["net", "axdriver_net/e1000"]
 
 irq = []
-dyn = [
-    "dep:axerrno",
-    "dep:axhal",
-    "dep:axklib",
-    "dep:memory_addr",
-    "dep:dma-api",
-    "dep:rd-block",
-    "dep:rdrive",
-    "dep:spin",
-]
+dyn = ["dep:axerrno", "dep:axplat-dyn"]
 
 default = ["bus-pci"]
 
@@ -65,13 +56,8 @@ axdriver_virtio = { workspace = true, optional = true }
 axdriver_vsock = { workspace = true, optional = true }
 axerrno = { workspace = true, optional = true }
 axhal = { workspace = true, optional = true }
-axklib = { workspace = true, optional = true }
 cfg-if.workspace = true
 crate_interface.workspace = true
-dma-api = { version = "0.7", optional = true }
 log.workspace = true
-memory_addr = { workspace = true, optional = true }
-rd-block = { version = "0.1", optional = true }
-rdrive = { version = "0.19", optional = true }
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
-spin = { version = "0.10", optional = true }
+axplat-dyn = { workspace = true, optional = true }

--- a/modules/axdriver/src/dyn_drivers/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/mod.rs
@@ -1,18 +1,23 @@
 use alloc::vec::Vec;
 
 pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
-    if let Err(err) = axplat_dyn::drivers::probe_all_devices() {
-        error!("failed to probe dynamic platform devices: {err:?}");
-        return Vec::new();
+    #[cfg(target_os = "none")]
+    {
+        if let Err(err) = axplat_dyn::drivers::probe_all_devices() {
+            error!("failed to probe dynamic platform devices: {err:?}");
+            return Vec::new();
+        }
+
+        #[allow(unused_mut)]
+        let mut devices = Vec::new();
+
+        #[cfg(feature = "block")]
+        for dev in axplat_dyn::drivers::take_block_devices() {
+            devices.push(super::AxDeviceEnum::Block(dev));
+        }
+
+        devices
     }
-
-    #[allow(unused_mut)]
-    let mut devices = Vec::new();
-
-    #[cfg(feature = "block")]
-    for dev in axplat_dyn::drivers::take_block_devices() {
-        devices.push(super::AxDeviceEnum::Block(dev));
-    }
-
-    devices
+    #[cfg(not(target_os = "none"))]
+    Vec::new()
 }

--- a/modules/axdriver/src/dyn_drivers/mod.rs
+++ b/modules/axdriver/src/dyn_drivers/mod.rs
@@ -1,154 +1,18 @@
-use alloc::{
-    alloc::{alloc, alloc_zeroed, dealloc},
-    vec::Vec,
-};
-use core::ptr::NonNull;
-
-use axerrno::AxError;
-use axhal::mem::PhysAddr;
-use rdrive::probe::OnProbeError;
-
-mod pci;
-
-#[cfg(feature = "block")]
-pub mod blk;
-
-#[allow(dead_code)]
-/// maps a mmio physical address to a virtual address.
-fn iomap(addr: PhysAddr, size: usize) -> Result<NonNull<u8>, OnProbeError> {
-    axklib::mem::iomap(addr, size)
-        .map_err(|e| match e {
-            AxError::NoMemory => OnProbeError::KError(rdrive::KError::NoMem),
-            _ => OnProbeError::Other(alloc::format!("{e:?}").into()),
-        })
-        .map(|v| unsafe { NonNull::new_unchecked(v.as_mut_ptr()) })
-}
+use alloc::vec::Vec;
 
 pub fn probe_all_devices() -> Vec<super::AxDeviceEnum> {
-    rdrive::probe_all(true).unwrap();
+    if let Err(err) = axplat_dyn::drivers::probe_all_devices() {
+        error!("failed to probe dynamic platform devices: {err:?}");
+        return Vec::new();
+    }
+
     #[allow(unused_mut)]
     let mut devices = Vec::new();
+
     #[cfg(feature = "block")]
-    {
-        let ls = rdrive::get_list::<rd_block::Block>();
-        for dev in ls {
-            devices.push(super::AxDeviceEnum::from_block(
-                crate::dyn_drivers::blk::Block::from(dev),
-            ));
-        }
+    for dev in axplat_dyn::drivers::take_block_devices() {
+        devices.push(super::AxDeviceEnum::Block(dev));
     }
+
     devices
-}
-
-pub(crate) struct DmaImpl;
-
-#[inline]
-fn dma_addr_from_ptr(ptr: NonNull<u8>) -> u64 {
-    axhal::mem::virt_to_phys((ptr.as_ptr() as usize).into()).as_usize() as u64
-}
-
-#[inline]
-fn dma_range_fits_mask(dma_addr: u64, size: usize, dma_mask: u64) -> bool {
-    if size == 0 {
-        dma_addr <= dma_mask
-    } else {
-        dma_addr
-            .checked_add(size.saturating_sub(1) as u64)
-            .map(|end| end <= dma_mask)
-            .unwrap_or(false)
-    }
-}
-
-#[inline]
-fn dma_addr_is_aligned(dma_addr: u64, align: usize) -> bool {
-    dma_addr.is_multiple_of(align as u64)
-}
-
-impl dma_api::DmaOp for DmaImpl {
-    fn page_size(&self) -> usize {
-        axhal::mem::PAGE_SIZE_4K
-    }
-
-    unsafe fn map_single(
-        &self,
-        dma_mask: u64,
-        addr: NonNull<u8>,
-        size: core::num::NonZeroUsize,
-        align: usize,
-        direction: dma_api::DmaDirection,
-    ) -> Result<dma_api::DmaMapHandle, dma_api::DmaError> {
-        let layout = core::alloc::Layout::from_size_align(size.get(), align)?;
-        let dma_addr = dma_addr_from_ptr(addr);
-
-        if dma_range_fits_mask(dma_addr, size.get(), dma_mask)
-            && dma_addr_is_aligned(dma_addr, align)
-        {
-            return Ok(unsafe { dma_api::DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
-        }
-
-        let map_ptr = unsafe { alloc(layout) };
-        let map_virt = NonNull::new(map_ptr).ok_or(dma_api::DmaError::NoMemory)?;
-
-        if matches!(
-            direction,
-            dma_api::DmaDirection::ToDevice | dma_api::DmaDirection::Bidirectional
-        ) {
-            unsafe {
-                map_virt
-                    .as_ptr()
-                    .copy_from_nonoverlapping(addr.as_ptr(), size.get());
-            }
-        }
-
-        let map_dma_addr = dma_addr_from_ptr(map_virt);
-        if !dma_range_fits_mask(map_dma_addr, size.get(), dma_mask) {
-            unsafe { dealloc(map_virt.as_ptr(), layout) };
-            return Err(dma_api::DmaError::DmaMaskNotMatch {
-                addr: map_dma_addr.into(),
-                mask: dma_mask,
-            });
-        }
-        if !dma_addr_is_aligned(map_dma_addr, align) {
-            unsafe { dealloc(map_virt.as_ptr(), layout) };
-            return Err(dma_api::DmaError::AlignMismatch {
-                required: align,
-                address: map_dma_addr.into(),
-            });
-        }
-
-        Ok(
-            unsafe {
-                dma_api::DmaMapHandle::new(addr, map_dma_addr.into(), layout, Some(map_virt))
-            },
-        )
-    }
-
-    unsafe fn unmap_single(&self, handle: dma_api::DmaMapHandle) {
-        if let Some(map_virt) = handle.alloc_virt() {
-            unsafe { dealloc(map_virt.as_ptr(), handle.layout()) };
-        }
-    }
-
-    unsafe fn alloc_coherent(
-        &self,
-        dma_mask: u64,
-        layout: core::alloc::Layout,
-    ) -> Option<dma_api::DmaHandle> {
-        let ptr = unsafe { alloc_zeroed(layout) };
-        let cpu_addr = NonNull::new(ptr)?;
-
-        let dma_addr = dma_addr_from_ptr(cpu_addr);
-        if !dma_range_fits_mask(dma_addr, layout.size(), dma_mask)
-            || !dma_addr_is_aligned(dma_addr, layout.align())
-        {
-            unsafe { dealloc(cpu_addr.as_ptr(), layout) };
-            return None;
-        }
-
-        Some(unsafe { dma_api::DmaHandle::new(cpu_addr, dma_addr.into(), layout) })
-    }
-
-    unsafe fn dealloc_coherent(&self, handle: dma_api::DmaHandle) {
-        unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
-    }
 }

--- a/modules/axplat-dyn/Cargo.toml
+++ b/modules/axplat-dyn/Cargo.toml
@@ -18,13 +18,21 @@ hv = ["somehal/hv", "axcpu/arm-el2"]
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
+axalloc.workspace = true
 axconfig-macros = "0.2"
 axcpu.workspace = true
+axdriver_base.workspace = true
+axdriver_block.workspace = true
+axdriver_virtio = { workspace = true, features = ["block"] }
 axerrno.workspace = true
 axklib.workspace = true
 axplat.workspace = true
+dma-api = "0.7"
 heapless = "0.9"
 log.workspace = true
+memory_addr.workspace = true
 percpu = { workspace = true, features = ["custom-base"] }
+rd-block = "0.1"
+rdrive = "0.19"
 somehal = "0.6"
 spin = "0.10"

--- a/modules/axplat-dyn/Cargo.toml
+++ b/modules/axplat-dyn/Cargo.toml
@@ -28,11 +28,12 @@ axerrno.workspace = true
 axklib.workspace = true
 axplat.workspace = true
 dma-api = "0.7"
+fdt-edit = "0.2"
 heapless = "0.9"
 log.workspace = true
 memory_addr.workspace = true
 percpu = { workspace = true, features = ["custom-base"] }
 rd-block = "0.1"
-rdrive = "0.19"
+rdrive = "0.20"
 somehal = "0.6"
 spin = "0.10"

--- a/modules/axplat-dyn/src/drivers/blk/mod.rs
+++ b/modules/axplat-dyn/src/drivers/blk/mod.rs
@@ -4,9 +4,8 @@ use rd_block::BlkError;
 use rdrive::Device;
 use spin::Mutex;
 
-use crate::dyn_drivers::DmaImpl;
+use super::DmaImpl;
 
-#[cfg(feature = "virtio-blk")]
 mod virtio;
 
 pub struct Block {
@@ -72,6 +71,17 @@ impl From<Device<rd_block::Block>> for Block {
     }
 }
 
+pub trait PlatformDeviceBlock {
+    fn register_block<T: rd_block::Interface>(self, dev: T);
+}
+
+impl PlatformDeviceBlock for rdrive::PlatformDevice {
+    fn register_block<T: rd_block::Interface>(self, dev: T) {
+        let dev = rd_block::Block::new(dev, &DmaImpl);
+        self.register(dev);
+    }
+}
+
 fn maping_blk_err_to_dev_err(err: BlkError) -> DevError {
     match err {
         BlkError::NotSupported => DevError::Unsupported,
@@ -82,29 +92,5 @@ fn maping_blk_err_to_dev_err(err: BlkError) -> DevError {
             error!("Block device error: {error}");
             DevError::Io
         }
-    }
-}
-
-fn maping_dev_err_to_blk_err(err: DevError) -> BlkError {
-    match err {
-        DevError::Again => BlkError::Retry,
-        DevError::AlreadyExists => BlkError::Other("Already exists".into()),
-        DevError::BadState => BlkError::Other("Bad internal state".into()),
-        DevError::InvalidParam => BlkError::Other("Invalid parameter".into()),
-        DevError::Io => BlkError::Other("I/O error".into()),
-        DevError::NoMemory => BlkError::NoMemory,
-        DevError::ResourceBusy => BlkError::Other("Resource busy".into()),
-        DevError::Unsupported => BlkError::NotSupported,
-    }
-}
-
-pub trait PlatformDeviceBlock {
-    fn register_block<T: rd_block::Interface>(self, dev: T);
-}
-
-impl PlatformDeviceBlock for rdrive::PlatformDevice {
-    fn register_block<T: rd_block::Interface>(self, dev: T) {
-        let dev = rd_block::Block::new(dev, &DmaImpl);
-        self.register(dev);
     }
 }

--- a/modules/axplat-dyn/src/drivers/blk/virtio.rs
+++ b/modules/axplat-dyn/src/drivers/blk/virtio.rs
@@ -7,7 +7,7 @@ use axalloc::{UsageKind, global_allocator};
 use axdriver_base::DeviceType;
 use axdriver_block::BlockDriverOps;
 use axdriver_virtio::{BufferDirection, MmioTransport, PhysAddr as VirtIoPhysAddr, VirtIoHal};
-use axplat::mem::PhysAddr;
+use axplat::mem::{PhysAddr, phys_to_virt};
 use rdrive::{
     DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
@@ -32,14 +32,15 @@ module_driver!(
 fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
     let base_reg = info
         .node
-        .reg()
-        .and_then(|mut regs| regs.next())
+        .regs()
+        .into_iter()
+        .next()
         .ok_or(OnProbeError::other(alloc::format!(
             "[{}] has no reg",
             info.node.name()
         )))?;
 
-    let mmio_size = base_reg.size.unwrap_or(0x1000);
+    let mmio_size = base_reg.size.unwrap_or(0x1000) as usize;
     let mmio_base = PhysAddr::from_usize(base_reg.address as usize);
 
     let mmio_base = iomap(mmio_base, mmio_size)?.as_ptr();
@@ -186,8 +187,8 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
     }
 
     #[inline]
-    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, size: usize) -> NonNull<u8> {
-        iomap((paddr as usize).into(), size).unwrap_or_else(|_| NonNull::dangling())
+    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, _size: usize) -> NonNull<u8> {
+        NonNull::new(phys_to_virt(paddr.into()).as_mut_ptr()).unwrap()
     }
 
     #[inline]

--- a/modules/axplat-dyn/src/drivers/blk/virtio.rs
+++ b/modules/axplat-dyn/src/drivers/blk/virtio.rs
@@ -1,20 +1,19 @@
 extern crate alloc;
 
 use alloc::format;
+use core::{marker::PhantomData, ptr::NonNull};
 
+use axalloc::{UsageKind, global_allocator};
 use axdriver_base::DeviceType;
 use axdriver_block::BlockDriverOps;
-use axdriver_virtio::MmioTransport;
-use axhal::mem::PhysAddr;
+use axdriver_virtio::{BufferDirection, MmioTransport, PhysAddr as VirtIoPhysAddr, VirtIoHal};
+use axplat::mem::PhysAddr;
 use rdrive::{
     DriverGeneric, PlatformDevice, module_driver, probe::OnProbeError, register::FdtInfo,
 };
 
 use super::PlatformDeviceBlock;
-use crate::{
-    dyn_drivers::{blk::maping_dev_err_to_blk_err, iomap},
-    virtio::VirtIoHalImpl,
-};
+use crate::drivers::iomap;
 
 type Device<T> = axdriver_virtio::VirtIoBlkDev<VirtIoHalImpl, T>;
 
@@ -146,5 +145,58 @@ impl rd_block::IQueue for BlockQueue {
 
     fn poll_request(&mut self, _request: rd_block::RequestId) -> Result<(), rd_block::BlkError> {
         Ok(())
+    }
+}
+
+fn maping_dev_err_to_blk_err(err: axdriver_base::DevError) -> rd_block::BlkError {
+    match err {
+        axdriver_base::DevError::Again => rd_block::BlkError::Retry,
+        axdriver_base::DevError::AlreadyExists => {
+            rd_block::BlkError::Other("Already exists".into())
+        }
+        axdriver_base::DevError::BadState => rd_block::BlkError::Other("Bad internal state".into()),
+        axdriver_base::DevError::InvalidParam => {
+            rd_block::BlkError::Other("Invalid parameter".into())
+        }
+        axdriver_base::DevError::Io => rd_block::BlkError::Other("I/O error".into()),
+        axdriver_base::DevError::NoMemory => rd_block::BlkError::NoMemory,
+        axdriver_base::DevError::ResourceBusy => rd_block::BlkError::Other("Resource busy".into()),
+        axdriver_base::DevError::Unsupported => rd_block::BlkError::NotSupported,
+    }
+}
+
+struct VirtIoHalImpl(PhantomData<()>);
+
+unsafe impl VirtIoHal for VirtIoHalImpl {
+    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (VirtIoPhysAddr, NonNull<u8>) {
+        let vaddr = if let Ok(vaddr) = global_allocator().alloc_pages(pages, 0x1000, UsageKind::Dma)
+        {
+            vaddr
+        } else {
+            return (0, NonNull::dangling());
+        };
+        let paddr = somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr;
+        let ptr = NonNull::new(vaddr as _).unwrap();
+        (paddr, ptr)
+    }
+
+    unsafe fn dma_dealloc(_paddr: VirtIoPhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
+        global_allocator().dealloc_pages(vaddr.as_ptr() as usize, pages, UsageKind::Dma);
+        0
+    }
+
+    #[inline]
+    unsafe fn mmio_phys_to_virt(paddr: VirtIoPhysAddr, size: usize) -> NonNull<u8> {
+        iomap((paddr as usize).into(), size).unwrap_or_else(|_| NonNull::dangling())
+    }
+
+    #[inline]
+    unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> VirtIoPhysAddr {
+        let vaddr = buffer.as_ptr() as *mut u8 as usize;
+        somehal::mem::virt_to_phys(vaddr as *mut u8) as VirtIoPhysAddr
+    }
+
+    #[inline]
+    unsafe fn unshare(_paddr: VirtIoPhysAddr, _buffer: NonNull<[u8]>, _direction: BufferDirection) {
     }
 }

--- a/modules/axplat-dyn/src/drivers/mod.rs
+++ b/modules/axplat-dyn/src/drivers/mod.rs
@@ -1,0 +1,175 @@
+extern crate alloc;
+
+use alloc::{
+    alloc::{alloc, alloc_zeroed, dealloc},
+    boxed::Box,
+};
+use core::ptr::NonNull;
+
+use axdriver_block::BlockDriverOps;
+use axerrno::AxError;
+use axplat::mem::PhysAddr;
+use heapless::Vec;
+use memory_addr::PAGE_SIZE_4K;
+use rdrive::probe::OnProbeError;
+use spin::Mutex;
+
+mod pci;
+
+pub mod blk;
+
+const MAX_BLOCK_DEVICES: usize = 16;
+
+pub type DynBlockDevice = Box<dyn BlockDriverOps>;
+
+static BLOCK_DEVICES: Mutex<Vec<DynBlockDevice, MAX_BLOCK_DEVICES>> = Mutex::new(Vec::new());
+
+pub fn clear_block_devices() {
+    BLOCK_DEVICES.lock().clear();
+}
+
+pub fn register_block_device(device: DynBlockDevice) -> Result<(), DynBlockDevice> {
+    BLOCK_DEVICES.lock().push(device)
+}
+
+pub fn take_block_devices() -> Vec<DynBlockDevice, MAX_BLOCK_DEVICES> {
+    let mut devices = BLOCK_DEVICES.lock();
+    core::mem::take(&mut *devices)
+}
+
+/// maps a mmio physical address to a virtual address.
+pub(crate) fn iomap(addr: PhysAddr, size: usize) -> Result<NonNull<u8>, OnProbeError> {
+    axklib::mem::iomap(addr, size)
+        .map_err(|e| match e {
+            AxError::NoMemory => OnProbeError::KError(rdrive::KError::NoMem),
+            _ => OnProbeError::Other(alloc::format!("{e:?}").into()),
+        })
+        .map(|v| unsafe { NonNull::new_unchecked(v.as_mut_ptr()) })
+}
+
+pub fn probe_all_devices() -> Result<(), AxError> {
+    clear_block_devices();
+    rdrive::probe_all(true).map_err(|_| AxError::BadState)?;
+
+    for dev in rdrive::get_list::<rd_block::Block>() {
+        let block = Box::new(blk::Block::from(dev));
+        if register_block_device(block).is_err() {
+            return Err(AxError::NoMemory);
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) struct DmaImpl;
+
+#[inline]
+fn dma_addr_from_ptr(ptr: NonNull<u8>) -> u64 {
+    somehal::mem::virt_to_phys(ptr.as_ptr()) as u64
+}
+
+#[inline]
+fn dma_range_fits_mask(dma_addr: u64, size: usize, dma_mask: u64) -> bool {
+    if size == 0 {
+        dma_addr <= dma_mask
+    } else {
+        dma_addr
+            .checked_add(size.saturating_sub(1) as u64)
+            .map(|end| end <= dma_mask)
+            .unwrap_or(false)
+    }
+}
+
+#[inline]
+fn dma_addr_is_aligned(dma_addr: u64, align: usize) -> bool {
+    dma_addr.is_multiple_of(align as u64)
+}
+
+impl dma_api::DmaOp for DmaImpl {
+    fn page_size(&self) -> usize {
+        PAGE_SIZE_4K
+    }
+
+    unsafe fn map_single(
+        &self,
+        dma_mask: u64,
+        addr: NonNull<u8>,
+        size: core::num::NonZeroUsize,
+        align: usize,
+        direction: dma_api::DmaDirection,
+    ) -> Result<dma_api::DmaMapHandle, dma_api::DmaError> {
+        let layout = core::alloc::Layout::from_size_align(size.get(), align)?;
+        let dma_addr = dma_addr_from_ptr(addr);
+
+        if dma_range_fits_mask(dma_addr, size.get(), dma_mask)
+            && dma_addr_is_aligned(dma_addr, align)
+        {
+            return Ok(unsafe { dma_api::DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
+        }
+
+        let map_ptr = unsafe { alloc(layout) };
+        let map_virt = NonNull::new(map_ptr).ok_or(dma_api::DmaError::NoMemory)?;
+
+        if matches!(
+            direction,
+            dma_api::DmaDirection::ToDevice | dma_api::DmaDirection::Bidirectional
+        ) {
+            unsafe {
+                map_virt
+                    .as_ptr()
+                    .copy_from_nonoverlapping(addr.as_ptr(), size.get());
+            }
+        }
+
+        let map_dma_addr = dma_addr_from_ptr(map_virt);
+        if !dma_range_fits_mask(map_dma_addr, size.get(), dma_mask) {
+            unsafe { dealloc(map_virt.as_ptr(), layout) };
+            return Err(dma_api::DmaError::DmaMaskNotMatch {
+                addr: map_dma_addr.into(),
+                mask: dma_mask,
+            });
+        }
+        if !dma_addr_is_aligned(map_dma_addr, align) {
+            unsafe { dealloc(map_virt.as_ptr(), layout) };
+            return Err(dma_api::DmaError::AlignMismatch {
+                required: align,
+                address: map_dma_addr.into(),
+            });
+        }
+
+        Ok(
+            unsafe {
+                dma_api::DmaMapHandle::new(addr, map_dma_addr.into(), layout, Some(map_virt))
+            },
+        )
+    }
+
+    unsafe fn unmap_single(&self, handle: dma_api::DmaMapHandle) {
+        if let Some(map_virt) = handle.alloc_virt() {
+            unsafe { dealloc(map_virt.as_ptr(), handle.layout()) };
+        }
+    }
+
+    unsafe fn alloc_coherent(
+        &self,
+        dma_mask: u64,
+        layout: core::alloc::Layout,
+    ) -> Option<dma_api::DmaHandle> {
+        let ptr = unsafe { alloc_zeroed(layout) };
+        let cpu_addr = NonNull::new(ptr)?;
+
+        let dma_addr = dma_addr_from_ptr(cpu_addr);
+        if !dma_range_fits_mask(dma_addr, layout.size(), dma_mask)
+            || !dma_addr_is_aligned(dma_addr, layout.align())
+        {
+            unsafe { dealloc(cpu_addr.as_ptr(), layout) };
+            return None;
+        }
+
+        Some(unsafe { dma_api::DmaHandle::new(cpu_addr, dma_addr.into(), layout) })
+    }
+
+    unsafe fn dealloc_coherent(&self, handle: dma_api::DmaHandle) {
+        unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+    }
+}

--- a/modules/axplat-dyn/src/drivers/pci.rs
+++ b/modules/axplat-dyn/src/drivers/pci.rs
@@ -1,13 +1,11 @@
 extern crate alloc;
 
-use memory_addr::MemoryAddr;
+use fdt_edit::PciSpace;
 use rdrive::{
     PlatformDevice, module_driver,
-    probe::{OnProbeError, fdt::PciSpace, pci::*},
+    probe::{OnProbeError, fdt::NodeType, pci::*},
     register::FdtInfo,
 };
-
-use super::iomap;
 
 module_driver!(
     name: "Generic PCIe Controller Driver",
@@ -22,23 +20,28 @@ module_driver!(
 );
 
 fn probe(info: FdtInfo<'_>, plat_dev: PlatformDevice) -> Result<(), OnProbeError> {
-    let node = info.node.into_pci().unwrap();
-    let mut pcie_regs = alloc::vec![];
-    for reg in node.node.reg().unwrap() {
+    let NodeType::Pci(node) = info.node else {
+        return Err(OnProbeError::NotMatch);
+    };
+
+    let regs = node.regs();
+    for reg in &regs {
         trace!(
             "pcie reg: {:#x}, bus: {:#x}",
             reg.address, reg.child_bus_address
         );
-        let end = (reg.address as usize + reg.size.unwrap_or_default()).align_up_4k();
-        let start = (reg.address as usize).align_down_4k();
-        let size = end - start;
-        pcie_regs.push(iomap(start.into(), size)?);
     }
 
-    let base_vaddr = pcie_regs[0];
-    let mut drv = new_driver_generic(base_vaddr);
+    let reg = regs
+        .first()
+        .ok_or_else(|| OnProbeError::other("PCIe controller has no regs"))?;
+    let mmio_base = reg.address as usize;
+    let mmio_size = reg.size.unwrap_or(0x1000) as usize;
+    let mut drv = new_driver_generic(mmio_base, mmio_size, &crate::boot::Kernel).map_err(|e| {
+        OnProbeError::other(alloc::format!("failed to create PCIe controller: {e:?}"))
+    })?;
 
-    for range in node.ranges().unwrap() {
+    for range in node.ranges().unwrap_or_default() {
         debug!("pcie range {range:?}");
         match range.space {
             PciSpace::Memory32 => {

--- a/modules/axplat-dyn/src/drivers/pci.rs
+++ b/modules/axplat-dyn/src/drivers/pci.rs
@@ -7,7 +7,7 @@ use rdrive::{
     register::FdtInfo,
 };
 
-use crate::dyn_drivers::iomap;
+use super::iomap;
 
 module_driver!(
     name: "Generic PCIe Controller Driver",

--- a/modules/axplat-dyn/src/lib.rs
+++ b/modules/axplat-dyn/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![cfg(not(any(windows, unix)))]
+#![feature(used_with_arg)]
 
 extern crate somehal;
 
@@ -11,6 +12,7 @@ extern crate log;
 
 mod boot;
 mod console;
+pub mod drivers;
 mod generic_timer;
 mod init;
 #[cfg(feature = "irq")]


### PR DESCRIPTION
This pull request performs a major refactor of the dynamic driver subsystem, moving dynamic device probing and DMA logic out of `axdriver` and into a new `axplat-dyn` crate. The changes modularize and isolate platform-specific dynamic driver logic, especially for block devices and PCI, and update dependencies accordingly. This improves maintainability and separation of concerns, and prepares the codebase for future extensibility.

**Dynamic driver subsystem refactor and modularization:**

- Moved dynamic driver logic from `axdriver` to a new `axplat-dyn` crate, including device probing, DMA operations, and block device management. This includes moving and refactoring files such as `dyn_drivers/mod.rs`, `blk/mod.rs`, and `pci.rs` into `axplat-dyn/src/drivers/`. (`[[1]](diffhunk://#diff-2d46dbddf5389f6f918c96b314cd7c77133640214d18fb56b2764171546cdd13L1-R17)`, `[[2]](diffhunk://#diff-adf9221231ec895e11b94132b694add40736a4b348da1f8f276254e8ea4b09e5L7-L9)`, `[[3]](diffhunk://#diff-adf9221231ec895e11b94132b694add40736a4b348da1f8f276254e8ea4b09e5R74-R84)`, `[[4]](diffhunk://#diff-ded65c361c8c723da0eacbbad99e194a602e345e5a6d09131c38dc38190ac7ccR1-R175)`, `[[5]](diffhunk://#diff-8e9c38cdfe7b39692abbb09fa28f6476dc1f566142a3478d6f3754dafaaf14b2L3-L11)`, `[[6]](diffhunk://#diff-8e9c38cdfe7b39692abbb09fa28f6476dc1f566142a3478d6f3754dafaaf14b2L25-R44)`, `[[7]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5R4-R16)`, `[[8]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5L36-R43)`, `[[9]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5R151-R203)`, `[[10]](diffhunk://#diff-dd9fb8dce6ecc351fd8503a3eead578ecde696221fd82fbaec7278611244aad3R15)`)
- Refactored the dynamic block device registry to use a thread-safe static list in `axplat-dyn`, with helper functions for registering, clearing, and retrieving devices. (`[modules/axplat-dyn/src/drivers/mod.rsR1-R175](diffhunk://#diff-ded65c361c8c723da0eacbbad99e194a602e345e5a6d09131c38dc38190ac7ccR1-R175)`)
- Moved and updated DMA operation implementations to the new crate, including memory mapping, address translation, and DMA handle management. (`[modules/axplat-dyn/src/drivers/mod.rsR1-R175](diffhunk://#diff-ded65c361c8c723da0eacbbad99e194a602e345e5a6d09131c38dc38190ac7ccR1-R175)`)

**Dependency and feature updates:**

- Updated `Cargo.toml` dependencies for both `axdriver` and the new `axplat-dyn` crate, removing now-unnecessary dependencies from `axdriver` and adding required ones to `axplat-dyn` (such as `axalloc`, `dma-api`, `rd-block`, `rdrive`, etc.). (`[[1]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L41-R41)`, `[[2]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L68-R63)`, `[[3]](diffhunk://#diff-cfdc3d72701291ee9f07deb307ceb00d65afc36beb3c63c5a1c9f30fc6e2473cR21-R37)`)
- Changed feature flags and dependency lists to reflect the new modular structure. (`[[1]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L41-R41)`, `[[2]](diffhunk://#diff-5ffb88be19b99c5b1870dbc755e319b2538b49b33ef8b92d772ab37e2eab52d5L68-R63)`, `[[3]](diffhunk://#diff-cfdc3d72701291ee9f07deb307ceb00d65afc36beb3c63c5a1c9f30fc6e2473cR21-R37)`)

**Platform device and VirtIO improvements:**

- Refactored VirtIO block driver logic, including DMA allocation and MMIO mapping, to use new platform abstractions and memory helpers from `axplat-dyn`. (`[[1]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5R4-R16)`, `[[2]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5L36-R43)`, `[[3]](diffhunk://#diff-3346f44dc39a9072482791082c91d535dd3776c2e3c96e0746a2c6d1045d27a5R151-R203)`)
- Improved PCI device probing logic to use updated device tree node parsing and memory mapping, with clearer error handling. (`[[1]](diffhunk://#diff-8e9c38cdfe7b39692abbb09fa28f6476dc1f566142a3478d6f3754dafaaf14b2L3-L11)`, `[[2]](diffhunk://#diff-8e9c38cdfe7b39692abbb09fa28f6476dc1f566142a3478d6f3754dafaaf14b2L25-R44)`)

**Miscellaneous:**

- Removed now-obsolete code from the old dynamic driver location in `axdriver`.
- Enabled the `used_with_arg` feature in `axplat-dyn` for future compatibility. (`[modules/axplat-dyn/src/lib.rsR3](diffhunk://#diff-dd9fb8dce6ecc351fd8503a3eead578ecde696221fd82fbaec7278611244aad3R3)`)

These changes collectively improve code organization, modularity, and maintainability, making it easier to extend and support platform-specific dynamic drivers in the future.