### PR TITLE
fix(axdriver): adapt to virtio-drivers 0.12.0 APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,8 +544,6 @@ dependencies = [
 [[package]]
 name = "axdriver_pci"
 version = "0.1.4-preview.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129bd3a5ad486d989e9bdc211c86fd8d50720462ef46e2b0013d333338d50e98"
 dependencies = [
  "virtio-drivers",
 ]
@@ -553,8 +551,6 @@ dependencies = [
 [[package]]
 name = "axdriver_virtio"
 version = "0.1.4-preview.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6c36cc900745f3bab9de0dd8d5a2d5ac720a253937b3c5f3ab81bbb9c9e139"
 dependencies = [
  "axdriver_base",
  "axdriver_block",
@@ -1783,6 +1779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,6 +2982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "safe-mmio"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a69f884a1511aa811aa94e04559414a66b18ca63f50f84ca31e304f38bad0d"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "sbi-rt"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,13 +3527,16 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "virtio-drivers"
-version = "0.7.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a39747311dabb3d37807037ed1c3c38d39f99198d091b5b79ecd5c8d82f799"
+checksum = "a7a6012590bf8cc11f57abb1b5a8470e2366353bf352386b48650a87b5538204"
 dependencies = [
  "bitflags 2.11.0",
+ "embedded-io",
  "enumn",
  "log",
+ "safe-mmio",
+ "thiserror",
  "zerocopy",
 ]
 
@@ -3738,19 +3752,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/modules/axdriver/src/bus/pci.rs
+++ b/modules/axdriver/src/bus/pci.rs
@@ -1,5 +1,6 @@
 use axdriver_pci::{
-    BarInfo, Cam, Command, DeviceFunction, HeaderType, MemoryBarType, PciRangeAllocator, PciRoot,
+    BarInfo, Cam, Command, ConfigurationAccess, DeviceFunction, HeaderType, MemoryBarType,
+    MmioCam, PciRangeAllocator, PciRoot,
 };
 use axhal::mem::phys_to_virt;
 
@@ -8,19 +9,19 @@ use crate::{AllDevices, prelude::*};
 const PCI_BAR_NUM: u8 = 6;
 
 fn config_pci_device(
-    root: &mut PciRoot,
+    root: &mut PciRoot<impl ConfigurationAccess>,
     bdf: DeviceFunction,
     allocator: &mut Option<PciRangeAllocator>,
 ) -> DevResult {
     let mut bar = 0;
     while bar < PCI_BAR_NUM {
         let info = root.bar_info(bdf, bar).unwrap();
-        if let BarInfo::Memory {
+        if let Some(BarInfo::Memory {
             address_type,
             address,
             size,
             ..
-        } = info
+        }) = info
         {
             // if the BAR address is not assigned, call the allocator and assign it.
             if size > 0 && address == 0 {
@@ -40,17 +41,17 @@ fn config_pci_device(
         // read the BAR info again after assignment.
         let info = root.bar_info(bdf, bar).unwrap();
         match info {
-            BarInfo::IO { address, size } => {
+            Some(BarInfo::IO { address, size }) => {
                 if address > 0 && size > 0 {
                     debug!("  BAR {}: IO  [{:#x}, {:#x})", bar, address, address + size);
                 }
             }
-            BarInfo::Memory {
+            Some(BarInfo::Memory {
                 address_type,
                 prefetchable,
                 address,
                 size,
-            } => {
+            }) => {
                 if address > 0 && size > 0 {
                     debug!(
                         "  BAR {}: MEM [{:#x}, {:#x}){}{}",
@@ -66,10 +67,11 @@ fn config_pci_device(
                     );
                 }
             }
+            None => {}
         }
 
         bar += 1;
-        if info.takes_two_entries() {
+        if info.as_ref().is_some_and(BarInfo::takes_two_entries) {
             bar += 1;
         }
     }
@@ -86,7 +88,8 @@ fn config_pci_device(
 impl AllDevices {
     pub(crate) fn probe_bus_devices(&mut self) {
         let base_vaddr = phys_to_virt(axconfig::devices::PCI_ECAM_BASE.into());
-        let mut root = unsafe { PciRoot::new(base_vaddr.as_mut_ptr(), Cam::Ecam) };
+        let cam = unsafe { MmioCam::new(base_vaddr.as_mut_ptr(), Cam::Ecam) };
+        let mut root = PciRoot::new(cam);
 
         // PCI 32-bit MMIO space
         let mut allocator = axconfig::devices::PCI_RANGES

--- a/modules/axdriver/src/drivers.rs
+++ b/modules/axdriver/src/drivers.rs
@@ -4,7 +4,7 @@
 
 use axdriver_base::DeviceType;
 #[cfg(feature = "bus-pci")]
-use axdriver_pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
+use axdriver_pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
 
 pub use super::dummy::*;
 use crate::AxDeviceEnum;
@@ -22,8 +22,8 @@ pub trait DriverProbe {
     }
 
     #[cfg(bus = "pci")]
-    fn probe_pci(
-        _root: &mut PciRoot,
+    fn probe_pci<C: ConfigurationAccess>(
+        _root: &mut PciRoot<C>,
         _bdf: DeviceFunction,
         _dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {

--- a/modules/axdriver/src/virtio.rs
+++ b/modules/axdriver/src/virtio.rs
@@ -10,10 +10,10 @@ use crate::{AxDeviceEnum, drivers::DriverProbe};
 
 cfg_if! {
     if #[cfg(bus = "pci")] {
-        use axdriver_pci::{PciRoot, DeviceFunction, DeviceFunctionInfo};
+        use axdriver_pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
         type VirtIoTransport = axdriver_virtio::PciTransport;
     } else if #[cfg(bus =  "mmio")] {
-        type VirtIoTransport = axdriver_virtio::MmioTransport;
+        type VirtIoTransport = axdriver_virtio::MmioTransport<'static>;
     }
 }
 
@@ -130,8 +130,8 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
     }
 
     #[cfg(bus = "pci")]
-    fn probe_pci(
-        root: &mut PciRoot,
+    fn probe_pci<C: ConfigurationAccess>(
+        root: &mut PciRoot<C>,
         bdf: DeviceFunction,
         dev_info: &DeviceFunctionInfo,
     ) -> Option<AxDeviceEnum> {
@@ -148,7 +148,7 @@ impl<D: VirtIoDevMeta> DriverProbe for VirtIoDriver<D> {
         }
 
         if let Some((ty, transport, irq)) =
-            axdriver_virtio::probe_pci_device::<VirtIoHalImpl>(root, bdf, dev_info)
+            axdriver_virtio::probe_pci_device::<VirtIoHalImpl, C>(root, bdf, dev_info)
             && ty == D::DEVICE_TYPE
         {
             match D::try_new(transport, Some(irq)) {
@@ -175,7 +175,7 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
         };
         let paddr = virt_to_phys(vaddr.into());
         let ptr = NonNull::new(vaddr as _).unwrap();
-        (paddr.as_usize(), ptr)
+        (paddr.as_usize() as PhysAddr, ptr)
     }
 
     unsafe fn dma_dealloc(_paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
@@ -185,13 +185,13 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
 
     #[inline]
     unsafe fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
-        NonNull::new(phys_to_virt(paddr.into()).as_mut_ptr()).unwrap()
+        NonNull::new(phys_to_virt((paddr as usize).into()).as_mut_ptr()).unwrap()
     }
 
     #[inline]
     unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {
         let vaddr = buffer.as_ptr() as *mut u8 as usize;
-        virt_to_phys(vaddr.into()).into()
+        virt_to_phys(vaddr.into()).as_usize() as PhysAddr
     }
 
     #[inline]


### PR DESCRIPTION
## Description
https://github.com/arceos-org/axdriver_crates/issues/17
This PR adapts `axdriver` in ArceOS to the `virtio-drivers 0.12.0` upgrade.

## Implementation

- Update PCI probing to use the new generic `PciRoot<C>` interface
- Construct `PciRoot` from `MmioCam`
- Update VirtIO PCI probing to call `probe_pci_device::<H, C>(...)`
- Adjust MMIO transport and `PhysAddr`-related type usage to match the new APIs
- Update `Cargo.lock`

## Additional Context

This PR depends on the corresponding `axdriver_crates` PR that upgrades `virtio-drivers` to `0.12.0`.
https://github.com/arceos-org/axdriver_crates/pull/20